### PR TITLE
fix: crash where multipart/form-data requests dont have params

### DIFF
--- a/packages/httpsnippet-client-api/__tests__/__fixtures__/output/multipart-form-data-no-params.js
+++ b/packages/httpsnippet-client-api/__tests__/__fixtures__/output/multipart-form-data-no-params.js
@@ -1,0 +1,5 @@
+const sdk = require('api')('https://example.com/openapi.json');
+
+sdk.post('/har')
+  .then(res => console.log(res))
+  .catch(err => console.error(err));

--- a/packages/httpsnippet-client-api/__tests__/__fixtures__/request/multipart-form-data-no-params/definition.json
+++ b/packages/httpsnippet-client-api/__tests__/__fixtures__/request/multipart-form-data-no-params/definition.json
@@ -1,0 +1,38 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "version": "1.0",
+    "title": "multipart-form-data"
+  },
+  "servers": [
+    {
+      "url": "http://mockbin.com"
+    }
+  ],
+  "paths": {
+    "/har": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "foo": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "default": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/httpsnippet-client-api/__tests__/__fixtures__/request/multipart-form-data-no-params/har.json
+++ b/packages/httpsnippet-client-api/__tests__/__fixtures__/request/multipart-form-data-no-params/har.json
@@ -1,0 +1,21 @@
+{
+  "log": {
+    "entries": [
+      {
+        "request": {
+          "method": "POST",
+          "url": "http://mockbin.com/har",
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "multipart/form-data"
+            }
+          ],
+          "postData": {
+            "mimeType": "multipart/form-data"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/packages/httpsnippet-client-api/__tests__/index.test.js
+++ b/packages/httpsnippet-client-api/__tests__/index.test.js
@@ -122,6 +122,7 @@ describe('snippets', () => {
     ['multipart-data'],
     ['multipart-file'],
     ['multipart-form-data'],
+    ['multipart-form-data-no-params'],
     ['petstore'],
     ['query'],
     ['query-auth'],

--- a/packages/httpsnippet-client-api/src/index.js
+++ b/packages/httpsnippet-client-api/src/index.js
@@ -213,22 +213,24 @@ module.exports = function (source, options) {
       break;
 
     case 'multipart/form-data':
-      body = {};
+      if (source.postData.params) {
+        body = {};
 
-      // If there's a `Content-Type` header present in the metadata, but it's for the form-data
-      // request then dump it off the snippet. We shouldn't offload that unnecessary bloat to the
-      // user, instead letting the SDK handle it automatically.
-      if ('content-type' in metadata && metadata['content-type'].indexOf('multipart/form-data') === 0) {
-        delete metadata['content-type'];
-      }
-
-      source.postData.params.forEach(function (param) {
-        if (param.fileName) {
-          body[param.name] = param.fileName;
-        } else {
-          body[param.name] = param.value;
+        // If there's a `Content-Type` header present in the metadata, but it's for the form-data
+        // request then dump it off the snippet. We shouldn't offload that unnecessary bloat to the
+        // user, instead letting the SDK handle it automatically.
+        if ('content-type' in metadata && metadata['content-type'].indexOf('multipart/form-data') === 0) {
+          delete metadata['content-type'];
         }
-      });
+
+        source.postData.params.forEach(function (param) {
+          if (param.fileName) {
+            body[param.name] = param.fileName;
+          } else {
+            body[param.name] = param.value;
+          }
+        });
+      }
       break;
 
     default:


### PR DESCRIPTION
## 🧰 What's being changed?

Much like https://github.com/readmeio/httpsnippet/pull/65 this also fixes this case where a `multipart/form-data` HAR might not have `postData.params` present.