### PR TITLE
fix: basic auth headers now decoded and exploded into `.auth()` calls

### DIFF
--- a/packages/httpsnippet-client-api/__tests__/__fixtures__/output/issue-128.js
+++ b/packages/httpsnippet-client-api/__tests__/__fixtures__/output/issue-128.js
@@ -1,7 +1,7 @@
 const sdk = require('api')('https://example.com/openapi.json');
 sdk.auth('authKey\'With\'Apostrophes');
 
-sdk.getItem({accept: 'application/xml'})
+sdk.getItem({Accept: 'application/xml'})
   .then(res => res.json())
   .then(json => console.log(json))
   .catch(err => console.error(err));

--- a/packages/httpsnippet-client-api/__tests__/__fixtures__/output/issue-76.js
+++ b/packages/httpsnippet-client-api/__tests__/__fixtures__/output/issue-76.js
@@ -1,7 +1,7 @@
 const sdk = require('api')('https://example.com/openapi.json');
 sdk.auth('a5a220e');
 
-sdk.get('/pet/findByStatus', {status: 'available', accept: 'application/xml'})
+sdk.get('/pet/findByStatus', {status: 'available', Accept: 'application/xml'})
   .then(res => res.json())
   .then(json => console.log(json))
   .catch(err => console.error(err));

--- a/packages/httpsnippet-client-api/__tests__/__fixtures__/output/issue-78-operationid.js
+++ b/packages/httpsnippet-client-api/__tests__/__fixtures__/output/issue-78-operationid.js
@@ -1,6 +1,6 @@
 const sdk = require('api')('https://example.com/openapi.json');
 
-sdk.getOrder({orderId: '1234', accept: 'application/xml'})
+sdk.getOrder({orderId: '1234', Accept: 'application/xml'})
   .then(res => res.json())
   .then(json => console.log(json))
   .catch(err => console.error(err));

--- a/packages/httpsnippet-client-api/__tests__/__fixtures__/output/issue-78.js
+++ b/packages/httpsnippet-client-api/__tests__/__fixtures__/output/issue-78.js
@@ -1,6 +1,6 @@
 const sdk = require('api')('https://example.com/openapi.json');
 
-sdk.get('/store/order/1234/tracking/{trackingId}', {accept: 'application/xml'})
+sdk.get('/store/order/1234/tracking/{trackingId}', {Accept: 'application/xml'})
   .then(res => res.json())
   .then(json => console.log(json))
   .catch(err => console.error(err));

--- a/packages/httpsnippet-client-api/__tests__/__fixtures__/output/petstore.js
+++ b/packages/httpsnippet-client-api/__tests__/__fixtures__/output/petstore.js
@@ -1,7 +1,7 @@
 const sdk = require('api')('https://example.com/openapi.json');
 sdk.auth('123');
 
-sdk.findPetsByStatus({status: 'available', accept: 'application/xml'})
+sdk.findPetsByStatus({status: 'available', Accept: 'application/xml'})
   .then(res => res.json())
   .then(json => console.log(json))
   .catch(err => console.error(err));

--- a/packages/httpsnippet-client-api/__tests__/__fixtures__/output/query-auth.js
+++ b/packages/httpsnippet-client-api/__tests__/__fixtures__/output/query-auth.js
@@ -1,7 +1,7 @@
 const sdk = require('api')('https://example.com/openapi.json');
 sdk.auth('a5a220e');
 
-sdk.findPetsByStatus({status: 'available', accept: 'application/xml'})
+sdk.findPetsByStatus({status: 'available', Accept: 'application/xml'})
   .then(res => res.json())
   .then(json => console.log(json))
   .catch(err => console.error(err));

--- a/packages/httpsnippet-client-api/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/httpsnippet-client-api/__tests__/__snapshots__/index.test.js.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`auth handling basic should be able to handle basic auth that's just a password 1`] = `
+"const sdk = require('api')('https://example.com/openapi.json');
+sdk.auth('', 'pug')
+
+sdk.getAPISpecification({perPage: '10', page: '1'})
+  .then(res => res.json())
+  .then(json => console.log(json))
+  .catch(err => console.error(err));"
+`;
+
+exports[`auth handling basic should be able to handle basic auth that's just a username 1`] = `
+"const sdk = require('api')('https://example.com/openapi.json');
+sdk.auth('buster')
+
+sdk.getAPISpecification({perPage: '10', page: '1'})
+  .then(res => res.json())
+  .then(json => console.log(json))
+  .catch(err => console.error(err));"
+`;
+
+exports[`auth handling basic should not encode basic auth in the \`.auth()\` call 1`] = `
+"const sdk = require('api')('https://example.com/openapi.json');
+sdk.auth('buster', 'pug')
+
+sdk.getAPISpecification({perPage: '10', page: '1'})
+  .then(res => res.json())
+  .then(json => console.log(json))
+  .catch(err => console.error(err));"
+`;

