### PR TITLE
feat: creation of a new APICore class to handle fetching

### DIFF
--- a/packages/api/.eslintignore
+++ b/packages/api/.eslintignore
@@ -1,3 +1,2 @@
 .nyc_output/
-@types/
 dist/

--- a/packages/api/.gitignore
+++ b/packages/api/.gitignore
@@ -1,4 +1,3 @@
 .nyc_output/
-@types/
 dist/
 node_modules/

--- a/packages/api/.prettierignore
+++ b/packages/api/.prettierignore
@@ -1,4 +1,3 @@
 .nyc_output/
-@types/
 dist/
 example.js

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -3,7 +3,7 @@
   "version": "4.2.0",
   "description": "Generate an SDK from an OpenAPI definition",
   "main": "dist/index.js",
-  "types": "@types/index.d.ts",
+  "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc",
     "lint": "eslint . --ext .js,.ts",

--- a/packages/api/src/core/index.ts
+++ b/packages/api/src/core/index.ts
@@ -1,7 +1,104 @@
+import type Oas from 'oas';
+import type { Operation } from 'oas';
+import type { HttpMethods } from 'oas/@types/rmoas.types';
+
+import 'isomorphic-fetch';
+import fetchHar from 'fetch-har';
+import oasToHar from '@readme/oas-to-har';
+import { FormDataEncoder } from 'form-data-encoder';
+
 import getJSONSchemaDefaults from './getJSONSchemaDefaults';
 import parseResponse from './parseResponse';
 import prepareAuth from './prepareAuth';
 import prepareParams from './prepareParams';
 import prepareServer from './prepareServer';
 
+export interface ConfigOptions {
+  parseResponse: boolean;
+}
+
 export { getJSONSchemaDefaults, parseResponse, prepareAuth, prepareParams, prepareServer };
+
+export default class APICore {
+  spec: Oas;
+
+  private auth: (number | string)[][] = [];
+
+  private server:
+    | false
+    | {
+        url?: string;
+        variables?: Record<string, string | number>;
+      } = false;
+
+  private config: ConfigOptions = { parseResponse: true };
+
+  private userAgent: string;
+
+  constructor(spec?: Oas, userAgent?: string) {
+    this.spec = spec;
+    this.userAgent = userAgent;
+  }
+
+  setSpec(spec: Oas) {
+    this.spec = spec;
+  }
+
+  setConfig(config: ConfigOptions) {
+    this.config = config;
+    return this;
+  }
+
+  setUserAgent(userAgent: string) {
+    this.userAgent = userAgent;
+    return this;
+  }
+
+  setAuth(...values: string[] | number[]) {
+    this.auth.push(values);
+    return this;
+  }
+
+  setServer(url: string, variables: Record<string, string | number> = {}) {
+    this.server = { url, variables };
+    return this;
+  }
+
+  async fetch(path: string, method: HttpMethods, body?: unknown, metadata?: Record<string, unknown>) {
+    const operation = this.spec.operation(path, method);
+
+    return this.fetchOperation(operation, body, metadata);
+  }
+
+  async fetchOperation(operation: Operation, body?: unknown, metadata?: Record<string, unknown>) {
+    return prepareParams(operation, body, metadata).then(params => {
+      const data = { ...params };
+
+      // If `sdk.server()` has been issued data then we need to do some extra work to figure out
+      // how to use that supplied server, and also handle any server variables that were sent
+      // alongside it.
+      if (this.server) {
+        const preparedServer = prepareServer(this.spec, this.server.url, this.server.variables);
+        if (preparedServer) {
+          data.server = preparedServer;
+        }
+      }
+
+      const har = oasToHar(this.spec, operation, data, prepareAuth(this.auth, operation));
+
+      return fetchHar(har, {
+        userAgent: this.userAgent,
+        files: data.files || {},
+        multipartEncoder: FormDataEncoder,
+      }).then((res: Response) => {
+        if (res.status >= 400 && res.status <= 599) {
+          throw res;
+        }
+
+        if (this.config.parseResponse === false) return res;
+
+        return parseResponse(res);
+      });
+    });
+  }
+}

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,20 +1,14 @@
 import type { Operation } from 'oas';
 import type { OASDocument } from './types';
+import type { HttpMethods } from 'oas/@types/rmoas.types';
+import type { ConfigOptions } from './core';
 
