### PR TITLE
fix: fixing how we generate the dist to work under CJS imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11803,7 +11803,7 @@
         "nock": "^13.2.2",
         "prettier": "^2.5.1",
         "ts-jest": "^27.1.3",
-        "typescript": "^4.5.5"
+        "typescript": "^4.6.0-beta"
       },
       "engines": {
         "node": "^14 || ^16"
@@ -12290,6 +12290,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "packages/api/node_modules/typescript": {
+      "version": "4.6.0-dev.20220208",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.0-dev.20220208.tgz",
+      "integrity": "sha512-2yfS4UYfkLnpVkjs2IEl7T++ojqdPiV5S/akYv1trTf50TZHmGnyhF5Umo2iLWZEuSDmBCe2K52x5qzBXDi+mQ==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
       }
     },
     "packages/httpsnippet-client-api": {
@@ -14899,7 +14912,7 @@
         "oas": "^17.6.0",
         "prettier": "^2.5.1",
         "ts-jest": "^27.1.3",
-        "typescript": "^4.5.5"
+        "typescript": "^4.6.0-beta"
       },
       "dependencies": {
         "@eslint/eslintrc": {
@@ -15238,6 +15251,12 @@
           "requires": {
             "has-flag": "^4.0.0"
           }
+        },
+        "typescript": {
+          "version": "4.6.0-dev.20220208",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.0-dev.20220208.tgz",
+          "integrity": "sha512-2yfS4UYfkLnpVkjs2IEl7T++ojqdPiV5S/akYv1trTf50TZHmGnyhF5Umo2iLWZEuSDmBCe2K52x5qzBXDi+mQ==",
+          "dev": true
         }
       }
     },

--- a/packages/api/.eslintignore
+++ b/packages/api/.eslintignore
@@ -1,4 +1,3 @@
 @types/
 coverage/
 dist/
-example.js

--- a/packages/api/.eslintrc
+++ b/packages/api/.eslintrc
@@ -27,5 +27,14 @@
     "jsdoc/require-param-type": "off",
     "jsdoc/require-returns": "off",
     "jsdoc/require-returns-type": "off"
-  }
+  },
+  "overrides": [
+    {
+      "files": ["example.js"],
+      "rules": {
+        "@typescript-eslint/no-var-requires": "off",
+        "no-console": "off"
+      }
+    }
+  ]
 }

--- a/packages/api/__tests__/dist.test.ts
+++ b/packages/api/__tests__/dist.test.ts
@@ -1,0 +1,23 @@
+import api from '../dist';
+import nock from 'nock';
+import uspto from '@readme/oas-examples/3.0/json/uspto.json';
+
+beforeAll(() => {
+  nock.disableNetConnect();
+});
+
+afterAll(() => {
+  nock.restore();
+});
+
+test('should be able to use the transpiled dist', async () => {
+  const mock = nock('https://developer.uspto.gov/ds-api')
+    .post('/oa_citations/v1/records')
+    .reply(200, uri => uri);
+
+  const sdk = api(uspto);
+
+  await expect(sdk.post('/oa_citations/v1/records')).resolves.toBe('/ds-api/oa_citations/v1/records');
+
+  mock.done();
+});

--- a/packages/api/__tests__/tsconfig.json
+++ b/packages/api/__tests__/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "module": "es2020",
+    "moduleResolution": "node",
     "noImplicitAny": false,
     "resolveJsonModule": true
   },

--- a/packages/api/__tests__/tsconfig.json
+++ b/packages/api/__tests__/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "module": "es2020",
     "noImplicitAny": false,
+    "resolveJsonModule": true
   },
   "include": ["../src/**/*", "*.ts", "**/*"]
 }

--- a/packages/api/example.js
+++ b/packages/api/example.js
@@ -1,13 +1,13 @@
-const sdk = require('./src')('https://raw.githubusercontent.com/readmeio/oas/master/packages/examples/3.0/yaml/readme.yaml');
+const sdk = require('.')('https://raw.githubusercontent.com/readmeio/oas-examples/main/3.0/json/readme.json');
 
 sdk
   .auth('readmeApiToken')
   .getChangelogs({
     perPage: 10,
-    page: 1
+    page: 1,
   })
-  .then(res => res.json())
   .then(res => {
     console.log(`there are ${res.length} changelogs`);
     console.log(res[0]);
-  });
+  })
+  .catch(console.error);

--- a/packages/api/package-lock.json
+++ b/packages/api/package-lock.json
@@ -34,7 +34,7 @@
         "nock": "^13.2.2",
         "prettier": "^2.5.1",
         "ts-jest": "^27.1.3",
-        "typescript": "^4.5.5"
+        "typescript": "^4.6.0-beta"
       },
       "engines": {
         "node": "^14 || ^16"
@@ -1921,6 +1921,35 @@
         "node": ">=10"
       }
     },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/tsutils": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^1.8.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/typescript": {
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/@typescript-eslint/experimental-utils": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.5.0.tgz",
@@ -2061,6 +2090,35 @@
         "node": ">=10"
       }
     },
