### PR TITLE
feat: upgrading oas to v17

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2519,21 +2519,24 @@
       "dev": true
     },
     "node_modules/@readme/oas-extensions": {
-      "version": "13.7.0",
-      "resolved": "https://registry.npmjs.org/@readme/oas-extensions/-/oas-extensions-13.7.0.tgz",
-      "integrity": "sha512-z+zSUfsz93puBOy4rITQSnwH3OBpv/6uJCntzAL1zY2hVKTSmN94Yj+wB3uqOez6YemLQTze0ujJbYpNPUnKcQ==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/oas-extensions/-/oas-extensions-14.0.0.tgz",
+      "integrity": "sha512-7CC5rcATBH0M2ZhHfX9RoHC8kSOcnKjvHXDb9gswUlLNQcLyRzg8ycQhSIJQna+6BSuHMZ79Den+Xw0z+P6Lpg==",
       "engines": {
         "node": "^12 || ^14 || ^16",
         "npm": "^7"
+      },
+      "peerDependencies": {
+        "oas": "^17.1.0"
       }
     },
     "node_modules/@readme/oas-to-har": {
-      "version": "13.8.1",
-      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-13.8.1.tgz",
-      "integrity": "sha512-Pthaw2PCGY8lLq9t3vy6C/pmlhPrNgrq6A5a/Xem6VIkRfVjCExlON+leRIYI2iElwBCQ0dhOqqsOofG/Ru6LA==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-14.0.0.tgz",
+      "integrity": "sha512-gWhMupVrmCcFb/yQ/cQuUuy3JLSxUl9Npq2bJAFz3sXDja3hPuwaBSBDscRecPtnfvzRfo6Og0osag5RXxnCDw==",
       "dependencies": {
-        "@readme/oas-extensions": "^13.7.0",
-        "oas": "^16.0.3",
+        "@readme/oas-extensions": "^14.0.0",
+        "oas": "^17.1.0",
         "parse-data-url": "^4.0.1"
       },
       "engines": {
@@ -11165,9 +11168,9 @@
       "dev": true
     },
     "node_modules/oas": {
-      "version": "16.0.4",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-16.0.4.tgz",
-      "integrity": "sha512-gYXdotuR33sCJ1QhO13eiIJ6uYes3TrSkRSmctHQxLrToTfcYXVDv9RN7IFaHJiepMJfi73HD96ru7NeYTYbPQ==",
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-17.1.0.tgz",
+      "integrity": "sha512-iaikb9s+xUi9AYqhak9nxX6H4lWUBEZ9FNQVzNb/N/lnD3Ue4dVYZ0ykMbdA+Rk0CK747RUJR4GH3j0HGJNIQQ==",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^9.0.6",
         "cardinal": "^2.1.1",
@@ -11176,7 +11179,7 @@
         "inquirer": "^8.1.2",
         "json-schema-merge-allof": "^0.8.1",
         "json2yaml": "^1.1.0",
-        "jsonpointer": "^4.1.0",
+        "jsonpointer": "^5.0.0",
         "memoizee": "^0.4.14",
         "minimist": "^1.2.0",
         "oas-normalize": "^5.0.1",
@@ -11364,6 +11367,14 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/oas/node_modules/jsonpointer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.0.tgz",
+      "integrity": "sha512-PNYZIdMjVIvVgDSYKTT63Y+KZ6IZvGRNNWcxwD+GNnUz1MKPfv30J8ueCjdwcN0nDx2SlshgyB7Oy0epAzVRRg==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/oas/node_modules/supports-color": {
@@ -13606,7 +13617,7 @@
       "version": "4.0.0",
       "license": "MIT",
       "dependencies": {
-        "@readme/oas-to-har": "^13.8.1",
+        "@readme/oas-to-har": "^14.0.0",
         "@readme/openapi-parser": "^1.1.0",
         "datauri": "^4.1.0",
         "fetch-har": "^5.0.0",
@@ -13617,7 +13628,7 @@
         "make-dir": "^3.1.0",
         "mimer": "^2.0.2",
         "node-fetch": "^2.6.0",
-        "oas": "^16.0.3"
+        "oas": "^17.1.0"
       },
       "devDependencies": {
         "@readme/eslint-config": "^7.2.2",
@@ -13668,7 +13679,7 @@
       },
       "peerDependencies": {
         "@readme/httpsnippet": "^3.0.0",
-        "oas": "^16.0.3"
+        "oas": "^17.1.0"
       }
     }
   },
@@ -15581,17 +15592,18 @@
       "dev": true
     },
     "@readme/oas-extensions": {
-      "version": "13.7.0",
-      "resolved": "https://registry.npmjs.org/@readme/oas-extensions/-/oas-extensions-13.7.0.tgz",
-      "integrity": "sha512-z+zSUfsz93puBOy4rITQSnwH3OBpv/6uJCntzAL1zY2hVKTSmN94Yj+wB3uqOez6YemLQTze0ujJbYpNPUnKcQ=="
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/oas-extensions/-/oas-extensions-14.0.0.tgz",
+      "integrity": "sha512-7CC5rcATBH0M2ZhHfX9RoHC8kSOcnKjvHXDb9gswUlLNQcLyRzg8ycQhSIJQna+6BSuHMZ79Den+Xw0z+P6Lpg==",
+      "requires": {}
     },
     "@readme/oas-to-har": {
-      "version": "13.8.1",
-      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-13.8.1.tgz",
-      "integrity": "sha512-Pthaw2PCGY8lLq9t3vy6C/pmlhPrNgrq6A5a/Xem6VIkRfVjCExlON+leRIYI2iElwBCQ0dhOqqsOofG/Ru6LA==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-14.0.0.tgz",
+      "integrity": "sha512-gWhMupVrmCcFb/yQ/cQuUuy3JLSxUl9Npq2bJAFz3sXDja3hPuwaBSBDscRecPtnfvzRfo6Og0osag5RXxnCDw==",
       "requires": {
-        "@readme/oas-extensions": "^13.7.0",
-        "oas": "^16.0.3",
+        "@readme/oas-extensions": "^14.0.0",
+        "oas": "^17.1.0",
         "parse-data-url": "^4.0.1"
       }
     },
