### PR TITLE
fix: adding better messaging when operations can't be found

### DIFF
--- a/packages/httpsnippet-client-api/__tests__/index.test.js
+++ b/packages/httpsnippet-client-api/__tests__/index.test.js
@@ -43,6 +43,33 @@ test('it should error if no apiDefinition was supplied', async () => {
   }).toThrow(/must have an `apiDefinition` option supplied/);
 });
 
+// This test should fail because the url in the HAR is missing `/v1` in the path.
+test('it should error if no matching operation was found in the apiDefinition', () => {
+  const definition = require('@readme/oas-examples/3.0/json/readme.json');
+  const har = {
+    bodySize: 0,
+    cookies: [],
+    headers: [],
+    headersSize: 0,
+    httpVersion: 'HTTP/1.1',
+    method: 'GET',
+    queryString: [
+      { name: 'perPage', value: '10' },
+      { name: 'page', value: '1' },
+    ],
+    url: 'https://dash.readme.io/api/api-specification',
+  };
+
+  const snippet = new HTTPSnippet(har);
+
+  expect(() => {
+    snippet.convert('node', 'api', {
+      apiDefinitionUri: 'https://example.com/openapi.json',
+      apiDefinition: definition,
+    });
+  }).toThrow(/unable to locate a matching operation/i);
+});
+
 describe('auth handling', () => {
   describe('basic', () => {
     it.each([

--- a/packages/httpsnippet-client-api/src/index.js
+++ b/packages/httpsnippet-client-api/src/index.js
@@ -88,6 +88,10 @@ module.exports = function (source, options) {
   const oas = new OAS(opts.apiDefinition);
   const operation = oas.getOperation(source.url, method);
 
+  if (!operation) {
+    throw new Error(`Unable to locate a matching operation in the supplied apiDefinition for ${method} {${source.url}`);
+  }
+
   // For cases where a server URL in the OAS has a path attached to it, we don't want to include that path with the
   // operation path.
   const path = source.url.replace(oas.url(), '');


### PR DESCRIPTION
## 🧰 What's being changed?

When an operation can't be found within the supplied `apiDefinition` we'd throw a fatal error on `operation.getSecurity()` not being a valid method because `operation` was null. This change cleans up that error to make it clearer what's happening.