### PR TITLE
fix: snippet paths should not include the server url

### DIFF
--- a/packages/httpsnippet-client-api/__tests__/__fixtures__/output/issue-76.js
+++ b/packages/httpsnippet-client-api/__tests__/__fixtures__/output/issue-76.js
@@ -1,0 +1,7 @@
+const sdk = require('api')('https://example.com/openapi.json');
+
+sdk.auth('a5a220e').get('/pet/findByStatus', {status: 'available', accept: 'application/xml'})
+  .then(res => res.json())
+  .then(res => {
+    console.log(res);
+  });

--- a/packages/httpsnippet-client-api/__tests__/__fixtures__/request/issue-76/definition.json
+++ b/packages/httpsnippet-client-api/__tests__/__fixtures__/request/issue-76/definition.json
@@ -1,0 +1,57 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+     "version": "1.0.0",
+     "title": "issue-76"
+  },
+  "servers": [
+     {
+        "url": "http://petstore.swagger.io/v2"
+     }
+  ],
+  "paths": {
+     "/pet/findByStatus": {
+        "get": {
+           "parameters": [
+              {
+                 "name": "status",
+                 "in": "query",
+                 "required": true,
+                 "explode": true,
+                 "schema": {
+                    "type": "array",
+                    "items": {
+                       "type": "string",
+                       "enum": [
+                          "available",
+                          "pending",
+                          "sold"
+                       ],
+                       "default": "available"
+                    }
+                 }
+              }
+           ],
+           "responses": {
+              "200": {
+                 "description": "OK"
+              }
+           },
+           "security": [
+              {
+                 "api_key": []
+              }
+           ]
+        }
+     }
+  },
+  "components": {
+     "securitySchemes": {
+        "api_key": {
+           "type": "apiKey",
+           "name": "api_key",
+           "in": "query"
+        }
+     }
+  }
+}

--- a/packages/httpsnippet-client-api/__tests__/__fixtures__/request/issue-76/har.json
+++ b/packages/httpsnippet-client-api/__tests__/__fixtures__/request/issue-76/har.json
@@ -1,0 +1,31 @@
+{
+  "log": {
+    "entries": [
+      {
+        "request": {
+          "allHeaders": {
+            "accept": "application/xml",
+            "authorization": "Bearer 123"
+          },
+          "cookies": [],
+          "headers": [
+            {"name": "Accept", "value": "application/xml"}
+          ],
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "jsonObj": false,
+            "mimeType": "application/octet-stream",
+            "paramsObj": false,
+            "size": 0
+          },
+          "queryString": [
+            {"name": "status", "value": "available"},
+            {"name": "api_key", "value": "a5a220e"}
+          ],
+          "url": "http://petstore.swagger.io/v2/pet/findByStatus"
+        }
+      }
+    ]
+  }
+}

--- a/packages/httpsnippet-client-api/__tests__/index.test.js
+++ b/packages/httpsnippet-client-api/__tests__/index.test.js
@@ -57,6 +57,7 @@ describe('snippets', () => {
     ['full'],
     ['headers'],
     ['https'],
+    ['issue-76'],
     ['jsonObj-multiline'],
     ['jsonObj-null-value'],
 

--- a/packages/httpsnippet-client-api/src/index.js
+++ b/packages/httpsnippet-client-api/src/index.js
@@ -175,7 +175,7 @@ module.exports = function (source, options) {
   if ('operationId' in operation && operation.operationId.length > 0) {
     accessor = operation.operationId;
   } else {
-    args.push(`'${source.uriObj.pathname}'`);
+    args.push(`'${operation.path}'`);
   }
 
   if (typeof body !== 'undefined') {


### PR DESCRIPTION
## 🧰 What's being changed?

Resolves a bug where if an operation did not have an `operationId`, and the server URL had a path in it, that path would be included in the operation path on the snippet method.

Resolves #76

## 🗳 Checklist
> 💡 If answering yes to any of the following, include additional info, before/after links, screenshots, etc. where appropriate!

* [ ] **🆕 I'm adding something new!**
* [x] **🐛 I'm fixing a bug!**
