### PR TITLE
fix(package.main): specify the entry point file

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "api",
   "version": "2.0.0",
   "description": "Generate an SDK from an OpenAPI definition",
+  "main": "src/index.js",
   "scripts": {
     "lint": "eslint .",
     "pretest": "npm run lint && npm run prettier",


### PR DESCRIPTION
## 🧰 What's being changed?

When I install and require the API package from my code, I get the following error:

```
internal/modules/cjs/loader.js:628
    throw err;
    ^
Error: Cannot find module 'api'
```

I can get it working by simply setting the required path to `api/src/index.js`. This PR adds a main field, which will hopefully make this workaround moot.

## 🧪 Testing

Install the API package in a local directory and try requiring the dependency in a node script. You should see the aforementioned "module not found" error.

## 🗳 Checklist

* I'm fixing a bug
