### PR TITLE
feat: changing the readme api url from .io to .com

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1969,9 +1969,9 @@
       }
     },
     "node_modules/@readme/oas-examples": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@readme/oas-examples/-/oas-examples-4.3.3.tgz",
-      "integrity": "sha512-7f28RJplXQQ5UpUj+mVgia6sONDOzEc8gl68V7xantz88Q4YTR34Y0AVUwMyOwx/poNL+PaEoY4SNylw7FTeJw==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@readme/oas-examples/-/oas-examples-4.4.0.tgz",
+      "integrity": "sha512-sZD5ZiRQGsR+h/LUnUGYm4NgfcA0cpv2+wDEiAuAxbk8rXxO2cvRPOeM9g+x93E2L1/t34Z8yCRFf0fnlI92ag==",
       "dev": true
     },
     "node_modules/@readme/oas-extensions": {
@@ -11204,7 +11204,7 @@
       },
       "devDependencies": {
         "@readme/eslint-config": "^8.1.2",
-        "@readme/oas-examples": "^4.3.3",
+        "@readme/oas-examples": "^4.4.0",
         "eslint": "^8.7.0",
         "jest": "^27.4.7",
         "memfs": "^3.4.1",
@@ -11811,7 +11811,7 @@
       },
       "devDependencies": {
         "@readme/eslint-config": "^8.1.2",
-        "@readme/oas-examples": "^4.3.3",
+        "@readme/oas-examples": "^4.4.0",
         "eslint": "^8.7.0",
         "jest": "^27.4.7",
         "prettier": "^2.5.1"
@@ -13889,9 +13889,9 @@
       }
     },
     "@readme/oas-examples": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@readme/oas-examples/-/oas-examples-4.3.3.tgz",