+    "node_modules/@typescript-eslint/parser/node_modules/tsutils": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^1.8.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/typescript": {
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/@typescript-eslint/scope-manager": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.5.0.tgz",
@@ -2102,6 +2160,35 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/tsutils": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^1.8.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/typescript": {
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
       }
     },
     "node_modules/@typescript-eslint/types": {
@@ -2157,6 +2244,35 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/tsutils": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^1.8.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/typescript": {
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
       }
     },
     "node_modules/@typescript-eslint/utils": {
@@ -2270,6 +2386,35 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/tsutils": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^1.8.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/typescript": {
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
@@ -9922,21 +10067,6 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true
     },
-    "node_modules/tsutils": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
-      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^1.8.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      },
-      "peerDependencies": {
-        "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
-      }
-    },
     "node_modules/type": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
@@ -9985,9 +10115,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "version": "4.6.0-beta",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.0-beta.tgz",
+      "integrity": "sha512-xg5avH08DioTdxex568HFLHvnHWxGzpu9FK0ehLNwlqzx/kjy5/qEkBmkbPlvC9xs45bc7gbAbEhNqtczJsHAg==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -11835,6 +11965,22 @@
           "requires": {
             "lru-cache": "^6.0.0"
           }
+        },
+        "tsutils": {
+          "version": "3.21.0",
+          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+          "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.8.1"
+          }
+        },
+        "typescript": {
+          "version": "4.5.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+          "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+          "dev": true,
+          "peer": true
         }
       }
     },
@@ -11913,6 +12059,22 @@
           "requires": {
             "lru-cache": "^6.0.0"
           }
+        },
+        "tsutils": {
+          "version": "3.21.0",
+          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+          "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.8.1"
+          }
+        },
+        "typescript": {
+          "version": "4.5.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+          "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+          "dev": true,
+          "peer": true
         }
       }
     },
@@ -11935,6 +12097,24 @@
         "@typescript-eslint/utils": "5.10.2",
         "debug": "^4.3.2",
         "tsutils": "^3.21.0"
+      },
+      "dependencies": {
+        "tsutils": {
+          "version": "3.21.0",
+          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+          "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.8.1"
+          }
+        },
+        "typescript": {
+          "version": "4.5.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+          "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+          "dev": true,
+          "peer": true
+        }
       }
     },
     "@typescript-eslint/types": {
@@ -11966,6 +12146,22 @@
           "requires": {
             "lru-cache": "^6.0.0"
           }
+        },
+        "tsutils": {
+          "version": "3.21.0",
+          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+          "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.8.1"
+          }
+        },
+        "typescript": {
+          "version": "4.5.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+          "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+          "dev": true,
+          "peer": true
         }
       }
     },
@@ -12032,6 +12228,22 @@
           "requires": {
             "lru-cache": "^6.0.0"
           }
+        },
+        "tsutils": {
+          "version": "3.21.0",
+          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+          "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.8.1"
+          }
+        },
+        "typescript": {
+          "version": "4.5.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+          "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+          "dev": true,
+          "peer": true
         }
       }
     },
@@ -17762,15 +17974,6 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true
     },
-    "tsutils": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
-      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
-      "dev": true,
-      "requires": {
-        "tslib": "^1.8.1"
-      }
-    },
     "type": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
@@ -17807,9 +18010,9 @@
       }
     },
     "typescript": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "version": "4.6.0-beta",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.0-beta.tgz",
+      "integrity": "sha512-xg5avH08DioTdxex568HFLHvnHWxGzpu9FK0ehLNwlqzx/kjy5/qEkBmkbPlvC9xs45bc7gbAbEhNqtczJsHAg==",
       "dev": true
     },
     "unbox-primitive": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "build": "tsc",
     "lint": "eslint . --ext .js,.ts",
-    "prebuild": "rm -rf dist/ @types/",
+    "prebuild": "rm -rf dist/ @types/; npm run prebuild.packageConfig",
+    "prebuild.packageConfig": "node -p \"'export const PACKAGE_NAME = \\'' + require('./package.json').name + '\\';\\nexport const PACKAGE_VERSION = \\'' + require('./package.json').version + '\\';'\" > src/package.ts",
     "prepack": "npm run build",
     "pretest": "npm run lint",
     "prettier": "prettier --list-different --write \"./**/**.{js,ts}\"",
@@ -54,7 +55,7 @@
     "nock": "^13.2.2",
     "prettier": "^2.5.1",
     "ts-jest": "^27.1.3",
-    "typescript": "^4.5.5"
+    "typescript": "^4.6.0-beta"
   },
   "prettier": "@readme/eslint-config/prettier"
 }

--- a/packages/api/src/cache.ts
+++ b/packages/api/src/cache.ts
@@ -9,16 +9,16 @@ import os from 'os';
 import path from 'path';
 import makeDir from 'make-dir';
 
