### PR TITLE
feat: cleaner snippets when body and metadata are present

### DIFF
--- a/packages/httpsnippet-client-api/__tests__/__fixtures__/output/full-many-query-params.js
+++ b/packages/httpsnippet-client-api/__tests__/__fixtures__/output/full-many-query-params.js
@@ -1,6 +1,11 @@
 const sdk = require('api')('https://example.com/openapi.json');
 
-sdk.post('/har', {foo: 'bar'}, {
+sdk.post('/har', {
+  foo: 'bar',
+  foo2: 'bar2',
+  foo3: 'bar3',
+  foo4: 'bar4'
+}, {
   foo: ['bar', 'baz'],
   baz: 'abc',
   key: 'value',

--- a/packages/httpsnippet-client-api/__tests__/__fixtures__/request/application-json/definition.json
+++ b/packages/httpsnippet-client-api/__tests__/__fixtures__/request/application-json/definition.json
@@ -1,83 +1,83 @@
 {
-   "openapi": "3.0.0",
-   "info": {
-     "version": "1.0",
-     "title": "application-json"
-   },
-   "servers": [
-     {
-       "url": "http://mockbin.com"
-     }
-   ],
-   "paths": {
-     "/har": {
-       "post": {
-         "requestBody": {
-           "required": true,
-           "content": {
-             "application/json": {
-               "schema": {
-                 "type": "object",
-                 "properties": {
-                   "number": {
-                     "type": "number"
-                   },
-                   "string": {
-                     "type": "string"
-                   },
-                   "arr": {
-                     "type": "array",
-                     "items": {
-                       "type": "number"
-                     }
-                   },
-                   "nested": {
-                     "type": "object",
-                     "properties": {
-                       "a": {
-                         "type": "string"
-                       }
-                     }
-                   },
-                   "arr_mix": {
-                     "type": "array",
-                     "items": {
-                       "oneOf": [
-                         {
-                           "type": "number"
-                         },
-                         {
-                           "type": "number"
-                         },
-                         {
-                           "type": "string"
-                         },
-                         {
-                           "properties": {
-                             "arr_mix_nested": {
-                               "type": "object",
-                               "properties": {}
-                             }
-                           },
-                           "type": "object"
-                         }
-                       ]
-                     }
-                   },
-                   "boolean": {
-                     "type": "boolean"
-                   }
-                 }
-               }
-             }
-           }
-         },
-         "responses": {
-           "default": {
-             "description": "OK"
-           }
-         }
-       }
-     }
-   }
- }
+  "openapi": "3.0.0",
+  "info": {
+    "version": "1.0",
+    "title": "application-json"
+  },
+  "servers": [
+    {
+      "url": "http://mockbin.com"
+    }
+  ],
+  "paths": {
+    "/har": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "number": {
+                    "type": "number"
+                  },
+                  "string": {
+                    "type": "string"
+                  },
+                  "arr": {
+                    "type": "array",
+                    "items": {
+                      "type": "number"
+                    }
+                  },
+                  "nested": {
+                    "type": "object",
+                    "properties": {
+                      "a": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "arr_mix": {
+                    "type": "array",
+                    "items": {
+                      "oneOf": [
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "properties": {
+                            "arr_mix_nested": {
+                              "type": "object",
+                              "properties": {}
+                            }
+                          },
+                          "type": "object"
+                        }
+                      ]
+                    }
+                  },
+                  "boolean": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "default": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/httpsnippet-client-api/__tests__/__fixtures__/request/full-many-query-params/definition.json
+++ b/packages/httpsnippet-client-api/__tests__/__fixtures__/request/full-many-query-params/definition.json
@@ -1,0 +1,79 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "version": "1.0",
+    "title": "full"
+  },
+  "servers": [
+    {
+      "url": "http://mockbin.com"
+    }
+  ],
+  "paths": {
+    "/har": {
+      "post": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "key",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "in": "query",
+            "name": "foo",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "in": "query",
+            "name": "baz",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "foo": {
+                    "type": "string"
+                  },
+                  "foo2": {
+                    "type": "string"
+                  },
+                  "foo3": {
+                    "type": "string"
+                  },
+                  "foo4": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "foo",
+                  "foo2",
+                  "foo3",
+                  "foo4"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "default": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/httpsnippet-client-api/__tests__/__fixtures__/request/full-many-query-params/har.json
+++ b/packages/httpsnippet-client-api/__tests__/__fixtures__/request/full-many-query-params/har.json
@@ -1,0 +1,68 @@
+{
+  "log": {
+    "entries": [
+      {
+        "request": {
+          "method": "POST",
+          "url": "http://mockbin.com/har?key=value",
+          "httpVersion": "HTTP/1.1",
+          "queryString": [
+            {
+              "name": "foo",
+              "value": "bar"
+            },
+            {
+              "name": "foo",
+              "value": "baz"
+            },
+            {
+              "name": "baz",
+              "value": "abc"
+            }
+          ],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            }
+          ],
+          "cookies": [
+            {
+              "name": "foo",
+              "value": "bar"
+            },
+            {
+              "name": "bar",
+              "value": "baz"
+            }
+          ],
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [
+              {
+                "name": "foo",
+                "value": "bar"
+              },
+              {
+                "name": "foo2",
+                "value": "bar2"
+              },
+              {
+                "name": "foo3",
+                "value": "bar3"
+              },
+              {
+                "name": "foo4",
+                "value": "bar4"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+}

--- a/packages/httpsnippet-client-api/__tests__/__fixtures__/request/full/definition.json
+++ b/packages/httpsnippet-client-api/__tests__/__fixtures__/request/full/definition.json
@@ -1,67 +1,67 @@
 {
-   "openapi": "3.0.0",
-   "info": {
-     "version": "1.0",
-     "title": "full"
-   },
-   "servers": [
-     {
-       "url": "http://mockbin.com"
-     }
-   ],
-   "paths": {
-     "/har": {
-       "post": {
-         "parameters": [
-           {
-             "in": "query",
-             "name": "key",
-             "schema": {
-               "type": "string"
-             },
-             "required": true
-           },
-           {
-             "in": "query",
-             "name": "foo",
-             "schema": {
-               "type": "string"
-             },
-             "required": true
-           },
-           {
-             "in": "query",
-             "name": "baz",
-             "schema": {
-               "type": "string"
-             },
-             "required": true
-           }
-         ],
-         "requestBody": {
-           "required": true,
-           "content": {
-             "application/x-www-form-urlencoded": {
-               "schema": {
-                 "type": "object",
-                 "properties": {
-                   "foo": {
-                     "type": "string"
-                   }
-                 },
-                 "required": [
-                   "foo"
-                 ]
-               }
-             }
-           }
-         },
-         "responses": {
-           "default": {
-             "description": "OK"
-           }
-         }
-       }
-     }
-   }
- }
+  "openapi": "3.0.0",
+  "info": {
+    "version": "1.0",
+    "title": "full"
+  },
+  "servers": [
+    {
+      "url": "http://mockbin.com"
+    }
+  ],
+  "paths": {
+    "/har": {
+      "post": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "key",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "in": "query",
+            "name": "foo",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "in": "query",
+            "name": "baz",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "foo": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "foo"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "default": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/httpsnippet-client-api/__tests__/__fixtures__/request/issue-128/definition.json
+++ b/packages/httpsnippet-client-api/__tests__/__fixtures__/request/issue-128/definition.json
@@ -1,38 +1,38 @@
 {
-   "openapi": "3.0.0",
-   "info": {
-     "version": "1.0.0",
-     "title": "issue-128"
-   },
-   "servers": [
-     {
-       "url": "http://example.com"
-     }
-   ],
-   "paths": {
-     "/": {
-       "get": {
-         "operationId": "getItem",
-         "responses": {
-           "200": {
-             "description": "OK"
-           }
-         },
-         "security": [
-           {
-             "api_key": []
-           }
-         ]
-       }
-     }
-   },
-   "components": {
-     "securitySchemes": {
-       "api_key": {
-         "type": "apiKey",
-         "name": "api_key",
-         "in": "query"
-       }
-     }
-   }
- }
+  "openapi": "3.0.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "issue-128"
+  },
+  "servers": [
+    {
+      "url": "http://example.com"
+    }
+  ],
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "getItem",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "api_key": {
+        "type": "apiKey",
+        "name": "api_key",
+        "in": "query"
+      }
+    }
+  }
+}

--- a/packages/httpsnippet-client-api/__tests__/__fixtures__/request/issue-78/definition.json
+++ b/packages/httpsnippet-client-api/__tests__/__fixtures__/request/issue-78/definition.json
@@ -1,45 +1,45 @@
 {
-   "openapi": "3.0.0",
-   "info": {
-     "version": "1.0.0",
-     "title": "issue-78"
-   },
-   "servers": [
-     {
-       "url": "http://petstore.swagger.io/v2"
-     }
-   ],
-   "paths": {
-     "/store/order/{orderId}/tracking/{trackingId}": {
-       "get": {
-         "parameters": [
-           {
-             "name": "orderId",
-             "in": "path",
-             "required": true,
-             "schema": {
-               "type": "integer",
-               "format": "int64",
-               "minimum": 1,
-               "maximum": 10
-             }
-           },
-           {
-             "name": "trackingId",
-             "in": "path",
-             "required": true,
-             "schema": {
-               "type": "integer",
-               "format": "int64"
-             }
-           }
-         ],
-         "responses": {
-           "200": {
-             "description": "OK"
-           }
-         }
-       }
-     }
-   }
- }
+  "openapi": "3.0.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "issue-78"
+  },
+  "servers": [
+    {
+      "url": "http://petstore.swagger.io/v2"
+    }
+  ],
+  "paths": {
+    "/store/order/{orderId}/tracking/{trackingId}": {
+      "get": {
+        "parameters": [
+          {
+            "name": "orderId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": 1,
+              "maximum": 10
+            }
+          },
+          {
+            "name": "trackingId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/httpsnippet-client-api/__tests__/__fixtures__/request/jsonObj-multiline/definition.json
+++ b/packages/httpsnippet-client-api/__tests__/__fixtures__/request/jsonObj-multiline/definition.json
@@ -1,38 +1,38 @@
 {
-   "openapi": "3.0.0",
-   "info": {
-     "version": "1.0",
-     "title": "jsonObj-multiline"
-   },
-   "servers": [
-     {
-       "url": "http://mockbin.com"
-     }
-   ],
-   "paths": {
-     "/har": {
-       "post": {
-         "requestBody": {
-           "required": true,
-           "content": {
-             "application/json": {
-               "schema": {
-                 "type": "object",
-                 "properties": {
-                   "foo": {
-                     "type": "string"
-                   }
-                 }
-               }
-             }
-           }
-         },
-         "responses": {
-           "default": {
-             "description": "OK"
-           }
-         }
-       }
-     }
-   }
- }
+  "openapi": "3.0.0",
+  "info": {
+    "version": "1.0",
+    "title": "jsonObj-multiline"
+  },
+  "servers": [
+    {
+      "url": "http://mockbin.com"
+    }
+  ],
+  "paths": {
+    "/har": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "foo": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "default": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/httpsnippet-client-api/__tests__/__fixtures__/request/jsonObj-null-value/definition.json
+++ b/packages/httpsnippet-client-api/__tests__/__fixtures__/request/jsonObj-null-value/definition.json
@@ -1,38 +1,38 @@
 {
-   "openapi": "3.0.0",
-   "info": {
-     "version": "1.0",
-     "title": "jsonObj-null-value"
-   },
-   "servers": [
-     {
-       "url": "http://mockbin.com"
-     }
-   ],
-   "paths": {
-     "/har": {
-       "post": {
-         "requestBody": {
-           "required": true,
-           "content": {
-             "application/json": {
-               "schema": {
-                 "type": "object",
-                 "properties": {
-                   "foo": {
-                     "type": "string"
-                   }
-                 }
-               }
-             }
-           }
-         },
-         "responses": {
-           "default": {
-             "description": "OK"
-           }
-         }
-       }
-     }
-   }
- }
+  "openapi": "3.0.0",
+  "info": {
+    "version": "1.0",
+    "title": "jsonObj-null-value"
+  },
+  "servers": [
+    {
+      "url": "http://mockbin.com"
+    }
+  ],
+  "paths": {
+    "/har": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "foo": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "default": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/httpsnippet-client-api/__tests__/__fixtures__/request/multipart-data/definition.json
+++ b/packages/httpsnippet-client-api/__tests__/__fixtures__/request/multipart-data/definition.json
@@ -1,39 +1,39 @@
 {
-   "openapi": "3.0.0",
-   "info": {
-     "version": "1.0",
-     "title": "multipart-data"
-   },
-   "servers": [
-     {
-       "url": "http://mockbin.com"
-     }
-   ],
-   "paths": {
-     "/har": {
-       "post": {
-         "requestBody": {
-           "required": true,
-           "content": {
-             "multipart/form-data": {
-               "schema": {
-                 "type": "object",
-                 "properties": {
-                   "foo": {
-                     "type": "string",
-                     "format": "binary"
-                   }
-                 }
-               }
-             }
-           }
-         },
-         "responses": {
-           "default": {
-             "description": "OK"
-           }
-         }
-       }
-     }
-   }
- }
+  "openapi": "3.0.0",
+  "info": {
+    "version": "1.0",
+    "title": "multipart-data"
+  },
+  "servers": [
+    {
+      "url": "http://mockbin.com"
+    }
+  ],
+  "paths": {
+    "/har": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "foo": {
+                    "type": "string",
+                    "format": "binary"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "default": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/httpsnippet-client-api/__tests__/__fixtures__/request/multipart-file/definition.json
+++ b/packages/httpsnippet-client-api/__tests__/__fixtures__/request/multipart-file/definition.json
@@ -1,39 +1,39 @@
 {
-   "openapi": "3.0.0",
-   "info": {
-     "version": "1.0",
-     "title": "multipart-file"
-   },
-   "servers": [
-     {
-       "url": "http://mockbin.com"
-     }
-   ],
-   "paths": {
-     "/har": {
-       "post": {
-         "requestBody": {
-           "required": true,
-           "content": {
-             "multipart/form-data": {
-               "schema": {
-                 "type": "object",
-                 "properties": {
-                   "foo": {
-                     "type": "string",
-                     "format": "binary"
-                   }
-                 }
-               }
-             }
-           }
-         },
-         "responses": {
-           "default": {
-             "description": "OK"
-           }
-         }
-       }
-     }
-   }
- }
+  "openapi": "3.0.0",
+  "info": {
+    "version": "1.0",
+    "title": "multipart-file"
+  },
+  "servers": [
+    {
+      "url": "http://mockbin.com"
+    }
+  ],
+  "paths": {
+    "/har": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "foo": {
+                    "type": "string",
+                    "format": "binary"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "default": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/httpsnippet-client-api/__tests__/index.test.js
+++ b/packages/httpsnippet-client-api/__tests__/index.test.js
@@ -113,6 +113,7 @@ describe('snippets', () => {
     ['application-json'],
     // ['cookies'], // Cookies test needs to get built out.
     ['full'],
+    ['full-many-query-params'],
     ['headers'],
     ['https'],
     ['issue-76'],

--- a/packages/httpsnippet-client-api/src/index.js
+++ b/packages/httpsnippet-client-api/src/index.js
@@ -229,12 +229,15 @@ module.exports = function (source, options) {
     accessor = `.${accessor}`;
   }
 
+  // If we're going to be rendering out body params and metadata we should cut their character limit in half because
+  // we'll be rendering them in their own lines.
+  const inlineCharacterLimit = typeof body !== 'undefined' && Object.keys(metadata).length > 0 ? 40 : 80;
   if (typeof body !== 'undefined') {
-    args.push(stringifyObject(body, { indent: '  ', inlineCharacterLimit: 80 }));
+    args.push(stringifyObject(body, { indent: '  ', inlineCharacterLimit }));
   }
 
   if (Object.keys(metadata).length > 0) {
-    args.push(stringifyObject(metadata, { indent: '  ', inlineCharacterLimit: 80 }));
+    args.push(stringifyObject(metadata, { indent: '  ', inlineCharacterLimit }));
   }
 
   if (authData.length) {


### PR DESCRIPTION
## 🧰 What's being changed?

Introduces some changes to snippet generation where if there are both `body` and `metadata` parameters, the inline character limit that we pass into [stringify-object](http://npm.im/stringify-object) gets cut in half so that they can both be presented in a cleaner syntax.