### PR TITLE
fix: adding a `.catch()` statement to code snippets

### DIFF
--- a/packages/httpsnippet-client-api/__tests__/__fixtures__/output/application-form-encoded.js
+++ b/packages/httpsnippet-client-api/__tests__/__fixtures__/output/application-form-encoded.js
@@ -2,6 +2,5 @@ const sdk = require('api')('https://example.com/openapi.json');
 
 sdk.post('/har', {foo: 'bar', hello: 'world'})
   .then(res => res.json())
-  .then(res => {
-    console.log(res);
-  });
+  .then(json => console.log(json))
+  .catch(err => console.error(err));

--- a/packages/httpsnippet-client-api/__tests__/__fixtures__/output/application-json.js
+++ b/packages/httpsnippet-client-api/__tests__/__fixtures__/output/application-json.js
@@ -9,6 +9,5 @@ sdk.post('/har', {
   boolean: false
 })
   .then(res => res.json())
-  .then(res => {
-    console.log(res);
-  });
+  .then(json => console.log(json))
+  .catch(err => console.error(err));

--- a/packages/httpsnippet-client-api/__tests__/__fixtures__/output/cookies.js
+++ b/packages/httpsnippet-client-api/__tests__/__fixtures__/output/cookies.js
@@ -2,6 +2,5 @@ const sdk = require('api')('https://example.com/openapi.json');
 
 sdk.post('/har')
   .then(res => res.json())
-  .then(res => {
-    console.log(res);
-  });
+  .then(json => console.log(json))
+  .catch(err => console.error(err));

--- a/packages/httpsnippet-client-api/__tests__/__fixtures__/output/full.js
+++ b/packages/httpsnippet-client-api/__tests__/__fixtures__/output/full.js
@@ -2,6 +2,5 @@ const sdk = require('api')('https://example.com/openapi.json');
 
 sdk.post('/har', {foo: 'bar'}, {foo: ['bar', 'baz'], baz: 'abc', key: 'value', accept: 'application/json'})
   .then(res => res.json())
-  .then(res => {
-    console.log(res);
-  });
+  .then(json => console.log(json))
+  .catch(err => console.error(err));

--- a/packages/httpsnippet-client-api/__tests__/__fixtures__/output/headers.js
+++ b/packages/httpsnippet-client-api/__tests__/__fixtures__/output/headers.js
@@ -2,6 +2,5 @@ const sdk = require('api')('https://example.com/openapi.json');
 
 sdk.get('/har', {'x-foo': 'Bar'})
   .then(res => res.json())
-  .then(res => {
-    console.log(res);
-  });
+  .then(json => console.log(json))
+  .catch(err => console.error(err));

--- a/packages/httpsnippet-client-api/__tests__/__fixtures__/output/https.js
+++ b/packages/httpsnippet-client-api/__tests__/__fixtures__/output/https.js
@@ -2,6 +2,5 @@ const sdk = require('api')('https://example.com/openapi.json');
 
 sdk.get('/har')
   .then(res => res.json())
-  .then(res => {
-    console.log(res);
-  });
+  .then(json => console.log(json))
+  .catch(err => console.error(err));

--- a/packages/httpsnippet-client-api/__tests__/__fixtures__/output/issue-128.js
+++ b/packages/httpsnippet-client-api/__tests__/__fixtures__/output/issue-128.js
@@ -3,6 +3,5 @@ sdk.auth('authKey\'With\'Apostrophes');
 
 sdk.getItem({accept: 'application/xml'})
   .then(res => res.json())
-  .then(res => {
-    console.log(res);
-  });
+  .then(json => console.log(json))
+  .catch(err => console.error(err));

--- a/packages/httpsnippet-client-api/__tests__/__fixtures__/output/issue-76.js
+++ b/packages/httpsnippet-client-api/__tests__/__fixtures__/output/issue-76.js
@@ -3,6 +3,5 @@ sdk.auth('a5a220e');
 
 sdk.get('/pet/findByStatus', {status: 'available', accept: 'application/xml'})
   .then(res => res.json())