-import pkg from '../package.json';
+import { PACKAGE_NAME } from './package';
 
-let cacheDir = findCacheDir({ name: pkg.name });
+let cacheDir = findCacheDir({ name: PACKAGE_NAME });
 if (typeof cacheDir === 'undefined') {
   // The `find-cache-dir` module returns `undefined` if the `node_modules/` directory isn't
   // writable, or there's no `package.json` in the root-most directory. If this happens, we can
   // instead adhoc create a cache directory in the users OS temp directory and store our data there.
   //
   // @link https://github.com/avajs/find-cache-dir/issues/29
-  cacheDir = makeDir.sync(path.join(os.tmpdir(), pkg.name));
+  cacheDir = makeDir.sync(path.join(os.tmpdir(), PACKAGE_NAME));
 }
 
 type Cache = Record<

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -10,7 +10,7 @@ import { FormDataEncoder } from 'form-data-encoder';
 import Cache from './cache';
 import { parseResponse, prepareAuth, prepareParams, prepareServer } from './lib';
 
-import pkg from '../package.json';
+import { PACKAGE_NAME, PACKAGE_VERSION } from './package';
 
 interface ConfigOptions {
   parseResponse: boolean;
@@ -23,7 +23,7 @@ class Sdk {
 
   constructor(uri: string | OASDocument) {
     this.uri = uri;
-    this.userAgent = `${pkg.name} (node)/${pkg.version}`;
+    this.userAgent = `${PACKAGE_NAME} (node)/${PACKAGE_VERSION}`;
   }
 
   load() {
@@ -201,6 +201,9 @@ class Sdk {
   }
 }
 
-export default function api(uri: string | OASDocument) {
+// Why `export` vs `export default`? If we leave this as `export` then TS will transpile it into
+// a `module.exports` export so that when folks load this they don't need to load it as
+// `require('api').default`.
+export = (uri: string | OASDocument) => {
   return new Sdk(uri).load();
-}
+};

--- a/packages/api/src/package.ts
+++ b/packages/api/src/package.ts
@@ -1,0 +1,2 @@
+export const PACKAGE_NAME = 'api';
+export const PACKAGE_VERSION = '4.2.0';

--- a/packages/api/src/typings.d.ts
+++ b/packages/api/src/typings.d.ts
@@ -1,3 +1,12 @@
 // These libraries don't have any types so we need to let TS know so we can use them.
 declare module 'fetch-har';
 declare module '@readme/oas-to-har';
+
+// Because this library uses ES2015+ `#private` syntax that would require us to make this library
+// ESM-only we're using a node12 module resolution for this library. Because of this the types
+// for `form-data-encoder` don't get automatically pulled in and since there is no standalone
+// `@types/form-data-encoder` package we need to declare a module.
+//
+// This isn't a great solution, and we lose some type checks on it, but it's far too early in the
+// ESM lifecycle for us to make API an ESM-only library.
+declare module 'form-data-encoder';

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -1,16 +1,15 @@
 {
   "compilerOptions": {
     "allowJs": true,
-    "baseUrl": "./src/",
+    "baseUrl": "./src",
     "declaration": true,
     "declarationDir": "./@types",
     "esModuleInterop": true,
     "lib": ["dom", "es2020"],
-    "moduleResolution": "node",
+    "module": "node12",
+    "moduleResolution": "node12",
     "noImplicitAny": true,
-    "outDir": "./dist",
-    "resolveJsonModule": true,
-    "target": "es2020"
+    "outDir": "dist"
   },
-  "include": ["./src/**/*"],
+  "include": ["./src/**/*"]
 }


### PR DESCRIPTION
| 🚥  | Fix RM-3394 |
| :-- | :--- |

## 🧰 Changes

This rolls back the `target: es2020` config I added to our TS config when I migrated the library to TS as I didn't really understand the implications of what was going on with it.

The reason I added it in the first place was this error:

![screen_shot_2022-02-08_at_2 49 10_pm](https://user-images.githubusercontent.com/33762/153288305-b5a11fe6-f5f4-48ea-acb6-ca5dcd1b1950.png)

Because `form-data-encoder` uses `#private` class member declarations TS can only compile that to ES2015+ targets. Thankfully with TS 4.6 they're adding a new `node12` module and moduleResolution config that's able to ignore these at the expense of using types elsewhere. https://www.typescriptlang.org/tsconfig#node12nodenext-nightly-builds

And because `form-data-encoder` doesn't have a `@types/form-data-encoder` package we need to declare a module for it ourselves, resulting in type loss.

It's an unfortunate loss but because IMHO it's still far too early to make libraries ESM-only I don't want to migrate `api` towards that direction yet. Maybe when Node 14 hits EOL but we'll see.

## 🧬 QA & Testing

It's hard to test how this was broken without manually reverting the TS config changes but the dist unit test I wrote loads the library without a `{default: api}` import, and running the `example.js` script also, works so if this test runs in CI it should be good?