-      "integrity": "sha512-7f28RJplXQQ5UpUj+mVgia6sONDOzEc8gl68V7xantz88Q4YTR34Y0AVUwMyOwx/poNL+PaEoY4SNylw7FTeJw==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@readme/oas-examples/-/oas-examples-4.4.0.tgz",
+      "integrity": "sha512-sZD5ZiRQGsR+h/LUnUGYm4NgfcA0cpv2+wDEiAuAxbk8rXxO2cvRPOeM9g+x93E2L1/t34Z8yCRFf0fnlI92ag==",
       "dev": true
     },
     "@readme/oas-extensions": {
@@ -14314,7 +14314,7 @@
       "version": "file:packages/api",
       "requires": {
         "@readme/eslint-config": "^8.1.2",
-        "@readme/oas-examples": "^4.3.3",
+        "@readme/oas-examples": "^4.4.0",
         "@readme/oas-to-har": "^14.0.5",
         "@readme/openapi-parser": "^2.0.0",
         "datauri": "^4.1.0",
@@ -16954,7 +16954,7 @@
       "version": "file:packages/httpsnippet-client-api",
       "requires": {
         "@readme/eslint-config": "^8.1.2",
-        "@readme/oas-examples": "^4.3.3",
+        "@readme/oas-examples": "^4.4.0",
         "content-type": "^1.0.4",
         "eslint": "^8.7.0",
         "jest": "^27.4.7",

--- a/packages/api/__tests__/cache.test.js
+++ b/packages/api/__tests__/cache.test.js
@@ -72,13 +72,13 @@ describe('#load', () => {
   describe('shorthand accessors', () => {
     it('should resolve the shorthand `@petstore/v1.0#uuid` syntax to the ReadMe API', () => {
       return expect(new Cache('@petstore/v1.0#n6kvf10vakpemvplx').uri).toBe(
-        'https://dash.readme.io/api/v1/api-registry/n6kvf10vakpemvplx'
+        'https://dash.readme.com/api/v1/api-registry/n6kvf10vakpemvplx'
       );
     });
 
     it('should resolve the shorthand `@petstore#uuid` syntax to the ReadMe API', () => {
       return expect(new Cache('@petstore#n6kvf10vakpemvplx').uri).toBe(
-        'https://dash.readme.io/api/v1/api-registry/n6kvf10vakpemvplx'
+        'https://dash.readme.com/api/v1/api-registry/n6kvf10vakpemvplx'
       );
     });
 

--- a/packages/api/__tests__/index.test.js
+++ b/packages/api/__tests__/index.test.js
@@ -217,7 +217,7 @@ describe('#fetch', () => {
         body: 'updated body',
       };
 
-      const mock = nock('https://dash.readme.io/api/v1').put(`/changelogs/${slug}`, body).reply(200);
+      const mock = nock('https://dash.readme.com/api/v1').put(`/changelogs/${slug}`, body).reply(200);
 
       return readmeSdk.updateChangelog(body, { slug }).then(() => mock.done());
     });
@@ -244,7 +244,7 @@ describe('#fetch', () => {
 
     it('should pass through parameters for method + path', () => {
       const slug = 'new-release';
-      const mock = nock('https://dash.readme.io/api/v1').put(`/changelogs/${slug}`).reply(200);
+      const mock = nock('https://dash.readme.com/api/v1').put(`/changelogs/${slug}`).reply(200);
       return readmeSdk.put('/changelogs/{slug}', { slug }).then(() => mock.done());
     });
 
@@ -255,7 +255,7 @@ describe('#fetch', () => {
         body: 'updated body',
       };
 
-      const mock = nock('https://dash.readme.io/api/v1')
+      const mock = nock('https://dash.readme.com/api/v1')
         .put(`/changelogs/${slug}`, body)
         .reply(200, (uri, requestBody) => {
           return {

--- a/packages/api/package-lock.json
+++ b/packages/api/package-lock.json
@@ -24,7 +24,7 @@
       },
       "devDependencies": {
         "@readme/eslint-config": "^8.1.2",
-        "@readme/oas-examples": "^4.3.3",
+        "@readme/oas-examples": "^4.4.0",
         "eslint": "^8.7.0",
         "jest": "^27.4.7",
         "memfs": "^3.4.1",
@@ -1443,9 +1443,9 @@
       }
     },
     "node_modules/@readme/oas-examples": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@readme/oas-examples/-/oas-examples-4.3.3.tgz",
-      "integrity": "sha512-7f28RJplXQQ5UpUj+mVgia6sONDOzEc8gl68V7xantz88Q4YTR34Y0AVUwMyOwx/poNL+PaEoY4SNylw7FTeJw==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@readme/oas-examples/-/oas-examples-4.4.0.tgz",
+      "integrity": "sha512-sZD5ZiRQGsR+h/LUnUGYm4NgfcA0cpv2+wDEiAuAxbk8rXxO2cvRPOeM9g+x93E2L1/t34Z8yCRFf0fnlI92ag==",
       "dev": true
     },
     "node_modules/@readme/oas-extensions": {
@@ -10882,9 +10882,9 @@
       }
     },
     "@readme/oas-examples": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@readme/oas-examples/-/oas-examples-4.3.3.tgz",
-      "integrity": "sha512-7f28RJplXQQ5UpUj+mVgia6sONDOzEc8gl68V7xantz88Q4YTR34Y0AVUwMyOwx/poNL+PaEoY4SNylw7FTeJw==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@readme/oas-examples/-/oas-examples-4.4.0.tgz",
+      "integrity": "sha512-sZD5ZiRQGsR+h/LUnUGYm4NgfcA0cpv2+wDEiAuAxbk8rXxO2cvRPOeM9g+x93E2L1/t34Z8yCRFf0fnlI92ag==",
       "dev": true
     },
     "@readme/oas-extensions": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@readme/eslint-config": "^8.1.2",
-    "@readme/oas-examples": "^4.3.3",
+    "@readme/oas-examples": "^4.4.0",
     "eslint": "^8.7.0",
     "jest": "^27.4.7",
     "memfs": "^3.4.1",

--- a/packages/api/src/cache.js
+++ b/packages/api/src/cache.js
@@ -33,7 +33,7 @@ class SdkCache {
      */
     const resolveReadMeRegistryAccessor = u =>
       typeof u === 'string'
-        ? u.replace(/^@[a-zA-Z0-9-_]+\/?(.+)#([a-z0-9]+)$/, 'https://dash.readme.io/api/v1/api-registry/$2')
+        ? u.replace(/^@[a-zA-Z0-9-_]+\/?(.+)#([a-z0-9]+)$/, 'https://dash.readme.com/api/v1/api-registry/$2')
         : u;
 
     this.uri = resolveReadMeRegistryAccessor(uri);

--- a/packages/httpsnippet-client-api/__tests__/index.test.js
+++ b/packages/httpsnippet-client-api/__tests__/index.test.js
@@ -53,7 +53,7 @@ test('it should error if no matching operation was found in the apiDefinition', 
       { name: 'perPage', value: '10' },
       { name: 'page', value: '1' },
     ],
-    url: 'https://dash.readme.io/api/api-specification',
+    url: 'https://dash.readme.com/api/api-specification',
   };
 
   const snippet = new HTTPSnippet(har);
@@ -89,7 +89,7 @@ describe('auth handling', () => {
           { name: 'perPage', value: '10' },
           { name: 'page', value: '1' },
         ],
-        url: 'https://dash.readme.io/api/v1/api-specification',
+        url: 'https://dash.readme.com/api/v1/api-specification',
       };
 
       const code = new HTTPSnippet(har).convert('node', 'api', {

--- a/packages/httpsnippet-client-api/package-lock.json
+++ b/packages/httpsnippet-client-api/package-lock.json
@@ -15,7 +15,7 @@
       },
       "devDependencies": {
         "@readme/eslint-config": "^8.1.2",
-        "@readme/oas-examples": "^4.3.3",
+        "@readme/oas-examples": "^4.4.0",
         "eslint": "^8.7.0",
         "jest": "^27.4.7",
         "prettier": "^2.5.1"
@@ -1624,9 +1624,9 @@
       }
     },
     "node_modules/@readme/oas-examples": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@readme/oas-examples/-/oas-examples-4.3.3.tgz",
-      "integrity": "sha512-7f28RJplXQQ5UpUj+mVgia6sONDOzEc8gl68V7xantz88Q4YTR34Y0AVUwMyOwx/poNL+PaEoY4SNylw7FTeJw==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@readme/oas-examples/-/oas-examples-4.4.0.tgz",
+      "integrity": "sha512-sZD5ZiRQGsR+h/LUnUGYm4NgfcA0cpv2+wDEiAuAxbk8rXxO2cvRPOeM9g+x93E2L1/t34Z8yCRFf0fnlI92ag==",
       "dev": true
     },
     "node_modules/@readme/openapi-parser": {
@@ -11428,9 +11428,9 @@
       }
     },
     "@readme/oas-examples": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@readme/oas-examples/-/oas-examples-4.3.3.tgz",
-      "integrity": "sha512-7f28RJplXQQ5UpUj+mVgia6sONDOzEc8gl68V7xantz88Q4YTR34Y0AVUwMyOwx/poNL+PaEoY4SNylw7FTeJw==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@readme/oas-examples/-/oas-examples-4.4.0.tgz",
+      "integrity": "sha512-sZD5ZiRQGsR+h/LUnUGYm4NgfcA0cpv2+wDEiAuAxbk8rXxO2cvRPOeM9g+x93E2L1/t34Z8yCRFf0fnlI92ag==",
       "dev": true
     },
     "@readme/openapi-parser": {

--- a/packages/httpsnippet-client-api/package.json
+++ b/packages/httpsnippet-client-api/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@readme/eslint-config": "^8.1.2",
-    "@readme/oas-examples": "^4.3.3",
+    "@readme/oas-examples": "^4.4.0",
     "eslint": "^8.7.0",
     "jest": "^27.4.7",
     "prettier": "^2.5.1"


### PR DESCRIPTION
## 🧰 Changes

Our API can be accessed against `dash.readme.io` or `dash.readme.com`, but we prefer the latter.

## 🧬 QA & Testing

Tests were updated and `@readme/oas-examples` was bumped to pull in our updated API definition with this server URL.
