### PR TITLE
feat: dropping support for node 12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [14.x, 16.x]
 
     steps:
       - uses: actions/checkout@v2.4.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "husky": "^7.0.4"
       },
       "engines": {
-        "node": "^12 || ^14 || ^16"
+        "node": "^14 || ^16"
       }
     },
     "node_modules/@apidevtools/openapi-schemas": {
@@ -11212,7 +11212,7 @@
         "prettier": "^2.5.1"
       },
       "engines": {
-        "node": "^12 || ^14 || ^16"
+        "node": "^14 || ^16"
       }
     },
     "packages/api/node_modules/@eslint/eslintrc": {
@@ -11817,7 +11817,7 @@
         "prettier": "^2.5.1"
       },
       "engines": {
-        "node": "^12 || ^14 || ^16"
+        "node": "^14 || ^16"
       },
       "peerDependencies": {
         "@readme/httpsnippet": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/readmeio/api.git"
   },
   "engines": {
-    "node": "^12 || ^14 || ^16"
+    "node": "^14 || ^16"
   },
   "workspaces": [
     "./packages/*"

--- a/packages/api/package-lock.json
+++ b/packages/api/package-lock.json
@@ -32,7 +32,7 @@
         "prettier": "^2.5.1"
       },
       "engines": {
-        "node": "^12 || ^14 || ^16"
+        "node": "^14 || ^16"
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -20,7 +20,7 @@
   "author": "Jon Ursenbach <jon@readme.io>",
   "license": "MIT",
   "engines": {
-    "node": "^12 || ^14 || ^16"
+    "node": "^14 || ^16"
   },
   "dependencies": {
     "@readme/oas-to-har": "^14.0.5",

--- a/packages/httpsnippet-client-api/package-lock.json
+++ b/packages/httpsnippet-client-api/package-lock.json
@@ -21,7 +21,7 @@
         "prettier": "^2.5.1"
       },
       "engines": {
-        "node": "^12 || ^14 || ^16"
+        "node": "^14 || ^16"
       },
       "peerDependencies": {
         "@readme/httpsnippet": "^3.0.0",

--- a/packages/httpsnippet-client-api/package.json
+++ b/packages/httpsnippet-client-api/package.json
@@ -20,7 +20,7 @@
   "author": "Jon Ursenbach <jon@readme.io>",
   "license": "MIT",
   "engines": {
-    "node": "^12 || ^14 || ^16"
+    "node": "^14 || ^16"
   },
   "dependencies": {
     "content-type": "^1.0.4",


### PR DESCRIPTION
## 🧰 Changes

Node 12 hits EOL status in April and we plan on immediately taking advantage of optional chaining, which Node 12 doesn't support, within #380 so we're dropping support for Node 12 now.

## 🧬 QA & Testing

No testing needed, tests are just no longer being run on Node 12.