-  .then(res => {
-    console.log(res);
-  });
+  .then(json => console.log(json))
+  .catch(err => console.error(err));

--- a/packages/httpsnippet-client-api/__tests__/__fixtures__/output/issue-78-operationid.js
+++ b/packages/httpsnippet-client-api/__tests__/__fixtures__/output/issue-78-operationid.js
@@ -2,6 +2,5 @@ const sdk = require('api')('https://example.com/openapi.json');
 
 sdk.getOrder({orderId: '1234', accept: 'application/xml'})
   .then(res => res.json())
-  .then(res => {
-    console.log(res);
-  });
+  .then(json => console.log(json))
+  .catch(err => console.error(err));

--- a/packages/httpsnippet-client-api/__tests__/__fixtures__/output/issue-78.js
+++ b/packages/httpsnippet-client-api/__tests__/__fixtures__/output/issue-78.js
@@ -2,6 +2,5 @@ const sdk = require('api')('https://example.com/openapi.json');
 
 sdk.get('/store/order/1234/tracking/{trackingId}', {accept: 'application/xml'})
   .then(res => res.json())
-  .then(res => {
-    console.log(res);
-  });
+  .then(json => console.log(json))
+  .catch(err => console.error(err));

--- a/packages/httpsnippet-client-api/__tests__/__fixtures__/output/jsonObj-multiline.js
+++ b/packages/httpsnippet-client-api/__tests__/__fixtures__/output/jsonObj-multiline.js
@@ -2,6 +2,5 @@ const sdk = require('api')('https://example.com/openapi.json');
 
 sdk.post('/har', {foo: 'bar'})
   .then(res => res.json())
-  .then(res => {
-    console.log(res);
-  });
+  .then(json => console.log(json))
+  .catch(err => console.error(err));

--- a/packages/httpsnippet-client-api/__tests__/__fixtures__/output/jsonObj-null-value.js
+++ b/packages/httpsnippet-client-api/__tests__/__fixtures__/output/jsonObj-null-value.js
@@ -2,6 +2,5 @@ const sdk = require('api')('https://example.com/openapi.json');
 
 sdk.post('/har', {foo: null})
   .then(res => res.json())
-  .then(res => {
-    console.log(res);
-  });
+  .then(json => console.log(json))
+  .catch(err => console.error(err));

--- a/packages/httpsnippet-client-api/__tests__/__fixtures__/output/multipart-data.js
+++ b/packages/httpsnippet-client-api/__tests__/__fixtures__/output/multipart-data.js
@@ -2,6 +2,5 @@ const sdk = require('api')('https://example.com/openapi.json');
 
 sdk.post('/har', {foo: 'hello.txt'})
   .then(res => res.json())
-  .then(res => {
-    console.log(res);
-  });
+  .then(json => console.log(json))
+  .catch(err => console.error(err));

--- a/packages/httpsnippet-client-api/__tests__/__fixtures__/output/multipart-file.js
+++ b/packages/httpsnippet-client-api/__tests__/__fixtures__/output/multipart-file.js
@@ -2,6 +2,5 @@ const sdk = require('api')('https://example.com/openapi.json');
 
 sdk.post('/har', {foo: 'test/fixtures/files/hello.txt'})
   .then(res => res.json())
-  .then(res => {
-    console.log(res);
-  });
+  .then(json => console.log(json))
+  .catch(err => console.error(err));

--- a/packages/httpsnippet-client-api/__tests__/__fixtures__/output/multipart-form-data.js
+++ b/packages/httpsnippet-client-api/__tests__/__fixtures__/output/multipart-form-data.js
@@ -2,6 +2,5 @@ const sdk = require('api')('https://example.com/openapi.json');
 
 sdk.post('/har', {foo: 'bar'})
   .then(res => res.json())
-  .then(res => {
-    console.log(res);
-  });
+  .then(json => console.log(json))
+  .catch(err => console.error(err));

