### PR TITLE
feat: adding support for cookie parameters

### DIFF
--- a/packages/api/__tests__/index.test.ts
+++ b/packages/api/__tests__/index.test.ts
@@ -4,7 +4,7 @@ import api from '../src';
 import Cache from '../src/cache';
 import { vol } from 'memfs';
 
-import pkg = require('../package.json');
+import pkg from '../package.json';
 
 const realFs = jest.requireActual('fs/promises');
 

--- a/packages/api/__tests__/lib/prepareParams.test.ts
+++ b/packages/api/__tests__/lib/prepareParams.test.ts
@@ -323,5 +323,49 @@ describe('#prepareParams', () => {
     });
   });
 
-  it.todo(`should be able to handle parameters when they're defined as common parameters`);
+  describe('parameter types', () => {
+    let parameterStyle;
+
+    beforeEach(async () => {
+      parameterStyle = await import('@readme/oas-examples/3.1/json/parameters-style.json').then(Oas.init);
+      await parameterStyle.dereference();
+    });
+
+    it.each([
+      ['cookies', '/cookies', 'get', 'cookie'],
+      ['headers', '/anything/headers', 'get', 'header'],
+      ['query', '/anything/query', 'get', 'query'],
+    ])('should support %s', async (_, path, method, paramName) => {
+      const operation = parameterStyle.operation(path, method);
+      const metadata = {
+        primitive: 'buster',
+      };
+
+      await expect(prepareParams(operation, metadata)).resolves.toStrictEqual({
+        [paramName]: {
+          primitive: 'buster',
+        },
+      });
+    });
+
+    it('should support path parameters', async () => {
+      const operation = parameterStyle.operation('/anything/path/{primitive}/{array}/{object}', 'get');
+      const metadata = {
+        primitive: 'buster',
+        array: ['buster'],
+        object: {
+          name: 'buster',
+          description: 'the dog',
+        },
+      };
+
+      await expect(prepareParams(operation, metadata)).resolves.toStrictEqual({
+        path: {
+          primitive: 'buster',
+          array: ['buster'],
+          object: { name: 'buster', description: 'the dog' },
+        },
+      });
+    });
+  });
 });

--- a/packages/api/__tests__/tsconfig.json
+++ b/packages/api/__tests__/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
+    "module": "es2020",
     "noImplicitAny": false,
   },
-  "include": ["../src/**/*", "**/*"]
+  "include": ["../src/**/*", "*.ts", "**/*"]
 }

--- a/packages/api/src/lib/prepareParams.ts
+++ b/packages/api/src/lib/prepareParams.ts
@@ -95,6 +95,7 @@ export default async function prepareParams(operation: Operation, body?: unknown
 
   const params: {
     body?: any;
+    cookie?: Record<string, string | number | boolean>;
     files?: Record<string, Buffer>;
     formData?: any;
     header?: Record<string, string | number | boolean>;
@@ -223,6 +224,7 @@ export default async function prepareParams(operation: Operation, body?: unknown
   // operation schema. If we couldn't digest anything, but metadata was supplied then we wouldn't know where to place
   // the metadata!
   if (hasDigestedParams) {
+    params.cookie = {};
     params.header = {};
     params.path = {};
     params.query = {};
@@ -243,7 +245,7 @@ export default async function prepareParams(operation: Operation, body?: unknown
           } else if (digested[param].in === 'header') {
             params.header[param] = metadata[param] as string;
           } else if (digested[param].in === 'cookie') {
-            // @todo add support cookie params here and also in @readme/oas-to-har
+            params.cookie[param] = metadata[param] as string;
           }
 
           // Because a user might have sent just a metadata object, we want to make sure that we
@@ -260,7 +262,7 @@ export default async function prepareParams(operation: Operation, body?: unknown
   }
 
   // Clean up any empty items.
-  ['body', 'files', 'formData', 'header', 'path', 'query'].forEach((type: keyof typeof params) => {
+  ['body', 'cookie', 'files', 'formData', 'header', 'path', 'query'].forEach((type: keyof typeof params) => {
     if (type in params && isEmpty(params[type])) {
       delete params[type];
     }


### PR DESCRIPTION
| 🚥  | Fix RM-3242 |
| :-- | :--- |

## 🧰 Changes

Adds full support for cookie parameters in SDK requests.

Cookie support was already built into `httpsnippet-client-api`, but we only supported cookies in auth within the SDK.

## 🧬 QA & Testing

See tests.