@@ -16091,7 +16103,7 @@
       "requires": {
         "@readme/eslint-config": "^7.2.2",
         "@readme/oas-examples": "^4.3.2",
-        "@readme/oas-to-har": "^13.8.1",
+        "@readme/oas-to-har": "^14.0.0",
         "@readme/openapi-parser": "^1.1.0",
         "datauri": "^4.1.0",
         "eslint": "^7.32.0",
@@ -16106,7 +16118,7 @@
         "mimer": "^2.0.2",
         "nock": "^13.1.3",
         "node-fetch": "^2.6.0",
-        "oas": "^16.0.3",
+        "oas": "^17.1.0",
         "prettier": "^2.4.1"
       },
       "dependencies": {
@@ -22177,9 +22189,9 @@
       "dev": true
     },
     "oas": {
-      "version": "16.0.4",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-16.0.4.tgz",
-      "integrity": "sha512-gYXdotuR33sCJ1QhO13eiIJ6uYes3TrSkRSmctHQxLrToTfcYXVDv9RN7IFaHJiepMJfi73HD96ru7NeYTYbPQ==",
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-17.1.0.tgz",
+      "integrity": "sha512-iaikb9s+xUi9AYqhak9nxX6H4lWUBEZ9FNQVzNb/N/lnD3Ue4dVYZ0ykMbdA+Rk0CK747RUJR4GH3j0HGJNIQQ==",
       "requires": {
         "@apidevtools/json-schema-ref-parser": "^9.0.6",
         "cardinal": "^2.1.1",
@@ -22188,7 +22200,7 @@
         "inquirer": "^8.1.2",
         "json-schema-merge-allof": "^0.8.1",
         "json2yaml": "^1.1.0",
-        "jsonpointer": "^4.1.0",
+        "jsonpointer": "^5.0.0",
         "memoizee": "^0.4.14",
         "minimist": "^1.2.0",
         "oas-normalize": "^5.0.1",
@@ -22255,6 +22267,11 @@
           "requires": {
             "argparse": "^2.0.1"
           }
+        },
+        "jsonpointer": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.0.tgz",
+          "integrity": "sha512-PNYZIdMjVIvVgDSYKTT63Y+KZ6IZvGRNNWcxwD+GNnUz1MKPfv30J8ueCjdwcN0nDx2SlshgyB7Oy0epAzVRRg=="
         },
         "supports-color": {
           "version": "7.2.0",

--- a/packages/api/__tests__/lib/prepareParams.test.js
+++ b/packages/api/__tests__/lib/prepareParams.test.js
@@ -1,5 +1,5 @@
 const fs = require('fs');
-const Oas = require('oas');
+const Oas = require('oas').default;
 const readmeExample = require('@readme/oas-examples/3.0/json/readme.json');
 const usptoExample = require('@readme/oas-examples/3.0/json/uspto.json');
 const payloadExamples = require('../__fixtures__/payloads.oas.json');

--- a/packages/api/package-lock.json
+++ b/packages/api/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.0.0",
       "license": "MIT",
       "dependencies": {
-        "@readme/oas-to-har": "^13.8.1",
+        "@readme/oas-to-har": "^14.0.0",
         "@readme/openapi-parser": "^1.1.0",
         "datauri": "^4.1.0",
         "fetch-har": "^5.0.0",
@@ -20,7 +20,7 @@
         "make-dir": "^3.1.0",
         "mimer": "^2.0.2",
         "node-fetch": "^2.6.0",
-        "oas": "^16.0.3"
+        "oas": "^17.1.0"
       },
       "devDependencies": {
         "@readme/eslint-config": "^7.2.2",
@@ -1997,21 +1997,24 @@
       "dev": true
     },
     "node_modules/@readme/oas-extensions": {
-      "version": "13.7.0",
-      "resolved": "https://registry.npmjs.org/@readme/oas-extensions/-/oas-extensions-13.7.0.tgz",
-      "integrity": "sha512-z+zSUfsz93puBOy4rITQSnwH3OBpv/6uJCntzAL1zY2hVKTSmN94Yj+wB3uqOez6YemLQTze0ujJbYpNPUnKcQ==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/oas-extensions/-/oas-extensions-14.0.0.tgz",
+      "integrity": "sha512-7CC5rcATBH0M2ZhHfX9RoHC8kSOcnKjvHXDb9gswUlLNQcLyRzg8ycQhSIJQna+6BSuHMZ79Den+Xw0z+P6Lpg==",
       "engines": {
         "node": "^12 || ^14 || ^16",
         "npm": "^7"
+      },
+      "peerDependencies": {
+        "oas": "^17.1.0"
       }
     },
     "node_modules/@readme/oas-to-har": {
-      "version": "13.8.1",
-      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-13.8.1.tgz",
-      "integrity": "sha512-Pthaw2PCGY8lLq9t3vy6C/pmlhPrNgrq6A5a/Xem6VIkRfVjCExlON+leRIYI2iElwBCQ0dhOqqsOofG/Ru6LA==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-14.0.0.tgz",
+      "integrity": "sha512-gWhMupVrmCcFb/yQ/cQuUuy3JLSxUl9Npq2bJAFz3sXDja3hPuwaBSBDscRecPtnfvzRfo6Og0osag5RXxnCDw==",
       "dependencies": {
-        "@readme/oas-extensions": "^13.7.0",
-        "oas": "^16.0.3",
+        "@readme/oas-extensions": "^14.0.0",
+        "oas": "^17.1.0",
         "parse-data-url": "^4.0.1"
       },
       "engines": {
@@ -3438,6 +3441,14 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/comment-patterns": {
@@ -10152,9 +10163,9 @@
       "dev": true
     },
     "node_modules/oas": {
-      "version": "16.0.4",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-16.0.4.tgz",
-      "integrity": "sha512-gYXdotuR33sCJ1QhO13eiIJ6uYes3TrSkRSmctHQxLrToTfcYXVDv9RN7IFaHJiepMJfi73HD96ru7NeYTYbPQ==",
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-17.1.0.tgz",
+      "integrity": "sha512-iaikb9s+xUi9AYqhak9nxX6H4lWUBEZ9FNQVzNb/N/lnD3Ue4dVYZ0ykMbdA+Rk0CK747RUJR4GH3j0HGJNIQQ==",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^9.0.6",
         "cardinal": "^2.1.1",
@@ -10163,7 +10174,7 @@
         "inquirer": "^8.1.2",
         "json-schema-merge-allof": "^0.8.1",
         "json2yaml": "^1.1.0",
-        "jsonpointer": "^4.1.0",
+        "jsonpointer": "^5.0.0",
         "memoizee": "^0.4.14",
         "minimist": "^1.2.0",
         "oas-normalize": "^5.0.1",
@@ -10325,6 +10336,14 @@
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/oas/node_modules/jsonpointer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.0.tgz",
+      "integrity": "sha512-PNYZIdMjVIvVgDSYKTT63Y+KZ6IZvGRNNWcxwD+GNnUz1MKPfv30J8ueCjdwcN0nDx2SlshgyB7Oy0epAzVRRg==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/oas/node_modules/supports-color": {
@@ -11622,14 +11641,6 @@
       },
       "engines": {
         "node": "^12 || ^14 || ^16"
-      }
-    },
-    "node_modules/swagger-inline/node_modules/commander": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
-      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/swagger2openapi": {
@@ -13874,17 +13885,18 @@
       "dev": true
     },
     "@readme/oas-extensions": {
-      "version": "13.7.0",
-      "resolved": "https://registry.npmjs.org/@readme/oas-extensions/-/oas-extensions-13.7.0.tgz",
-      "integrity": "sha512-z+zSUfsz93puBOy4rITQSnwH3OBpv/6uJCntzAL1zY2hVKTSmN94Yj+wB3uqOez6YemLQTze0ujJbYpNPUnKcQ=="
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/oas-extensions/-/oas-extensions-14.0.0.tgz",
+      "integrity": "sha512-7CC5rcATBH0M2ZhHfX9RoHC8kSOcnKjvHXDb9gswUlLNQcLyRzg8ycQhSIJQna+6BSuHMZ79Den+Xw0z+P6Lpg==",
+      "requires": {}
     },
     "@readme/oas-to-har": {
-      "version": "13.8.1",
-      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-13.8.1.tgz",
-      "integrity": "sha512-Pthaw2PCGY8lLq9t3vy6C/pmlhPrNgrq6A5a/Xem6VIkRfVjCExlON+leRIYI2iElwBCQ0dhOqqsOofG/Ru6LA==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-14.0.0.tgz",
+      "integrity": "sha512-gWhMupVrmCcFb/yQ/cQuUuy3JLSxUl9Npq2bJAFz3sXDja3hPuwaBSBDscRecPtnfvzRfo6Og0osag5RXxnCDw==",
       "requires": {
-        "@readme/oas-extensions": "^13.7.0",
-        "oas": "^16.0.3",
+        "@readme/oas-extensions": "^14.0.0",
+        "oas": "^17.1.0",
         "parse-data-url": "^4.0.1"
       }
     },
@@ -14958,6 +14970,11 @@
       "requires": {
         "delayed-stream": "~1.0.0"
       }
+    },
+    "commander": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA=="
     },
     "comment-patterns": {
       "version": "0.12.0",
@@ -20119,9 +20136,9 @@
       "dev": true
     },
     "oas": {
-      "version": "16.0.4",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-16.0.4.tgz",
-      "integrity": "sha512-gYXdotuR33sCJ1QhO13eiIJ6uYes3TrSkRSmctHQxLrToTfcYXVDv9RN7IFaHJiepMJfi73HD96ru7NeYTYbPQ==",
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-17.1.0.tgz",
+      "integrity": "sha512-iaikb9s+xUi9AYqhak9nxX6H4lWUBEZ9FNQVzNb/N/lnD3Ue4dVYZ0ykMbdA+Rk0CK747RUJR4GH3j0HGJNIQQ==",
       "requires": {
         "@apidevtools/json-schema-ref-parser": "^9.0.6",
         "cardinal": "^2.1.1",
@@ -20130,7 +20147,7 @@
         "inquirer": "^8.1.2",
         "json-schema-merge-allof": "^0.8.1",
         "json2yaml": "^1.1.0",
-        "jsonpointer": "^4.1.0",
+        "jsonpointer": "^5.0.0",
         "memoizee": "^0.4.14",
         "minimist": "^1.2.0",
         "oas-normalize": "^5.0.1",
@@ -20173,6 +20190,11 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "jsonpointer": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.0.tgz",
+          "integrity": "sha512-PNYZIdMjVIvVgDSYKTT63Y+KZ6IZvGRNNWcxwD+GNnUz1MKPfv30J8ueCjdwcN0nDx2SlshgyB7Oy0epAzVRRg=="
         },
         "supports-color": {
           "version": "7.2.0",
@@ -21259,13 +21281,6 @@
         "js-yaml": "^4.1.0",
         "multilang-extract-comments": "^0.4.0",
         "promise.any": "^2.0.2"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
-          "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA=="
-        }
       }
     },
     "swagger2openapi": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -23,7 +23,7 @@
     "node": "^12 || ^14 || ^16"
   },
   "dependencies": {
-    "@readme/oas-to-har": "^13.8.1",
+    "@readme/oas-to-har": "^14.0.0",
     "@readme/openapi-parser": "^1.1.0",
     "datauri": "^4.1.0",
     "fetch-har": "^5.0.0",
@@ -34,7 +34,7 @@
     "make-dir": "^3.1.0",
     "mimer": "^2.0.2",
     "node-fetch": "^2.6.0",
-    "oas": "^16.0.3"
+    "oas": "^17.1.0"
   },
   "devDependencies": {
     "@readme/eslint-config": "^7.2.2",

--- a/packages/api/src/index.js
+++ b/packages/api/src/index.js
@@ -1,11 +1,11 @@
 const fetch = require('node-fetch');
 const fetchHar = require('fetch-har');
-const Oas = require('oas');
+const Oas = require('oas').default;
 const oasToHar = require('@readme/oas-to-har');
 const pkg = require('../package.json');
 
 const Cache = require('./cache');
-const { parseResponse, prepareAuth, prepareParams, prepareServer } = require('./lib/index');
+const { parseResponse, prepareAuth, prepareParams, prepareServer } = require('./lib');
 
 global.fetch = fetch;
 global.Request = fetch.Request;
@@ -19,9 +19,9 @@ class Sdk {
   }
 
   static getOperations(spec) {
-    return Object.keys(spec.paths)
+    return Object.keys(spec.api.paths)
       .map(path => {
-        return Object.keys(spec.paths[path]).map(method => {
+        return Object.keys(spec.api.paths[path]).map(method => {
           return spec.operation(path, method);
         });
       })

--- a/packages/api/src/lib/prepareParams.js
+++ b/packages/api/src/lib/prepareParams.js
@@ -89,7 +89,7 @@ module.exports = async (operation, body, metadata) => {
   // body payload to see if anything in there is either a file path or a file stream so we can translate those into a
   // data URL for `@readme/oas-to-har` to make a request.
   if ('body' in params && operation.isMultipart()) {
-    let requestBody = getSchema(operation.schema, operation.oas);
+    let requestBody = getSchema(operation.schema, operation.api);
     if (requestBody) {
       requestBody = requestBody.schema;
     } else {

--- a/packages/api/src/lib/prepareServer.js
+++ b/packages/api/src/lib/prepareServer.js
@@ -18,7 +18,7 @@ function stripTrailingSlash(url) {
 module.exports = (spec, url, variables = {}) => {
   let serverIdx;
   const sanitizedUrl = stripTrailingSlash(url);
-  (spec.servers || []).forEach((server, i) => {
+  (spec.api.servers || []).forEach((server, i) => {
     if (server.url === sanitizedUrl) {
       serverIdx = i;
     }

--- a/packages/httpsnippet-client-api/package-lock.json
+++ b/packages/httpsnippet-client-api/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "httpsnippet-client-api",
-      "version": "3.4.2",
+      "version": "4.0.0",
       "license": "MIT",
       "dependencies": {
         "content-type": "^1.0.4",
@@ -25,7 +25,7 @@
       },
       "peerDependencies": {
         "@readme/httpsnippet": "^3.0.0",
-        "oas": "^16.0.3"
+        "oas": "^17.1.0"
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {
@@ -10349,9 +10349,9 @@
       "dev": true
     },
     "node_modules/oas": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-16.0.3.tgz",
-      "integrity": "sha512-H+iPKY9UR8wO0N1Q+PoFh4mf3q+GgWMsLk+BX7wk6/9cfq7sccxoFjzhfW95fQRSCZTpvx60uY3gDBPIgRR3lQ==",
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-17.1.0.tgz",
+      "integrity": "sha512-iaikb9s+xUi9AYqhak9nxX6H4lWUBEZ9FNQVzNb/N/lnD3Ue4dVYZ0ykMbdA+Rk0CK747RUJR4GH3j0HGJNIQQ==",
       "peer": true,
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^9.0.6",
@@ -10361,7 +10361,7 @@
         "inquirer": "^8.1.2",
         "json-schema-merge-allof": "^0.8.1",
         "json2yaml": "^1.1.0",
-        "jsonpointer": "^4.1.0",
+        "jsonpointer": "^5.0.0",
         "memoizee": "^0.4.14",
         "minimist": "^1.2.0",
         "oas-normalize": "^5.0.1",
@@ -10553,6 +10553,15 @@
       "peer": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/oas/node_modules/jsonpointer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.0.tgz",
+      "integrity": "sha512-PNYZIdMjVIvVgDSYKTT63Y+KZ6IZvGRNNWcxwD+GNnUz1MKPfv30J8ueCjdwcN0nDx2SlshgyB7Oy0epAzVRRg==",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/oas/node_modules/supports-color": {
@@ -20562,9 +20571,9 @@
       "dev": true
     },
     "oas": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-16.0.3.tgz",
-      "integrity": "sha512-H+iPKY9UR8wO0N1Q+PoFh4mf3q+GgWMsLk+BX7wk6/9cfq7sccxoFjzhfW95fQRSCZTpvx60uY3gDBPIgRR3lQ==",
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-17.1.0.tgz",
+      "integrity": "sha512-iaikb9s+xUi9AYqhak9nxX6H4lWUBEZ9FNQVzNb/N/lnD3Ue4dVYZ0ykMbdA+Rk0CK747RUJR4GH3j0HGJNIQQ==",
       "peer": true,
       "requires": {
         "@apidevtools/json-schema-ref-parser": "^9.0.6",
@@ -20574,7 +20583,7 @@
         "inquirer": "^8.1.2",
         "json-schema-merge-allof": "^0.8.1",
         "json2yaml": "^1.1.0",
-        "jsonpointer": "^4.1.0",
+        "jsonpointer": "^5.0.0",
         "memoizee": "^0.4.14",
         "minimist": "^1.2.0",
         "oas-normalize": "^5.0.1",
@@ -20621,6 +20630,12 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "peer": true
+        },
+        "jsonpointer": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.0.tgz",
+          "integrity": "sha512-PNYZIdMjVIvVgDSYKTT63Y+KZ6IZvGRNNWcxwD+GNnUz1MKPfv30J8ueCjdwcN0nDx2SlshgyB7Oy0epAzVRRg==",
           "peer": true
         },
         "supports-color": {

--- a/packages/httpsnippet-client-api/package.json
+++ b/packages/httpsnippet-client-api/package.json
@@ -29,7 +29,7 @@
   },
   "peerDependencies": {
     "@readme/httpsnippet": "^3.0.0",
-    "oas": "^16.0.3"
+    "oas": "^17.1.0"
   },
   "devDependencies": {
     "@readme/eslint-config": "^7.2.2",

--- a/packages/httpsnippet-client-api/src/index.js
+++ b/packages/httpsnippet-client-api/src/index.js
@@ -2,7 +2,7 @@ const { match } = require('path-to-regexp');
 const stringifyObject = require('stringify-object');
 const CodeBuilder = require('@readme/httpsnippet/src/helpers/code-builder');
 const contentType = require('content-type');
-const Oas = require('oas');
+const Oas = require('oas').default;
 
 function stringify(obj, opts = {}) {
   return stringifyObject(obj, { indent: '  ', ...opts });
@@ -90,6 +90,7 @@ module.exports = function (source, options) {
 
   const method = source.method.toLowerCase();
   const oas = new Oas(opts.apiDefinition);
+  const apiDefinition = oas.getDefinition();
   const foundOperation = oas.findOperation(source.url, method);
   if (!foundOperation) {
     throw new Error(
@@ -112,7 +113,7 @@ module.exports = function (source, options) {
   // `oas` library then the URL either has server variables contained in it (that don't match the defaults), or the
   // OAS offers alternate server URLs and we should expose that in the generated snippet.
   const configData = [];
-  if ((oas.servers || []).length > 1) {
+  if ((apiDefinition.servers || []).length > 1) {
     const stockUrl = oas.url();
     const baseUrl = source.url.replace(path, '');
     if (baseUrl !== stockUrl) {


### PR DESCRIPTION
## 🧰 What's being changed?

* [x] `oas` → v17
  * ~95% rewrite in Typescript
  * A change in how core API definitions are stored on the main `Oas` class instance
  * Heaps of new helpers methods and accessors
* [x] `@readme/oas-to-har` → v14
  * Compatibility with `oas` v17.