### PR TITLE
fix: bug where path params wouldn't be included in snippets

### DIFF
--- a/packages/httpsnippet-client-api/__tests__/__fixtures__/output/issue-78.js
+++ b/packages/httpsnippet-client-api/__tests__/__fixtures__/output/issue-78.js
@@ -1,0 +1,7 @@
+const sdk = require('api')('https://example.com/openapi.json');
+
+sdk.get('/store/order/1234', {accept: 'application/xml'})
+  .then(res => res.json())
+  .then(res => {
+    console.log(res);
+  });

--- a/packages/httpsnippet-client-api/__tests__/__fixtures__/request/issue-78/definition.json
+++ b/packages/httpsnippet-client-api/__tests__/__fixtures__/request/issue-78/definition.json
@@ -1,0 +1,36 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+     "version": "1.0.0",
+     "title": "issue-78"
+  },
+  "servers": [
+     {
+        "url": "http://petstore.swagger.io/v2"
+     }
+  ],
+  "paths": {
+     "/store/order/{orderId}": {
+        "get": {
+           "parameters": [
+              {
+                 "name": "orderId",
+                 "in": "path",
+                 "required": true,
+                 "schema": {
+                    "type": "integer",
+                    "format": "int64",
+                    "minimum": 1,
+                    "maximum": 10
+                 }
+              }
+           ],
+           "responses": {
+              "200": {
+                 "description": "OK"
+              }
+           }
+        }
+     }
+  }
+}

--- a/packages/httpsnippet-client-api/__tests__/__fixtures__/request/issue-78/har.json
+++ b/packages/httpsnippet-client-api/__tests__/__fixtures__/request/issue-78/har.json
@@ -1,0 +1,25 @@
+{
+  "log": {
+    "entries": [
+      {
+        "request": {
+          "headers": [
+            {
+              "name": "Accept",
+              "value": "application/xml"
+            }
+          ],
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "jsonObj": false,
+            "mimeType": "application/octet-stream",
+            "paramsObj": false,
+            "size": 0
+          },
+          "url": "http://petstore.swagger.io/v2/store/order/1234"
+        }
+      }
+    ]
+  }
+}

--- a/packages/httpsnippet-client-api/__tests__/index.test.js
+++ b/packages/httpsnippet-client-api/__tests__/index.test.js
@@ -58,6 +58,7 @@ describe('snippets', () => {
     ['headers'],
     ['https'],
     ['issue-76'],
+    ['issue-78'],
     ['jsonObj-multiline'],
     ['jsonObj-null-value'],
 

--- a/packages/httpsnippet-client-api/package-lock.json
+++ b/packages/httpsnippet-client-api/package-lock.json
@@ -953,9 +953,9 @@
       }
     },
     "@readme/oas-tooling": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/@readme/oas-tooling/-/oas-tooling-3.4.5.tgz",
-      "integrity": "sha512-180iNHjAbyx9EMB2sE5SzUuSisssXKlcL2HmS07m8YA2pcAizf1W9AWnbg8v47F39CYyri5RdRzFgLb6pNrPjg==",
+      "version": "3.4.6",
+      "resolved": "https://registry.npmjs.org/@readme/oas-tooling/-/oas-tooling-3.4.6.tgz",
+      "integrity": "sha512-4uMynz3Dw1gh0TyMkwJZR1rpwAaseFDX8rDuJaWHhtDm3X45zpIAuXta5MYSSpozTP5oAQsG2GrvkIxjWrlNaA==",
       "requires": {
         "jsonpointer": "^4.0.1",
         "path-to-regexp": "^6.1.0"

--- a/packages/httpsnippet-client-api/package.json
+++ b/packages/httpsnippet-client-api/package.json
@@ -23,7 +23,7 @@
     "node": ">=10"
   },
   "dependencies": {
-    "@readme/oas-tooling": "^3.4.5",
+    "@readme/oas-tooling": "^3.4.6",
     "content-type": "^1.0.4",
     "httpsnippet": "^1.20.0",
     "stringify-object": "^3.3.0"

--- a/packages/httpsnippet-client-api/src/index.js
+++ b/packages/httpsnippet-client-api/src/index.js
@@ -53,10 +53,9 @@ module.exports = function (source, options) {
     throw new Error('This HTTP Snippet client must have an `apiDefinition` option supplied to it.');
   }
 
-  const url = source.url;
   const method = source.method.toLowerCase();
   const oas = new OAS(opts.apiDefinition);
-  const operation = oas.getOperation(url, method);
+  const operation = oas.getOperation(source.url, method);
 
   const authData = [];
   const authSources = getAuthSources(operation);
@@ -175,7 +174,10 @@ module.exports = function (source, options) {
   if ('operationId' in operation && operation.operationId.length > 0) {
     accessor = operation.operationId;
   } else {
-    args.push(`'${operation.path}'`);
+    // For cases where a server URL in the OAS has a path attached to it, we don't want to include that path with the
+    // operation path.
+    const path = source.url.replace(oas.url(), '');
+    args.push(`'${path}'`);
   }
 
   if (typeof body !== 'undefined') {


### PR DESCRIPTION
## 🧰 What's being changed?

This resolves a bug where if an operation had path parameters, those path parameters wouldn't be present in code snippets.

Resolves #78

## 🗳 Checklist
> 💡 If answering yes to any of the following, include additional info, before/after links, screenshots, etc. where appropriate!

* [ ] **🆕 I'm adding something new!**
* [x] **🐛 I'm fixing a bug!**
