### PR TITLE
fix: issues with circular references being dereferenced and unable to…

### DIFF
--- a/packages/api/__tests__/__fixtures__/circular.oas.json
+++ b/packages/api/__tests__/__fixtures__/circular.oas.json
@@ -1,0 +1,62 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "API definition with a circular $ref",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://httpbin.org"
+    }
+  ],
+  "paths": {
+    "/anything": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ErrorMessage": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "statusCode": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "error": {
+            "type": "string",
+            "nullable": true
+          },
+          "inner": {
+            "$ref": "#/components/schemas/ErrorMessage"
+          },
+          "canBeRetried": {
+            "type": "string",
+            "enum": ["Unknown", "Yes", "No"]
+          },
+          "detailedErrorCode": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/api/__tests__/cache.test.js
+++ b/packages/api/__tests__/cache.test.js
@@ -37,6 +37,10 @@ beforeEach(async () => {
   readmeExampleYaml = await realFs.readFile(require.resolve('@readme/oas-examples/3.0/yaml/readme.yaml'), 'utf8');
 
   vol.fromJSON({
+    [`${[examplesDir]}/circular.json`]: await realFs.readFile(
+      require.resolve('./__fixtures__/circular.oas.json'),
+      'utf8'
+    ),
     [`${[examplesDir]}/invalid-openapi.json`]: JSON.stringify(pkg),
     [`${[examplesDir]}/readme.json`]: readmeExampleJson,
     [`${[examplesDir]}/readme.yaml`]: readmeExampleYaml,
@@ -193,6 +197,17 @@ describe('#save()', () => {
 
   it('should cache a new file', async () => {
     const file = path.join(examplesDir, 'readme.json');
+    const cacheStore = new Cache(file);
+
+    expect(cacheStore.isCached()).toBe(false);
+
+    await cacheStore.saveFile();
+
+    expect(cacheStore.isCached()).toBe(true);
+  });
+
+  it('should be able to cache a definition that contains a circular reference', async () => {
+    const file = path.join(examplesDir, 'circular.json');
     const cacheStore = new Cache(file);
 
     expect(cacheStore.isCached()).toBe(false);

--- a/packages/api/__tests__/lib/prepareParams.test.js
+++ b/packages/api/__tests__/lib/prepareParams.test.js
@@ -1,6 +1,5 @@
 const fs = require('fs');
 const Oas = require('oas');
-const $RefParser = require('@apidevtools/json-schema-ref-parser');
 const readmeExample = require('@readme/oas-examples/3.0/json/readme.json');
 const usptoExample = require('@readme/oas-examples/3.0/json/uspto.json');
 const payloadExamples = require('../__fixtures__/payloads.oas.json');
@@ -12,11 +11,11 @@ describe('#prepareParams', () => {
   let usptoSpec;
 
   beforeAll(async () => {
-    let schema = await $RefParser.dereference(readmeExample);
-    readmeSpec = new Oas(schema);
+    readmeSpec = new Oas(readmeExample);
+    await readmeSpec.dereference();
 
-    schema = await $RefParser.dereference(usptoExample);
-    usptoSpec = new Oas(schema);
+    usptoSpec = new Oas(usptoExample);
+    await usptoSpec.dereference();
   });
 
   it('should prepare nothing if nothing was supplied', async () => {

--- a/packages/api/package-lock.json
+++ b/packages/api/package-lock.json
@@ -6,10 +6,9 @@
   "packages": {
     "": {
       "name": "api",
-      "version": "3.4.0",
+      "version": "3.4.1",
       "license": "MIT",
       "dependencies": {
-        "@apidevtools/json-schema-ref-parser": "^9.0.1",
         "@apidevtools/swagger-parser": "^10.0.1",
         "@readme/oas-to-har": "^13.7.2",
         "datauri": "^4.1.0",
@@ -21,7 +20,7 @@
         "make-dir": "^3.1.0",
         "mimer": "^2.0.2",
         "node-fetch": "^2.6.0",
-        "oas": "^14.5.1"
+        "oas": "^14.7.0"
       },
       "devDependencies": {
         "@readme/eslint-config": "^7.2.2",
@@ -9980,9 +9979,9 @@
       "dev": true
     },
     "node_modules/oas": {
-      "version": "14.6.1",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-14.6.1.tgz",
-      "integrity": "sha512-PDO6+i1GOaTyi0SqqvO/OsVMExRE0ftNIr7t00H0drgOvHG0D+nItwC74cttRLZT980Dlg7KktKA/70RfSivMg==",
+      "version": "14.7.0",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-14.7.0.tgz",
+      "integrity": "sha512-2ZmTMPZX36z+tjBYPt6vBcb4QCwaN4TAYoYBShKGGNlvu6ZKYKAJe/yi/lTgZk1a3nB02i/uE1IngM0NBIJQWA==",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^9.0.6",
         "cardinal": "^2.1.1",
@@ -19802,9 +19801,9 @@
       "dev": true
     },
     "oas": {
-      "version": "14.6.1",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-14.6.1.tgz",
-      "integrity": "sha512-PDO6+i1GOaTyi0SqqvO/OsVMExRE0ftNIr7t00H0drgOvHG0D+nItwC74cttRLZT980Dlg7KktKA/70RfSivMg==",
+      "version": "14.7.0",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-14.7.0.tgz",
+      "integrity": "sha512-2ZmTMPZX36z+tjBYPt6vBcb4QCwaN4TAYoYBShKGGNlvu6ZKYKAJe/yi/lTgZk1a3nB02i/uE1IngM0NBIJQWA==",
       "requires": {
         "@apidevtools/json-schema-ref-parser": "^9.0.6",
         "cardinal": "^2.1.1",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -23,7 +23,6 @@
     "node": "^12 || ^14 || ^16"
   },
   "dependencies": {
-    "@apidevtools/json-schema-ref-parser": "^9.0.1",
     "@apidevtools/swagger-parser": "^10.0.1",
     "@readme/oas-to-har": "^13.7.2",
     "datauri": "^4.1.0",
@@ -35,7 +34,7 @@
     "make-dir": "^3.1.0",
     "mimer": "^2.0.2",
     "node-fetch": "^2.6.0",
-    "oas": "^14.5.1"
+    "oas": "^14.7.0"
   },
   "devDependencies": {
     "@readme/eslint-config": "^7.2.2",

--- a/packages/httpsnippet-client-api/package-lock.json
+++ b/packages/httpsnippet-client-api/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "httpsnippet-client-api",
-      "version": "3.4.0",
+      "version": "3.4.1",
       "license": "MIT",
       "dependencies": {
         "content-type": "^1.0.4",


### PR DESCRIPTION
## 🧰 What's being changed?

This resolves a problem in our handling of API definitions with a circular reference where instead of **not** leaving them alone, we were dereferencing them. This was causing us to end up with `[Circular]` JS references that couldn't be stringified into the API definition cache, resulting in a hard crash of `api`.

Fixes #313

## 🧬 Testing

See the test I added to `cache.test.js`.

You can also test this with the definition @josei provided in #313:

```js
const sdk = require('./src')('@codat/v1.1.0#1mld74kq6wk0s1');

sdk
  .ListCompanies()
  .then(res => res.json())
  .then(res => {
    console.log(res);
  })
  .catch(err => {
    console.log(err)
  });
```

You should see a `Response` dump instead of:

```
RangeError: Maximum call stack size exceeded
    at crawl (/Users/erunion/code/readmeio/api/node_modules/@apidevtools/json-schema-ref-parser/lib/resolve-external.js:54:16)
    at crawl (/Users/erunion/code/readmeio/api/node_modules/@apidevtools/json-schema-ref-parser/lib/resolve-external.js:70:38)
    at crawl (/Users/erunion/code/readmeio/api/node_modules/@apidevtools/json-schema-ref-parser/lib/resolve-external.js:70:38)
    at crawl (/Users/erunion/code/readmeio/api/node_modules/@apidevtools/json-schema-ref-parser/lib/resolve-external.js:70:38)
    at crawl (/Users/erunion/code/readmeio/api/node_modules/@apidevtools/json-schema-ref-parser/lib/resolve-external.js:70:38)
    at crawl (/Users/erunion/code/readmeio/api/node_modules/@apidevtools/json-schema-ref-parser/lib/resolve-external.js:70:38)
    at crawl (/Users/erunion/code/readmeio/api/node_modules/@apidevtools/json-schema-ref-parser/lib/resolve-external.js:70:38)
    at crawl (/Users/erunion/code/readmeio/api/node_modules/@apidevtools/json-schema-ref-parser/lib/resolve-external.js:70:38)
    at crawl (/Users/erunion/code/readmeio/api/node_modules/@apidevtools/json-schema-ref-parser/lib/resolve-external.js:70:38)
    at crawl (/Users/erunion/code/readmeio/api/node_modules/@apidevtools/json-schema-ref-parser/lib/resolve-external.js:70:38)
```

**Note:** If running the above code from within `packages/api` you may ned to clear your definition cache between these two manual tests -- you can do this with `rm -rf node_modules/.cache`.