### PR TITLE
fix: quirk with node 16 and `response.clone()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## <small>4.2.1 (2022-03-18)</small>
+
+* fix: quirk with node 16 and `response.clone()` ([de8d964](https://github.com/readmeio/api/commit/de8d964))
+
+
+
 ## 4.2.0 (2022-01-03)
 
 * chore(deps-dev): bump @commitlint/cli from 15.0.0 to 16.0.1 (#372) ([2279bcf](https://github.com/readmeio/api/commit/2279bcf)), closes [#372](https://github.com/readmeio/api/issues/372)

--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "4.2.0"
+  "version": "4.2.1"
 }

--- a/packages/api/package-lock.json
+++ b/packages/api/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "Generate an SDK from an OpenAPI definition",
   "main": "src/index.js",
   "scripts": {

--- a/packages/api/src/lib/parseResponse.js
+++ b/packages/api/src/lib/parseResponse.js
@@ -6,18 +6,16 @@ const {
 
 module.exports = async function getResponseBody(response) {
   const contentType = response.headers.get('Content-Type');
-  const isJson = contentType && (matchesMimeType.json(contentType) || matchesMimeType.wildcard(contentType));
+  const isJSON = contentType && (matchesMimeType.json(contentType) || matchesMimeType.wildcard(contentType));
 
-  // We have to clone it before reading, just incase
-  // we cannot parse it as JSON later, then we can
-  // re-read again as plain text
-  const clonedResponse = response.clone();
-  let responseBody;
+  const responseBody = await response.text();
 
-  try {
-    responseBody = await response[isJson ? 'json' : 'text']();
-  } catch (e) {
-    responseBody = await clonedResponse.text();
+  if (isJSON) {
+    try {
+      return JSON.parse(responseBody);
+    } catch (e) {
+      // If our JSON parsing failed then we can just return plaintext instead.
+    }
   }
 
   return responseBody;


### PR DESCRIPTION
> Because `main` isn't ready to go out yet I've branched this change directly off the v4.2.0 release and will publish it from here and later backport this change into `main`.
>
> This PR should **not** merged after it's approved. 🚨 

## 🧰 Changes

We've found a quirk in how we're processing responses in Node 16 when making a successful API call where Node immediately kills the program without any errors or traces:

```js
const api = require('api')
const ashby = api('@ashby/v1.0#3hpc18l02t6450');
ashby.auth('APIKEY');

try {
  (async () => {
    await ashby.joblist({ status: ['Open', 'Closed', 'Archived'] }).then(console.log).catch(console.error)
  })();
} catch (err) {
  throw err;
}
```

We've narrowed this down to the `response.clone()` call in `parseResponse` where every time that line is called it pollutes the general `response` object that we have present and the program dies when we reach `await response.json()`.

Infuriatingly, we have tests for this case of if we can't process a non-JSON response with `.json()` to instead call `.text()` and this code, with the `.clone()` call, work all just fine on Node 16 in the isolated test case:

```js
const { Response } = require('node-fetch');
const parseResponse = require('./src/lib/parseResponse');

const invalidJsonResponse = new Response('plain text', {
  headers: {
    'Content-Type': 'application/json',
  },
});

(async () => {
  await parseResponse(invalidJsonResponse).then(console.log).catch(console.error);
})();
```

There's just something *different* about how it's run through the entire `api` flow that breaks it that we're unable to find so instead of trying to mess around with it I've slightly refactored the `parseResponse` library to never call `.clone()` instead, opting to run `JSON.parse()` through a try-catch if we think that the content is JSON.

It's not the best solution but hey it works.

## 🧬 QA & Testing

It's really hard to debug this because all the tests here have been, and still, pass, but if the code looks good to you then 👍 