--- a/packages/httpsnippet-client-api/__tests__/index.test.js
+++ b/packages/httpsnippet-client-api/__tests__/index.test.js
@@ -43,6 +43,43 @@ test('it should error if no apiDefinition was supplied', async () => {
   }).toThrow(/must have an `apiDefinition` option supplied/);
 });
 
+describe('auth handling', () => {
+  describe('basic', () => {
+    it.each([
+      ['should not encode basic auth in the `.auth()` call', 'buster:pug'],
+      ["should be able to handle basic auth that's just a username", 'buster:'],
+      ["should be able to handle basic auth that's just a password", ':pug'],
+    ])('%s', (testCase, authKey) => {
+      const definition = require('@readme/oas-examples/3.0/json/readme.json');
+      const har = {
+        bodySize: 0,
+        cookies: [],
+        headers: [
+          {
+            name: 'Authorization',
+            value: `Basic ${Buffer.from(authKey).toString('base64')}`,
+          },
+        ],
+        headersSize: 0,
+        httpVersion: 'HTTP/1.1',
+        method: 'GET',
+        queryString: [
+          { name: 'perPage', value: '10' },
+          { name: 'page', value: '1' },
+        ],
+        url: 'https://dash.readme.io/api/v1/api-specification',
+      };
+
+      const code = new HTTPSnippet(har).convert('node', 'api', {
+        apiDefinitionUri: 'https://example.com/openapi.json',
+        apiDefinition: definition,
+      });
+
+      expect(code).toMatchSnapshot();
+    });
+  });
+});
+
 describe('snippets', () => {
   it.each([
     ['application-form-encoded'],

--- a/packages/httpsnippet-client-api/package-lock.json
+++ b/packages/httpsnippet-client-api/package-lock.json
@@ -1678,9 +1678,9 @@
       }
     },
     "@readme/httpsnippet": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@readme/httpsnippet/-/httpsnippet-2.1.1.tgz",
-      "integrity": "sha512-7vpyeyPqjhIeWI/vFY+eHzebK9cCayDlGYkRRtbpNfpINWEjlONcK6PHs60GS55WJpLhNeECV7UQYEui5QVaiA==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@readme/httpsnippet/-/httpsnippet-2.2.2.tgz",
+      "integrity": "sha512-Ejhwekiii6EMcfBKCLsizzQtWf27ipVv0mCtra/0Qj8qBNYlr50OMDxkt56J6nf4C/rH9+AoMsfQUIl3bcXQlA==",
       "requires": {
         "event-stream": "4.0.1",
         "form-data": "3.0.0",
@@ -1688,10 +1688,16 @@
         "stringify-object": "^3.3.0"
       }
     },
-    "@readme/oas-tooling": {
+    "@readme/oas-examples": {
       "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@readme/oas-tooling/-/oas-tooling-3.6.0.tgz",
-      "integrity": "sha512-HmDCQbvZ2sCZwv5BeGKh0deaP+2PuLI3XL6J4CGoy41zGcFZt/eFwsSVAOQRM/zzhU3EwNnxPstXFbOcUvahKw==",
+      "resolved": "https://registry.npmjs.org/@readme/oas-examples/-/oas-examples-3.6.0.tgz",
+      "integrity": "sha512-8wAXHTKOEstiDO5tYxCdVXv9LOTU7xO5OWqcHTlVQwEZ8bXMxiVRgmGbYuAjLvC851J3jaajoNMVvsRxcQ7YMA==",
+      "dev": true
+    },
+    "@readme/oas-tooling": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@readme/oas-tooling/-/oas-tooling-3.6.1.tgz",
+      "integrity": "sha512-hF0Iwh3DmsP3HHY9djVUI957HsHvlBw+H9GMjZJCy2pRFqjor1+l9uOYZl9L1AaajGJX5EXf8PqXfwD1Cr0V6Q==",
       "requires": {
         "jsonpointer": "^4.0.1",
         "path-to-regexp": "^6.1.0"

--- a/packages/httpsnippet-client-api/package.json
+++ b/packages/httpsnippet-client-api/package.json
@@ -23,8 +23,8 @@
     "node": ">=10"
   },
   "dependencies": {
-    "@readme/httpsnippet": "^2.0.1",
-    "@readme/oas-tooling": "^3.5.8",
+    "@readme/httpsnippet": "^2.2.2",
+    "@readme/oas-tooling": "^3.6.1",
     "content-type": "^1.0.4",
     "path-to-regexp": "^6.1.0",
     "stringify-object": "^3.3.0"
@@ -34,6 +34,7 @@
   },
   "devDependencies": {
     "@readme/eslint-config": "^3.4.1",
+    "@readme/oas-examples": "^3.6.0",
     "eslint": "^7.6.0",
     "jest": "^26.0.1",
     "prettier": "^2.0.5"


### PR DESCRIPTION
## 🧰 What's being changed?

Fixes a bug in code snippets where a `Basic` auth header would remain encoded in the `.auth()` call and unable to be used properly when making a call. These auth heads are now being decoded and exploded into 1+ arguments for `.auth()` calls.

Fixes https://github.com/readmeio/api-explorer/issues/832