### PR TITLE
fix: quirks in oas-to-har where query params are not being URI encoded

### DIFF
--- a/packages/api/__tests__/index.test.js
+++ b/packages/api/__tests__/index.test.js
@@ -270,4 +270,44 @@ describe('#fetch', () => {
       });
     });
   });
+
+  describe('query parameter URL encoding', () => {
+    it('should encode url parameters if they are not already encoded', () => {
+      const params = {
+        tags: 'somethign&nothing=true',
+        limit: 'hash#data',
+      };
+
+      const mock = nock(petstoreServerUrl)
+        .get('/pets')
+        .query(true)
+        .reply(200, function () {
+          return { path: this.req.path };
+        });
+
+      return petstoreSdk.findPets(params).then(res => {
+        expect(res.path).toStrictEqual('/api/pets?tags=somethign%26nothing%3Dtrue&limit=hash%23data');
+        mock.done();
+      });
+    });
+
+    it("should not double encode query params if they're supplied as encoded", () => {
+      const params = {
+        tags: encodeURIComponent('somethign&nothing=true'),
+        limit: encodeURIComponent('hash#data'),
+      };
+
+      const mock = nock(petstoreServerUrl)
+        .get('/pets')
+        .query(true)
+        .reply(200, function () {
+          return { path: this.req.path };
+        });
+
+      return petstoreSdk.findPets(params).then(res => {
+        expect(res.path).toStrictEqual('/api/pets?tags=somethign%26nothing%3Dtrue&limit=hash%23data');
+        mock.done();
+      });
+    });
+  });
 });

