### PR TITLE
fix: relative paths in parent parent directories not being supported

### DIFF
--- a/packages/api/__tests__/cache.test.js
+++ b/packages/api/__tests__/cache.test.js
@@ -40,6 +40,7 @@ beforeEach(async () => {
       'readme.yaml': readmeExampleYaml,
       'swagger.json': await fs.readFile(require.resolve('@readme/oas-examples/2.0/json/petstore.json'), 'utf8'),
     },
+    '../examples/readme.json': readmeExampleJson,
     [findCacheDir({ name: pkg.name })]: {},
   });
 });
@@ -118,6 +119,17 @@ describe('#saveUrl()', () => {
 describe('#saveFile()', () => {
   it('should be able to save a definition', () => {
     const cacheStore = new Cache(join(examplesDir, 'readme.json'));
+
+    expect(cacheStore.isCached()).toBe(false);
+
+    return cacheStore.saveFile().then(() => {
+      expect(cacheStore.get().paths['/api-specification'].get.parameters).toBeDereferenced();
+      expect(cacheStore.isCached()).toBe(true);
+    });
+  });
+
+  it('should be able handle a relative path', () => {
+    const cacheStore = new Cache('../examples/readme.json');
 
     expect(cacheStore.isCached()).toBe(false);
 

--- a/packages/api/src/cache.js
+++ b/packages/api/src/cache.js
@@ -6,6 +6,7 @@ const crypto = require('crypto');
 const findCacheDir = require('find-cache-dir');
 const pkg = require('../package.json');
 const fs = require('fs');
+const path = require('path');
 
 const cacheDir = findCacheDir({ name: pkg.name, thunk: true });
 
@@ -77,6 +78,9 @@ class SdkCache {
 
       return this.saveUrl();
     } catch (err) {
+      // Support relative paths by resolving them against the cwd.
+      this.uri = path.resolve(process.cwd(), this.uri);
+
       if (!fs.existsSync(this.uri)) {
         throw new Error(
           `Sorry, we were unable to load that OpenAPI definition. Please either supply a URL or a path on your filesystem.`


### PR DESCRIPTION
## 🧰 What's being changed?

This resolves a bug where relative paths in parent directories (`../openapi.json`, not `./openapi.json`) would not be able to be read.

Resolves https://github.com/readmeio/api/issues/61

## 🗳 Checklist
> 💡 If answering yes to any of the following, include additional info, before/after links, screenshots, etc. where appropriate!

* [ ] **🆕 I'm adding something new!**
* [x] **🐛 I'm fixing a bug!**