--- a/packages/httpsnippet-client-api/__tests__/__fixtures__/output/petstore.js
+++ b/packages/httpsnippet-client-api/__tests__/__fixtures__/output/petstore.js
@@ -3,6 +3,5 @@ sdk.auth('123');
 
 sdk.findPetsByStatus({status: 'available', accept: 'application/xml'})
   .then(res => res.json())
-  .then(res => {
-    console.log(res);
-  });
+  .then(json => console.log(json))
+  .catch(err => console.error(err));

--- a/packages/httpsnippet-client-api/__tests__/__fixtures__/output/query-auth.js
+++ b/packages/httpsnippet-client-api/__tests__/__fixtures__/output/query-auth.js
@@ -3,6 +3,5 @@ sdk.auth('a5a220e');
 
 sdk.findPetsByStatus({status: 'available', accept: 'application/xml'})
   .then(res => res.json())
-  .then(res => {
-    console.log(res);
-  });
+  .then(json => console.log(json))
+  .catch(err => console.error(err));

--- a/packages/httpsnippet-client-api/__tests__/__fixtures__/output/query.js
+++ b/packages/httpsnippet-client-api/__tests__/__fixtures__/output/query.js
@@ -2,6 +2,5 @@ const sdk = require('api')('https://example.com/openapi.json');
 
 sdk.get('/har', {foo: ['bar', 'baz'], baz: 'abc', key: 'value'})
   .then(res => res.json())
-  .then(res => {
-    console.log(res);
-  });
+  .then(json => console.log(json))
+  .catch(err => console.error(err));

--- a/packages/httpsnippet-client-api/__tests__/__fixtures__/output/short.js
+++ b/packages/httpsnippet-client-api/__tests__/__fixtures__/output/short.js
@@ -2,6 +2,5 @@ const sdk = require('api')('https://example.com/openapi.json');
 
 sdk.get('/har')
   .then(res => res.json())
-  .then(res => {
-    console.log(res);
-  });
+  .then(json => console.log(json))
+  .catch(err => console.error(err));

--- a/packages/httpsnippet-client-api/__tests__/__fixtures__/output/text-plain.js
+++ b/packages/httpsnippet-client-api/__tests__/__fixtures__/output/text-plain.js
@@ -2,6 +2,5 @@ const sdk = require('api')('https://example.com/openapi.json');
 
 sdk.post('/har', 'Hello World')
   .then(res => res.json())
-  .then(res => {
-    console.log(res);
-  });
+  .then(json => console.log(json))
+  .catch(err => console.error(err));

--- a/packages/httpsnippet-client-api/src/index.js
+++ b/packages/httpsnippet-client-api/src/index.js
@@ -206,11 +206,11 @@ module.exports = function (source, options) {
 
   code.blank();
 
-  code.push(`sdk.${accessor}(${args.join(', ')})`);
-  code.push(1, '.then(res => res.json())');
-  code.push(1, '.then(res => {');
-  code.push(2, 'console.log(res);');
-  code.push(1, '});');
+  code
+    .push(`sdk.${accessor}(${args.join(', ')})`)
+    .push(1, '.then(res => res.json())')
+    .push(1, '.then(json => console.log(json))')
+    .push(1, '.catch(err => console.error(err));');
 
   return code.join();
 };


### PR DESCRIPTION
## 🧰 What's being changed?

Adds a `.catch()` statement to code snippets and also removes some unncessary logic block bloat.

### Before
```js
const sdk = require('api')('http://localhost:9966/swagger-files/petstore.json');

sdk.addPet({'Content-Type': 'application/json', Authorization: 'Bearer 123'})
  .then(res => res.json())
  .then(res => {
    console.log(res);
  });
```

### After
```js
const sdk = require('api')('http://localhost:9966/swagger-files/petstore.json');

sdk.addPet({'Content-Type': 'application/json', Authorization: 'Bearer 123'})
  .then(res => res.json())
  .then(json => console.log(json))
  .catch(err => console.error(err));
```