### PR TITLE
chore: moving off our httpsnippet fork and to v1.20.x

### DIFF
--- a/packages/httpsnippet-client-api/README.md
+++ b/packages/httpsnippet-client-api/README.md
@@ -13,8 +13,6 @@ An HTTP Snippet client for generating snippets for the [api](https://npm.im/api)
 npm install --save httpsnippet-client-api
 ```
 
-> ⚠️ Please note that this package is currently only compatile with the [ReadMe fork of httpsnippet](https://github.com/readmeio/httpsnippet/). Once PR [#165](https://github.com/Kong/httpsnippet/pull/165) is accepted into `httpsnippet` to pull in the new plugin architecture we've proposed, this package will function with the mainline package.
-
 ## Usage
 
 ```js

--- a/packages/httpsnippet-client-api/package-lock.json
+++ b/packages/httpsnippet-client-api/package-lock.json
@@ -3354,8 +3354,9 @@
       }
     },
     "httpsnippet": {
-      "version": "https://github.com/readmeio/httpsnippet.git#b7818e6660b16f5d572bbb06f36e2ed5f71a87a9",
-      "from": "https://github.com/readmeio/httpsnippet.git#feat/plugin-architecture",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/httpsnippet/-/httpsnippet-1.20.0.tgz",
+      "integrity": "sha512-8cMk8qGnlXkWh6kN6RiTIooybNiqG71rZ6RIMT/NSxgoW74JZ2okE6QBuWeZjMGU78y/Nk6HIBEhF/ZjUUeu+w==",
       "requires": {
         "chalk": "^1.1.1",
         "commander": "^2.9.0",

--- a/packages/httpsnippet-client-api/package.json
+++ b/packages/httpsnippet-client-api/package.json
@@ -24,8 +24,11 @@
   },
   "dependencies": {
     "content-type": "^1.0.4",
-    "httpsnippet": "https://github.com/readmeio/httpsnippet.git#feat/plugin-architecture",
+    "httpsnippet": "^1.20.0",
     "stringify-object": "^3.3.0"
+  },
+  "peerDependencies": {
+    "httpsnippet": "^1.20.0"
   },
   "devDependencies": {
     "@readme/eslint-config": "^3.1.0",


### PR DESCRIPTION
## 🧰 What's being changed?

My work to add support for custom targets and clients to [HTTP Snippet](https://github.com/Kong/httpsnippet) was accepted, so this moves us off our fork and to that new version.

It also sets that version as a peer dependency so anytime this library is installed, it'll also require that the version of that library that supports it is also made aware to the user.
