### PR TITLE
fix: if no cache dir is determined, fallback to the os temp dir

### DIFF
--- a/packages/api/__tests__/cache-tmp.test.js
+++ b/packages/api/__tests__/cache-tmp.test.js
@@ -1,0 +1,17 @@
+jest.mock('find-cache-dir', () => {
+  return () => undefined;
+});
+
+const os = require('os');
+const Cache = require('../src/cache');
+
+// Since this test is mocking out the `find-cache-dir` module for a single test, it needs to be run separately from the
+// rest of the cache tests, otherwise all of those tests would use this mocked out version.
+test('should fallback to an os-level temp directory if a cache directory cannot be determined', () => {
+  const dir = os.tmpdir();
+  const cacheStore = new Cache('http://example.com/readme.json');
+
+  expect(cacheStore.dir).toMatch(dir);
+  expect(cacheStore.cacheStore).toMatch(dir);
+  expect(cacheStore.specsCache).toMatch(dir);
+});

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -33,6 +33,7 @@
     "form-data": "^3.0.0",
     "get-stream": "^6.0.0",
     "js-yaml": "^3.14.0",
+    "make-dir": "^3.1.0",
     "mimer": "^1.1.0",
     "node-fetch": "^2.6.0"
   },

--- a/packages/api/src/cache.js
+++ b/packages/api/src/cache.js
@@ -13,7 +13,7 @@ const makeDir = require('make-dir');
 let cacheDir = findCacheDir({ name: pkg.name });
 if (typeof cacheDir === 'undefined') {
   // The `find-cache-dir` module returns `undefined` if the `node_modules/` directory isn't writable, or there's no
-  // `package.json`  in the root-most directory. If this happens, we can instead adhoc create a cache directory in the
+  // `package.json` in the root-most directory. If this happens, we can instead adhoc create a cache directory in the
   // users OS temp directory and store our data there.
   //
   // @link https://github.com/avajs/find-cache-dir/issues/29


### PR DESCRIPTION
## 🧰 What's being changed?

This resolves #107 and edge case with the [find-cache-dir](https://www.npmjs.com/package/find-cache-dir) module where if it can't determine a cache directory, it'll return `undefined`. When this could crop up is if a user runs `npm install api` in a fresh directory without a `package.json` file. Since `find-cache-dir` looks for the root-most directory with a `package.json` file to determine where to put its `.cache/` directory into `node_modules/`, it can't.

So to account for this edge case, if we end up with an undefined cache directory from the module we'll instead fallback to creating a temp directory at the OS level.