-import 'isomorphic-fetch';
-import fetchHar from 'fetch-har';
 import Oas from 'oas';
-import oasToHar from '@readme/oas-to-har';
-import { parseResponse, prepareAuth, prepareParams, prepareServer } from './core';
-import { FormDataEncoder } from 'form-data-encoder';
+import APICore from './core';
 
 import Cache from './cache';
 
 import { PACKAGE_NAME, PACKAGE_VERSION } from './packageInfo';
-
-interface ConfigOptions {
-  parseResponse: boolean;
-}
 
 class Sdk {
   uri: string | OASDocument;
@@ -27,53 +21,15 @@ class Sdk {
   }
 
   load() {
-    const authKeys: (number | string)[][] = [];
     const cache = new Cache(this.uri);
     const userAgent = this.userAgent;
 
-    let config: ConfigOptions = { parseResponse: true };
-    let server:
-      | false
-      | {
-          url: string;
-          variables: Record<string, string | number>;
-        } = false;
+    const core = new APICore();
+    core.setUserAgent(userAgent);
 
     let isLoaded = false;
     let isCached = cache.isCached();
     let sdk = {};
-
-    function fetchOperation(spec: Oas, operation: Operation, body?: unknown, metadata?: Record<string, unknown>) {
-      return prepareParams(operation, body, metadata).then(params => {
-        const data = { ...params };
-
-        // If `sdk.server()` has been issued data then we need to do some extra work to figure out
-        // how to use that supplied server, and also handle any server variables that were sent
-        // alongside it.
-        if (server) {
-          const preparedServer = prepareServer(spec, server.url, server.variables);
-          if (preparedServer) {
-            data.server = preparedServer;
-          }
-        }
-
-        const har = oasToHar(spec, operation, data, prepareAuth(authKeys, operation));
-
-        return fetchHar(har, {
-          userAgent,
-          files: data.files || {},
-          multipartEncoder: FormDataEncoder,
-        }).then((res: Response) => {
-          if (res.status >= 400 && res.status <= 599) {
-            throw res;
-          }
-
-          if (config.parseResponse === false) return res;
-
-          return parseResponse(res);
-        });
-      });
-    }
 
     /**
      * Create dynamic accessors for every HTTP method that the OpenAPI specification supports.
@@ -82,15 +38,12 @@ class Sdk {
      * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#fixed-fields-7}
      * @param spec
      */
-    function loadMethods(spec: Oas) {
+    function loadMethods() {
       return ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace']
         .map(httpVerb => {
           return {
             [httpVerb]: ((method: string, path: string, ...args: unknown[]) => {
-              // The HTTPMethods enum in `oas` makes working with string methods difficult so we
-              // need to cast it as `any` here.
-              const operation = spec.operation(path, method as any);
-              return fetchOperation(spec, operation, ...args);
+              return core.fetch(path, method as HttpMethods, ...args);
             }).bind(null, httpVerb),
           };
         })
@@ -115,7 +68,7 @@ class Sdk {
         .reduce((prev, next) => {
           return Object.assign(prev, {
             [next.getOperationId()]: ((operation: Operation, ...args: unknown[]) => {
-              return fetchOperation(spec, operation, ...args);
+              return core.fetchOperation(operation, ...args);
             }).bind(null, next),
           });
         }, {});
@@ -132,8 +85,10 @@ class Sdk {
 
       const spec = new Oas(cachedSpec);
 
+      core.setSpec(spec);
+
       sdk = Object.assign(sdk, {
-        ...loadMethods(spec),
+        ...loadMethods(),
         ...loadOperations(spec),
       });
 
@@ -179,21 +134,14 @@ class Sdk {
 
     sdk = {
       auth: (...values: string[] | number[]) => {
-        authKeys.push(values);
+        core.setAuth(...values);
         return new Proxy(sdk, sdkProxy);
       },
-      config: (opts: ConfigOptions) => {
-        // Downside to having `opts` be merged into the existing `config` is that there isn't a
-        // clean way to reset your current config to the default, so having `opts` assigned directly
-        // to the existing config should be okay.
-        config = opts;
-        return new Proxy(sdk, sdkProxy);
+      config: (config: ConfigOptions) => {
+        core.setConfig(config);
       },
       server: (url: string, variables = {}) => {
-        server = {
-          url,
-          variables,
-        };
+        core.setServer(url, variables);
       },
     };
 

--- a/packages/api/test/core/index.test.ts
+++ b/packages/api/test/core/index.test.ts
@@ -1,0 +1,302 @@
+import { assert, expect } from 'chai';
+import APICore from '../../src/core';
+import Oas from 'oas';
+import nock from 'nock';
+
+describe('APICore', function () {
+  let petstore: APICore;
+  let readme: APICore;
+  let security: APICore;
+  let serverVariables: APICore;
+
+  const petId = 123;
+  const response = {
+    id: petId,
+    name: 'Buster',
+  };
+
+  beforeEach(async function () {
+    petstore = await import('@readme/oas-examples/3.0/json/petstore-expanded.json')
+      .then(Oas.init)
+      .then(oas => new APICore(oas));
+
+    readme = await import('@readme/oas-examples/3.0/json/readme.json').then(Oas.init).then(oas => new APICore(oas));
+
+    security = await import('@readme/oas-examples/3.0/json/security.json').then(Oas.init).then(oas => new APICore(oas));
+
+    serverVariables = await import('@readme/oas-examples/3.0/json/server-variables.json')
+      .then(Oas.init)
+      .then(oas => new APICore(oas));
+  });
+
+  describe('#fetchOperation', function () {
+    it('should make a request for a given operation with body + metadata parameters', async function () {
+      const slug = 'new-release';
+      const body = {
+        title: 'revised title',
+        body: 'updated body',
+      };
+
+      const mock = nock('https://dash.readme.com/api/v1')
+        .put(`/changelogs/${slug}`, body)
+        .reply(200, function (uri, requestBody) {
+          return {
+            uri,
+            requestBody,
+          };
+        });
+
+      const operation = readme.spec.operation('/changelogs/{slug}', 'put');
+
+      expect(await readme.fetchOperation(operation, body, { slug })).to.deep.equal({
+        uri: '/api/v1/changelogs/new-release',
+        requestBody: body,
+      });
+      mock.done();
+    });
+  });
+
+  describe('#fetch', function () {
+    describe('error handling', function () {
+      it('should reject for error-level status codes', async function () {
+        const mock = nock('http://petstore.swagger.io/api').delete(`/pets/${petId}`).reply(404, 'Not Found');
+
+        await petstore
+          .fetch('/pets/{id}', 'delete', undefined, { id: petId })
+          .then(() => assert.fail())
+          .catch(async err => {
+            expect(err.status).to.equal(404);
+
+            const res = await err.text();
+            expect(res).to.equal('Not Found');
+          });
+
+        mock.done();
+      });
+    });
+
+    describe('payload delivery', function () {
+      it('should pass through body for method + path', async function () {
+        const body = { name: 'Buster' };
+
+        const mock = nock('http://petstore.swagger.io/api')
+          .post('/pets', body)
+          .reply(200, (uri, requestBody) => requestBody);
+
+        expect(await petstore.fetch('/pets', 'post', body)).to.deep.equal(body);
+        mock.done();
+      });
+
+      it('should pass through parameters for method + path', async function () {
+        const slug = 'new-release';
+        const mock = nock('https://dash.readme.com/api/v1')
+          .put(`/changelogs/${slug}`)
+          .reply(200, uri => uri);
+
+        expect(await readme.fetch('/changelogs/{slug}', 'put', undefined, { slug })).to.equal(
+          '/api/v1/changelogs/new-release'
+        );
+        mock.done();
+      });
+
+      it('should pass through parameters and body for method + path', async function () {
+        const slug = 'new-release';
+        const body = {
+          title: 'revised title',
+          body: 'updated body',
+        };
+
+        const mock = nock('https://dash.readme.com/api/v1')
+          .put(`/changelogs/${slug}`, body)
+          .reply(200, function (uri, requestBody) {
+            return {
+              uri,
+              requestBody,
+            };
+          });
+
+        expect(await readme.fetch('/changelogs/{slug}', 'put', body, { slug })).to.deep.equal({
+          uri: '/api/v1/changelogs/new-release',
+          requestBody: body,
+        });
+        mock.done();
+      });
+
+      describe('query parameter encoding', function () {
+        let queryEncoding: APICore;
+
+        beforeEach(function () {
+          queryEncoding = new APICore(
+            Oas.init({
+              servers: [{ url: 'https://httpbin.org/' }],
+              paths: {
+                '/anything': {
+                  get: {
+                    operationId: 'getAnything',
+                    parameters: [
+                      { name: 'stringPound', in: 'query', schema: { type: 'string' } },
+                      { name: 'stringPound2', in: 'query', schema: { type: 'string' } },
+                      { name: 'stringHash', in: 'query', schema: { type: 'string' } },
+                      { name: 'stringArray', in: 'query', schema: { type: 'string' } },
+                      { name: 'stringWeird', in: 'query', schema: { type: 'string' } },
+                      { name: 'array', in: 'query', schema: { type: 'array', items: { type: 'string' } } },
+                    ],
+                  },
+                },
+              },
+            })
+          );
+        });
+
+        it('should encode query parameters', async function () {
+          const params = {
+            stringPound: 'something&nothing=true',
+            stringHash: 'hash#data',
+            stringArray: 'where[4]=10',
+            stringWeird: 'properties["$email"] == "testing"',
+            array: [
+              encodeURIComponent('something&nothing=true'), // This is already encoded so it shouldn't be double encoded.
+              'nothing&something=false',
+              'another item',
+            ],
+          };
+
+          const mock = nock('https://httpbin.org/')
+            .get('/anything')
+            .query(true)
+            .reply(200, function () {
+              return { path: this.req.path };
+            });
+
+          expect(await queryEncoding.fetch('/anything', 'get', undefined, params)).to.deep.equal({
+            path: '/anything?stringPound=something%26nothing%3Dtrue&stringHash=hash%23data&stringArray=where%5B4%5D%3D10&stringWeird=properties%5B%22%24email%22%5D%20%3D%3D%20%22testing%22&array=something%26nothing%3Dtrue&array=nothing%26something%3Dfalse&array=another%20item',
+          });
+
+          mock.done();
+        });
+
+        it("should not double encode query params if they're already encoded", async function () {
+          const params = {
+            stringPound: encodeURIComponent('something&nothing=true'),
+            stringHash: encodeURIComponent('hash#data'),
+            stringArray: encodeURIComponent('where[4]=10'),
+            stringWeird: encodeURIComponent('properties["$email"] == "testing"'),
+            array: [
+              'something&nothing=true', // Should still encode this one eventhrough the others are already encoded.
+              encodeURIComponent('nothing&something=false'),
+              encodeURIComponent('another item'),
+            ],
+          };
+
+          const mock = nock('https://httpbin.org/')
+            .get('/anything')
+            .query(true)
+            .reply(200, function () {
+              return { path: this.req.path };
+            });
+
+          expect(await queryEncoding.fetch('/anything', 'get', undefined, params)).to.deep.equal({
+            path: '/anything?stringPound=something%26nothing%3Dtrue&stringHash=hash%23data&stringArray=where%5B4%5D%3D10&stringWeird=properties%5B%22%24email%22%5D%20%3D%3D%20%22testing%22&array=something%26nothing%3Dtrue&array=nothing%26something%3Dfalse&array=another%20item',
+          });
+
+          mock.done();
+        });
+      });
+    });
+  });
+
+  describe('#setUserAgent()', function () {
+    it('should contain a custom user agent for the library in requests', async function () {
+      const userAgent = 'customUserAgent 1.0';
+
+      const mock = nock('http://petstore.swagger.io/api', {
+        reqheaders: {
+          'User-Agent': userAgent,
+        },
+      })
+        .delete(`/pets/${petId}`)
+        .reply(200, function () {
+          return this.req.headers['user-agent'];
+        });
+
+      expect(
+        await petstore.setUserAgent(userAgent).fetch('/pets/{id}', 'delete', undefined, { id: petId })
+      ).to.deep.equal([userAgent]);
+      mock.done();
+    });
+  });
+
+  describe('#setAuth()', function () {
+    it('should pass along auth in the request', async function () {
+      const user = 'username';
+      const pass = 'changeme';
+
+      const authHeader = `Basic ${Buffer.from(`${user}:${pass}`).toString('base64')}`;
+      const mock = nock('https://httpbin.org')
+        .post('/basic')
+        .reply(200, function () {
+          return this.req.headers;
+        });
+
+      expect(await security.setAuth(user, pass).fetch('/basic', 'post')).to.have.deep.property('authorization', [
+        authHeader,
+      ]);
+      mock.done();
+    });
+  });
+
+  describe('#setServer()', function () {
+    it('should support supplying a full server url', async function () {
+      const mock = nock('https://buster.example.com:3000').post('/v14/').reply(200, response);
+
+      serverVariables.setServer('https://buster.example.com:3000/v14');
+
+      expect(await serverVariables.fetch('/', 'post')).to.deep.equal(response);
+      mock.done();
+    });
+
+    it('should support supplying a server url with server variables', async function () {
+      const mock = nock('http://dev.local/v14').post('/').reply(200, response);
+
+      serverVariables.setServer('http://{name}.local/{basePath}', {
+        name: 'dev',
+        basePath: 'v14',
+      });
+
+      expect(await serverVariables.fetch('/', 'post')).to.deep.equal(response);
+      mock.done();
+    });
+
+    it.skip('should be able to supply a url on an OAS that has no servers defined');
+
+    it.skip("should be able to supply a url that doesn't match any defined server");
+  });
+
+  describe('#setConfig', function () {
+    describe('parseResponse', function () {
+      it('should parse the response by default', async function () {
+        const mock = nock('http://petstore.swagger.io/api').delete(`/pets/${petId}`).reply(200, response);
+
+        petstore.setConfig({ parseResponse: true });
+
+        const res = await petstore.fetch('/pets/{id}', 'delete', undefined, { id: petId });
+        expect(res instanceof Response).to.be.false;
+        expect(res).to.deep.equal(response);
+        mock.done();
+      });
+
+      it('should give access to the Response object if `parseResponse` is `false`', async function () {
+        const mock = nock('http://petstore.swagger.io/api').delete(`/pets/${petId}`).reply(200, response);
+
+        petstore.setConfig({ parseResponse: false });
+
+        const res = await petstore.fetch('/pets/{id}', 'delete', undefined, { id: petId });
+        expect(res instanceof Response).to.be.true;
+        expect(res.status).to.equal(200);
+
+        expect(await res.json()).to.deep.equal(response);
+        mock.done();
+      });
+    });
+  });
+});

--- a/packages/api/test/dist.test.ts
+++ b/packages/api/test/dist.test.ts
@@ -6,6 +6,7 @@ import api from '../dist';
 import Cache from '../src/cache';
 
 import uspto from '@readme/oas-examples/3.0/json/uspto.json';
+import securityOas from '@readme/oas-examples/3.0/json/security.json';
 
 describe('typescript dist verification', function () {
   // eslint-disable-next-line mocha/no-setup-in-describe
@@ -24,6 +25,24 @@ describe('typescript dist verification', function () {
 
     expect(await sdk.post('/oa_citations/v1/records')).to.equal('/ds-api/oa_citations/v1/records');
 
+    mock.done();
+  });
+
+  it('should be able to set an auth token', async function () {
+    const user = 'username';
+    const pass = 'changeme';
+
+    const authHeader = `Basic ${Buffer.from(`${user}:${pass}`).toString('base64')}`;
+    const mock = nock('https://httpbin.org')
+      .post('/basic')
+      .reply(200, function () {
+        return this.req.headers;
+      });
+
+    const sdk = api(securityOas);
+
+    sdk.auth(user, pass);
+    expect(await sdk.post('/basic')).to.have.deep.property('authorization', [authHeader]);
     mock.done();
   });
 });

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -3,11 +3,10 @@
     "allowJs": true,
     "baseUrl": "./src",
     "declaration": true,
-    "declarationDir": "./@types",
     "esModuleInterop": true,
     "lib": ["dom", "es2020"],
     "noImplicitAny": true,
-    "outDir": "dist",
+    "outDir": "dist/",
     "paths": {
       // Because this library uses ES2015+ `#private` syntax that would require us to maket his
       // library ESM-only we're overloading its types with a `paths` config with this empty file.


### PR DESCRIPTION
## 🧰 Changes

This creates a new `APICore` class that can, and will, handle all API requests and fetching and parameter determination between `api` and the new codegen work.

This work was previously done in https://github.com/readmeio/api/pull/403 but as I'm decomissioning that branch I'm pulling the work there into `main` now.