--- a/packages/api/__tests__/index.test.js
+++ b/packages/api/__tests__/index.test.js
@@ -274,7 +274,7 @@ describe('#fetch', () => {
   describe('query parameter URL encoding', () => {
     it('should encode url parameters if they are not already encoded', () => {
       const params = {
-        tags: 'somethign&nothing=true',
+        tags: 'somethign&nothing=true&20%',
         limit: 'hash#data',
       };
 
@@ -286,7 +286,7 @@ describe('#fetch', () => {
         });
 
       return petstoreSdk.findPets(params).then(res => {
-        expect(res.path).toStrictEqual('/api/pets?tags=somethign%26nothing%3Dtrue&limit=hash%23data');
+        expect(res.path).toStrictEqual('/api/pets?tags=somethign%26nothing%3Dtrue%2620%25&limit=hash%23data');
         mock.done();
       });
     });

--- a/packages/api/package-lock.json
+++ b/packages/api/package-lock.json
@@ -5,12 +5,13 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "api",
       "version": "3.3.2",
       "license": "MIT",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^9.0.1",
         "@apidevtools/swagger-parser": "^10.0.1",
-        "@readme/oas-to-har": "^13.7.0",
+        "@readme/oas-to-har": "^13.7.2",
         "datauri": "^4.1.0",
         "fetch-har": "^5.0.0",
         "find-cache-dir": "^3.3.1",
@@ -1933,9 +1934,9 @@
       }
     },
     "node_modules/@readme/oas-to-har": {
-      "version": "13.7.0",
-      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-13.7.0.tgz",
-      "integrity": "sha512-AtP9dTvJAQNMkMosP9kyn+901fdeYnjWBKQ9zN5Wbz5dZTjmzhKl1nIyKrrwB/lo6tcPAeaU15F8cjphp1L0EQ==",
+      "version": "13.7.2",
+      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-13.7.2.tgz",
+      "integrity": "sha512-7Ho0+d4WSW9OPeP/fjdtgRPij1v6YCdMbKEAC0qh//J3xuv6VtpzoEluIeM8sQKWZGKMmBkXp+pE/0pXHJnERQ==",
       "dependencies": {
         "@readme/oas-extensions": "^13.6.0",
         "oas": "^14.0.0",
@@ -13600,9 +13601,9 @@
       "integrity": "sha512-y7fi0F0mx+DvmEBMq0he+CLbctGRKKeSc/AKicL+Sz6PWoos+kyppKpOLE7ahiJ4RgM+Y3snbkCcmKdsVAdKfQ=="
     },
     "@readme/oas-to-har": {
-      "version": "13.7.0",
-      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-13.7.0.tgz",
-      "integrity": "sha512-AtP9dTvJAQNMkMosP9kyn+901fdeYnjWBKQ9zN5Wbz5dZTjmzhKl1nIyKrrwB/lo6tcPAeaU15F8cjphp1L0EQ==",
+      "version": "13.7.2",
+      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-13.7.2.tgz",
+      "integrity": "sha512-7Ho0+d4WSW9OPeP/fjdtgRPij1v6YCdMbKEAC0qh//J3xuv6VtpzoEluIeM8sQKWZGKMmBkXp+pE/0pXHJnERQ==",
       "requires": {
         "@readme/oas-extensions": "^13.6.0",
         "oas": "^14.0.0",

--- a/packages/api/package-lock.json
+++ b/packages/api/package-lock.json
@@ -5,12 +5,12 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "3.3.1",
+      "version": "3.3.2",
       "license": "MIT",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^9.0.1",
         "@apidevtools/swagger-parser": "^10.0.1",
-        "@readme/oas-to-har": "^13.6.0",
+        "@readme/oas-to-har": "^13.7.0",
         "datauri": "^4.1.0",
         "fetch-har": "^5.0.0",
         "find-cache-dir": "^3.3.1",
@@ -1933,9 +1933,9 @@
       }
     },
     "node_modules/@readme/oas-to-har": {
-      "version": "13.6.1",
-      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-13.6.1.tgz",
-      "integrity": "sha512-af56xwomcTw//LyXSu67sNcYTMwptjEITrbySDHltFrbhRx6gY/1zvniXJJm4nrQ/yam9vqCoH+dIOwpjbbSuQ==",
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-13.7.0.tgz",
+      "integrity": "sha512-AtP9dTvJAQNMkMosP9kyn+901fdeYnjWBKQ9zN5Wbz5dZTjmzhKl1nIyKrrwB/lo6tcPAeaU15F8cjphp1L0EQ==",
       "dependencies": {
         "@readme/oas-extensions": "^13.6.0",
         "oas": "^14.0.0",
@@ -13600,9 +13600,9 @@
       "integrity": "sha512-y7fi0F0mx+DvmEBMq0he+CLbctGRKKeSc/AKicL+Sz6PWoos+kyppKpOLE7ahiJ4RgM+Y3snbkCcmKdsVAdKfQ=="
     },
     "@readme/oas-to-har": {
-      "version": "13.6.1",
-      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-13.6.1.tgz",
-      "integrity": "sha512-af56xwomcTw//LyXSu67sNcYTMwptjEITrbySDHltFrbhRx6gY/1zvniXJJm4nrQ/yam9vqCoH+dIOwpjbbSuQ==",
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-13.7.0.tgz",
+      "integrity": "sha512-AtP9dTvJAQNMkMosP9kyn+901fdeYnjWBKQ9zN5Wbz5dZTjmzhKl1nIyKrrwB/lo6tcPAeaU15F8cjphp1L0EQ==",
       "requires": {
         "@readme/oas-extensions": "^13.6.0",
         "oas": "^14.0.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^9.0.1",
     "@apidevtools/swagger-parser": "^10.0.1",
-    "@readme/oas-to-har": "^13.6.0",
+    "@readme/oas-to-har": "^13.7.0",
     "datauri": "^4.1.0",
     "fetch-har": "^5.0.0",
     "find-cache-dir": "^3.3.1",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^9.0.1",
     "@apidevtools/swagger-parser": "^10.0.1",
-    "@readme/oas-to-har": "^13.7.0",
+    "@readme/oas-to-har": "^13.7.2",
     "datauri": "^4.1.0",
     "fetch-har": "^5.0.0",
     "find-cache-dir": "^3.3.1",


### PR DESCRIPTION
## 🧰 What's being changed?

This upgrades `@readme/oas-to-har` to fix a quirk with query parameter handling where data is not being URL encoded before it's sent off to `fetch-har` to making a request.

See https://github.com/readmeio/oas-to-har/pull/16 for more details on the fix.

## 🧬 Testing

You can see this quirk in action right now against `main` by running the following snippet:

```js
const spec = {
  servers: [
    { url: 'https://httpbin.org' }
  ],
  paths: {
    '/anything': {
      get: {
        parameters: [
          { name: 'pound', in: 'query' },
          { name: 'hash', in: 'query' },
          { name: 'array', in: 'query' },
          { name: 'weird', in: 'query' },
        ],
      },
    },
  },
};

const sdk = require('./packages/api')(spec);

(async () => {
  await sdk.get('/anything', {
    pound: 'somethign&nothing=true',
    hash: 'hash#data',
    array: 'where[4]=10',
    weird: 'properties["$email"] == "testing"',
  }).then(res => {
    console.log(res)
  });
})();
```

```
{
  args: { hash: 'hash', nothing: 'true', pound: 'somethign' },
  data: '',
  files: {},
  form: {},
  headers: {
    Accept: '*/*',
    'Accept-Encoding': 'gzip,deflate',
    Host: 'httpbin.org',
    'User-Agent': 'api (node)/3.3.2',
    'X-Amzn-Trace-Id': 'Root=1-613015bc-09f7a08854acbc2b14eadfbf'
  },
  json: null,
  method: 'GET',
  origin: '<my ip address>',
  url: 'https://httpbin.org/anything?pound=somethign&nothing=true&hash=hash'
}
```

Whereas if you run those parameters through `encodeURIComponent()`, or with this `oas-to-har` update, the resulting payload from https://httpbin.org looks right:

```
{
  args: {
    array: 'where[4]=10',
    hash: 'hash#data',
    pound: 'somethign&nothing=true',
    weird: 'properties["$email"] == "testing"'
  },
  data: '',
  files: {},
  form: {},
  headers: {
    Accept: '*/*',
    'Accept-Encoding': 'gzip,deflate',
    Host: 'httpbin.org',
    'User-Agent': 'api (node)/3.3.2',
    'X-Amzn-Trace-Id': 'Root=1-61301651-2a45f56f00c7c0797ad92f9d'
  },
  json: null,
  method: 'GET',
  origin: '<my ip address>',
  url: 'https://httpbin.org/anything?pound=somethign%26nothing%3Dtrue&hash=hash%23data&array=where[4]%3D10&weird=properties["%24email"] %3D%3D "testing"'
}
```
