### PR TITLE
chore(deps): swapping yaml for js-yaml

### DIFF
--- a/packages/api/package-lock.json
+++ b/packages/api/package-lock.json
@@ -7602,11 +7602,6 @@
       "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
       "dev": true
     },
-    "yaml": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
-      "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg=="
-    },
     "yargs": {
       "version": "15.3.1",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.3.1.tgz",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -29,8 +29,8 @@
     "@readme/oas-tooling": "^3.4.1",
     "fetch-har": "^2.3.1",
     "find-cache-dir": "^3.3.1",
-    "node-fetch": "^2.6.0",
-    "yaml": "^1.9.2"
+    "js-yaml": "^3.14.0",
+    "node-fetch": "^2.6.0"
   },
   "devDependencies": {
     "@readme/eslint-config": "^3.1.0",

--- a/packages/api/src/cache.js
+++ b/packages/api/src/cache.js
@@ -1,7 +1,7 @@
 const fetch = require('node-fetch');
 const SwaggerParser = require('@apidevtools/swagger-parser');
 const $RefParser = require('@apidevtools/json-schema-ref-parser');
-const yaml = require('yaml');
+const yaml = require('js-yaml');
 const crypto = require('crypto');
 const findCacheDir = require('find-cache-dir');
 const pkg = require('../package.json');
@@ -153,7 +153,7 @@ class SdkCache {
 
         if (res.headers.get('content-type') === 'application/yaml' || /\.(yaml|yml)/.test(this.uri)) {
           return res.text().then(text => {
-            return yaml.parse(text);
+            return yaml.safeLoad(text);
           });
         }
 
@@ -168,7 +168,7 @@ class SdkCache {
     })
       .then(res => {
         if (/\.(yaml|yml)/.test(this.uri)) {
-          return yaml.parse(res);
+          return yaml.safeLoad(res);
         }
 
         return JSON.parse(res);


### PR DESCRIPTION
## 🧰 What's being changed?

We've had a bit of a falling out with the `yaml` package so we're moving to `js-yaml` as it's the more used package, and has a smaller smaller footprint.

## 🗳 Checklist
> 💡 If answering yes to any of the following, include additional info, before/after links, screenshots, etc. where appropriate!

* [x] **🆕 I'm adding something new!**
* [ ] **🐛 I'm fixing a bug!**
