### PR TITLE
feat: cleaning up how we access paths out of the OAS

### DIFF
--- a/packages/api/__tests__/index.test.ts
+++ b/packages/api/__tests__/index.test.ts
@@ -150,6 +150,8 @@ describe('#accessors', () => {
     it('should error if method does not exist', () => {
       return expect(petstoreSdk.fetch('/pets')).rejects.toThrow(/does not appear to be a valid operation/);
     });
+
+    it.todo('should error if a path does not exist on a method');
   });
 });
 


### PR DESCRIPTION
| 🚥  | 
| :-- |

## 🧰 Changes

This cleans up how we're extracting paths out of an API definition by using the `.getPaths()` accessor that `oas` offers.

## 🧬 QA & Testing

All tests should still be passing