### PR TITLE
feat: automatically reject the sdk promise for error statuses

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "bootstrap": "lerna bootstrap",
     "clean": "lerna clean",
     "lint": "lerna run lint --stream",
+    "postinstall": "npm run bootstrap",
     "publish": "lerna publish",
     "test": "lerna run test --stream",
     "version": "conventional-changelog --pkg lerna.json -i CHANGELOG.md -s && git add CHANGELOG.md"

--- a/packages/api/__tests__/index.test.js
+++ b/packages/api/__tests__/index.test.js
@@ -147,6 +147,26 @@ describe('#accessors', () => {
 describe('#fetch', () => {
   const petId = 123;
 
+  it('should reject for error-level status codes', () => {
+    expect.assertions(2);
+
+    const response = {
+      error: 'ENDPOINT_NOTFOUND',
+      message: `The endpoint you called (GET /pets/${petId}) doesn't exist`,
+    };
+
+    const mock = nock(petstoreServerUrl).delete(`/pets/${petId}`).reply(404, response);
+
+    return petstoreSdk.deletePet({ id: petId }).catch(async err => {
+      expect(err.status).toBe(404);
+
+      const json = await err.json();
+      expect(json).toStrictEqual(response);
+
+      mock.done();
+    });
+  });
+
   describe('operationId', () => {
     it('should pass through parameters for operationId', () => {
       const response = {

--- a/packages/api/src/index.js
+++ b/packages/api/src/index.js
@@ -36,7 +36,13 @@ class Sdk {
     function fetchOperation(spec, operation, body, metadata) {
       const har = oasToHar(spec, operation, prepareParams(operation, body, metadata), prepareAuth(authKeys, operation));
 
-      return fetchHar(har);
+      return fetchHar(har).then(res => {
+        if (res.status >= 400 && res.status <= 599) {
+          throw res;
+        }
+
+        return res;
+      });
     }
 
     function loadMethods(spec) {


### PR DESCRIPTION
## 🧰 What's being changed?

This updates the SDK so when error HTTP statuses (>=400, <=599) are hit, the promise is automatically rejected. 

It will turn the following, unnecessarily verbose code:

```js
readme
  .auth(apiKey)
  .createChangelog({ title, body: body.join('\n'), hidden: true })
  .then(res => {
    if (res.status !== 201) {
      console.error('Error creating Changelog:', res.status, res.statusText);
      process.exit(1);
    }
    return res.json();
  })
  .then(json => {
    console.log('Changelog created!', json._id);
  })
  .catch(err => {
    console.error(err);
    process.exit(1);
  });
```

Into the following:

```js
readme
  .auth(apiKey)
  .createChangelog({ title, body: body.join('\n'), hidden: true })
  .then(res => res.json())
  .then(json => {
    console.log('Changelog created!', json._id);
  })
  .catch(err => {
    console.error('Error creating Changelog:', err.status, err.statusText);
    process.exit(1);
  });
```

`err` in this case, is the full error response from the API request so if you wish to inspect it for JSON content you can do so within the `.catch()` by doing an `await err.json()`.

Resolves https://github.com/readmeio/api/issues/103