### PR TITLE
fix: quirk with node 16 and `response.clone()`

### DIFF
--- a/packages/api/src/core/parseResponse.ts
+++ b/packages/api/src/core/parseResponse.ts
@@ -4,17 +4,16 @@ const { matchesMimeType } = utils;
 
 export default async function getResponseBody(response: Response) {
   const contentType = response.headers.get('Content-Type');
-  const isJson = contentType && (matchesMimeType.json(contentType) || matchesMimeType.wildcard(contentType));
+  const isJSON = contentType && (matchesMimeType.json(contentType) || matchesMimeType.wildcard(contentType));
 
-  // We have to clone it before reading, just incase we cannot parse it as JSON later, then we can
-  // re-read again as plain text.
-  const clonedResponse = response.clone();
-  let responseBody;
+  const responseBody = await response.text();
 
-  try {
-    responseBody = await response[isJson ? 'json' : 'text']();
-  } catch (e) {
-    responseBody = await clonedResponse.text();
+  if (isJSON) {
+    try {
+      return JSON.parse(responseBody);
+    } catch (e) {
+      // If our JSON parsing failed then we can just return plaintext instead.
+    }
   }
 
   return responseBody;


### PR DESCRIPTION
## 🧰 Changes

This is pulling over the work I did in https://github.com/readmeio/api/pull/418 into the `main` branch.

See https://github.com/readmeio/api/pull/418 more details.