### PR TITLE
feat: cleaning up api snippets by breaking off the auth call

### DIFF
--- a/packages/httpsnippet-client-api/__tests__/__fixtures__/output/issue-76.js
+++ b/packages/httpsnippet-client-api/__tests__/__fixtures__/output/issue-76.js
@@ -1,6 +1,7 @@
 const sdk = require('api')('https://example.com/openapi.json');
+sdk.auth('a5a220e');
 
-sdk.auth('a5a220e').get('/pet/findByStatus', {status: 'available', accept: 'application/xml'})
+sdk.get('/pet/findByStatus', {status: 'available', accept: 'application/xml'})
   .then(res => res.json())
   .then(res => {
     console.log(res);

--- a/packages/httpsnippet-client-api/__tests__/__fixtures__/output/petstore.js
+++ b/packages/httpsnippet-client-api/__tests__/__fixtures__/output/petstore.js
@@ -1,6 +1,7 @@
 const sdk = require('api')('https://example.com/openapi.json');
+sdk.auth('123');
 
-sdk.auth('123').findPetsByStatus({status: 'available', accept: 'application/xml'})
+sdk.findPetsByStatus({status: 'available', accept: 'application/xml'})
   .then(res => res.json())
   .then(res => {
     console.log(res);

--- a/packages/httpsnippet-client-api/__tests__/__fixtures__/output/query-auth.js
+++ b/packages/httpsnippet-client-api/__tests__/__fixtures__/output/query-auth.js
@@ -1,6 +1,7 @@
 const sdk = require('api')('https://example.com/openapi.json');
+sdk.auth('a5a220e');
 
-sdk.auth('a5a220e').findPetsByStatus({status: 'available', accept: 'application/xml'})
+sdk.findPetsByStatus({status: 'available', accept: 'application/xml'})
   .then(res => res.json())
   .then(res => {
     console.log(res);

--- a/packages/httpsnippet-client-api/src/index.js
+++ b/packages/httpsnippet-client-api/src/index.js
@@ -5,7 +5,7 @@ const contentType = require('content-type');
 const OAS = require('@readme/oas-tooling');
 
 function buildAuthSnippet(authKey) {
-  return `.auth('${authKey.replace("'", "\\'")}')`;
+  return `sdk.auth('${authKey.replace("'", "\\'")}');`;
 }
 
 function getAuthSources(operation) {
@@ -83,7 +83,7 @@ module.exports = function (source, options) {
   let includeFS = false;
   const code = new CodeBuilder(opts.indent);
 
-  code.push(`const sdk = require('api')('${opts.apiDefinitionUri}');`).blank();
+  code.push(`const sdk = require('api')('${opts.apiDefinitionUri}');`);
 
   let metadata = {};
   if (Object.keys(source.queryObj).length) {
@@ -194,11 +194,6 @@ module.exports = function (source, options) {
       }
   }
 
-  let authCode = [];
-  if (authData.length) {
-    authCode = authData;
-  }
-
   const args = [];
 
   let accessor = method;
@@ -220,7 +215,13 @@ module.exports = function (source, options) {
     code.unshift('const fs = require("fs");');
   }
 
-  code.push(`sdk${authCode.join()}.${accessor}(${args.join(', ')})`);
+  if (authData.length) {
+    code.push(authData.join('\n'));
+  }
+
+  code.blank();
+
+  code.push(`sdk.${accessor}(${args.join(', ')})`);
   code.push(1, '.then(res => res.json())');
   code.push(1, '.then(res => {');
   code.push(2, 'console.log(res);');


### PR DESCRIPTION
## 🧰 What's being changed?

This breaks up the API snippets we're generating by breaking off the `sdk.auth()` call into a separate line.

Resolves https://github.com/readmeio/api-explorer/issues/823
