### PR TITLE
feat: add a config() function that allows disabling of response parsing

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -24,7 +24,7 @@ Using `api` is as simple as supplying it an OpenAPI and using the SDK as you wou
 ```js
 const sdk = require('api')('https://raw.githubusercontent.com/readmeio/oas/master/packages/examples/3.0/json/petstore.json');
 
-sdk.listPets().then(res => res.json()).then(res => {
+sdk.listPets().then(res => {
   console.log(`My pets name is ${res[0].name}!`);
 });
 ```
@@ -88,6 +88,21 @@ You can also give it a stream and it'll handle all of the hard work for you.
 sdk.uploadFile({ file: fs.createReadStream('/path/to/a/file.txt') }).then(...)
 ```
 
+### Responses
+Since we know the `Content-Type` of the returned response, we automatically parse it for you before returning it. So no more superfluous `.then(res => res.json())` calls. If your API returned with JSON, we'll give you the parsed JSON.
+
+If you need access to the [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response) object you can disable our automatic parsing using `.config()` like so:
+
+```js
+sdk.config({ parseResponse: false });
+
+sdk.createPets({ name: 'Buster' })
+  .then(res => {
+    // `res` will be a Response object
+    // so you can access status and headers
+  })
+```
+
 ### HTTP requests
 If the API you're using doesn't have any documented operation IDs, you can make requests with HTTP verbs instead:
 
@@ -134,4 +149,11 @@ Not yet! The URL that you give the module must be publicy accessible. If it isn'
 
 ```js
 const sdk = require('api')('/path/to/downloaded.json');
+```
+
+#### How do I access the Response object (for status and headers)?
+By default we parse the response based on the `content-type` header for you. You can disable this by doing the following:
+
+```js
+sdk.config({ parseResponse: false });
 ```

--- a/packages/api/__tests__/config.test.js
+++ b/packages/api/__tests__/config.test.js
@@ -1,0 +1,35 @@
+const nock = require('nock');
+const api = require('../src');
+const { Response } = require('node-fetch');
+
+const serverUrl = 'https://api.example.com';
+const createOas = require('./__fixtures__/createOas')(serverUrl);
+
+describe('#config()', () => {
+  describe('parseResponse: false', () => {
+    it('should give access to the Response object', () => {
+      const petId = 123;
+      const response = {
+        id: petId,
+        name: 'Buster',
+      };
+
+      const sdk = api(
+        createOas('delete', `/pets/${petId}`, {
+          operationId: 'deletePet',
+        })
+      );
+
+      const mock = nock(serverUrl).delete(`/pets/${petId}`).reply(200, response);
+
+      sdk.config({ parseResponse: false });
+
+      return sdk.deletePet({ id: petId }).then(async res => {
+        expect(res instanceof Response).toBe(true);
+        expect(res.status).toStrictEqual(200);
+        expect(await res.json()).toStrictEqual(response);
+        mock.done();
+      });
+    });
+  });
+});

--- a/packages/api/__tests__/index.test.js
+++ b/packages/api/__tests__/index.test.js
@@ -62,7 +62,7 @@ describe('#preloading', () => {
 
     // SDK should still not be loaded since we haven't officially called it yet.
     expect(new Cache(uspto).isCached()).toBe(false);
-    expect(Object.keys(sdk)).toStrictEqual(['auth']);
+    expect(Object.keys(sdk)).toStrictEqual(['auth', 'config']);
 
     await sdk.get('/').then(() => {
       mock.done();
@@ -72,6 +72,7 @@ describe('#preloading', () => {
     expect(new Cache(uspto).isCached()).toBe(true);
     expect(Object.keys(sdk)).toStrictEqual([
       'auth',
+      'config',
       'get',
       'put',
       'post',


### PR DESCRIPTION
## 🧰 What's being changed?

If you ever need to access the raw Response object (instead of us parsing
automatically) you can do the following:

```js
sdk.config({ parseResponse: false });
sdk.deletePet({ id: petId });
```

This follows a similar pattern to the auth function.
