### PR TITLE
fix: adding support for non-alphanumerical operation ids

### DIFF
--- a/packages/httpsnippet-client-api/__tests__/__fixtures__/output/issue-119.js
+++ b/packages/httpsnippet-client-api/__tests__/__fixtures__/output/issue-119.js
@@ -1,0 +1,7 @@
+const sdk = require('api')('https://example.com/openapi.json');
+sdk.auth('123');
+
+sdk['find/pets-by-status']({status: 'available'})
+  .then(res => res.json())
+  .then(json => console.log(json))
+  .catch(err => console.error(err));

--- a/packages/httpsnippet-client-api/__tests__/__fixtures__/request/issue-119/definition.json
+++ b/packages/httpsnippet-client-api/__tests__/__fixtures__/request/issue-119/definition.json
@@ -1,0 +1,156 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore"
+  },
+  "servers": [
+    {
+      "url": "http://petstore.swagger.io/v2"
+    }
+  ],
+  "paths": {
+    "/pet/findByStatus": {
+      "get": {
+        "summary": "Finds Pets by status",
+        "description": "Multiple status values can be provided with comma separated strings",
+        "operationId": "find/pets-by-status",
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "description": "Status values that need to be considered for filter",
+            "required": true,
+            "explode": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "available",
+                  "pending",
+                  "sold"
+                ],
+                "default": "available"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Pet"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid status value"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "petstore_auth": {
+        "type": "oauth2",
+        "flows": {
+          "implicit": {
+            "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
+            "scopes": {
+              "write:pets": "modify pets in your account",
+              "read:pets": "read your pets"
+            }
+          }
+        }
+      },
+      "api_key": {
+        "type": "apiKey",
+        "name": "api_key",
+        "in": "header"
+      }
+    },
+    "schemas": {
+      "Category": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "Tag": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "Pet": {
+        "type": "object",
+        "required": [
+          "name",
+          "photoUrls"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "category": {
+            "$ref": "#/components/schemas/Category"
+          },
+          "name": {
+            "type": "string",
+            "example": "doggie"
+          },
+          "photoUrls": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Tag"
+            }
+          },
+          "status": {
+            "type": "string",
+            "description": "pet status in the store",
+            "enum": [
+              "available",
+              "pending",
+              "sold"
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/httpsnippet-client-api/__tests__/__fixtures__/request/issue-119/har.json
+++ b/packages/httpsnippet-client-api/__tests__/__fixtures__/request/issue-119/har.json
@@ -1,0 +1,32 @@
+{
+  "log": {
+    "entries": [
+      {
+        "request": {
+          "cookies": [],
+          "headers": [
+            {
+              "name": "Authorization",
+              "value": "Bearer 123"
+            }
+          ],
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "jsonObj": false,
+            "mimeType": "application/octet-stream",
+            "paramsObj": false,
+            "size": 0
+          },
+          "queryString": [
+            {
+              "name": "status",
+              "value": "available"
+            }
+          ],
+          "url": "http://petstore.swagger.io/v2/pet/findByStatus"
+        }
+      }
+    ]
+  }
+}

--- a/packages/httpsnippet-client-api/__tests__/index.test.js
+++ b/packages/httpsnippet-client-api/__tests__/index.test.js
@@ -91,6 +91,7 @@ describe('snippets', () => {
     ['issue-76'],
     ['issue-78'],
     ['issue-78-operationid'],
+    ['issue-119'],
     ['issue-128'],
     ['jsonObj-multiline'],
     ['jsonObj-null-value'],

--- a/packages/httpsnippet-client-api/src/index.js
+++ b/packages/httpsnippet-client-api/src/index.js
@@ -217,6 +217,14 @@ module.exports = function (source, options) {
     args.push(`'${decodeURIComponent(path)}'`);
   }
 
+  // If the operation or method accessor is non-alphanumeric, we need to add it to the SDK object as an array key.
+  // https://github.com/readmeio/api/issues/119
+  if (accessor.match(/[^a-zA-Z\d\s:]/)) {
+    accessor = `['${accessor}']`;
+  } else {
+    accessor = `.${accessor}`;
+  }
+
   if (typeof body !== 'undefined') {
     args.push(stringifyObject(body, { indent: '  ', inlineCharacterLimit: 80 }));
   }
@@ -232,7 +240,7 @@ module.exports = function (source, options) {
   code.blank();
 
   code
-    .push(`sdk.${accessor}(${args.join(', ')})`)
+    .push(`sdk${accessor}(${args.join(', ')})`)
     .push(1, '.then(res => res.json())')
     .push(1, '.then(json => console.log(json))')
     .push(1, '.catch(err => console.error(err));');


### PR DESCRIPTION
## 🧰 What's being changed?

Adds support for the case where an `operationId` is not fully alphanumerical and thus can't be used as an object accessor.

Fixes https://github.com/readmeio/api/issues/119