### PR TITLE
feat: adding support for cookies in snippets

### DIFF
--- a/packages/httpsnippet-client-api/.eslintignore
+++ b/packages/httpsnippet-client-api/.eslintignore
@@ -1,3 +1,3 @@
 .nyc_output/
 node_modules/
-test/__datasets__/
+test/__datasets__/**/output.js

--- a/packages/httpsnippet-client-api/.prettierignore
+++ b/packages/httpsnippet-client-api/.prettierignore
@@ -1,2 +1,2 @@
 .nyc_output/
-test/__datasets__/
+test/__datasets__/**/output.js

--- a/packages/httpsnippet-client-api/package.json
+++ b/packages/httpsnippet-client-api/package.json
@@ -7,7 +7,8 @@
     "lint": "eslint .",
     "pretest": "npm run lint",
     "prettier": "prettier --list-different --write \"./**/**.js\"",
-    "test": "nyc mocha \"test/**/*.test.js\""
+    "test": "nyc mocha \"test/**/*.test.js\"",
+    "test:watch": "nyc mocha \"test/**/*.test.js\" --watch"
   },
   "repository": {
     "type": "git",

--- a/packages/httpsnippet-client-api/test/__datasets__/auth-apikey-cookie/har.json
+++ b/packages/httpsnippet-client-api/test/__datasets__/auth-apikey-cookie/har.json
@@ -1,0 +1,16 @@
+{
+  "log": {
+    "entries": [
+      {
+        "request": {
+          "cookies": [
+            { "name": "api_key", "value": "buster" }
+          ],
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "url": "https://httpbin.org/apiKey"
+        }
+      }
+    ]
+  }
+}

--- a/packages/httpsnippet-client-api/test/__datasets__/auth-apikey-cookie/openapi.js
+++ b/packages/httpsnippet-client-api/test/__datasets__/auth-apikey-cookie/openapi.js
@@ -1,0 +1,1 @@
+module.exports = require('@readme/oas-examples/3.0/json/security.json');

--- a/packages/httpsnippet-client-api/test/__datasets__/auth-apikey-cookie/output.js
+++ b/packages/httpsnippet-client-api/test/__datasets__/auth-apikey-cookie/output.js
@@ -1,5 +1,6 @@
 const sdk = require('api')('https://example.com/openapi.json');
 
-sdk.post('/anything', {bar: 'baz', foo: 'bar'})
+sdk.auth('buster');
+sdk.post('/apiKey')
   .then(res => console.log(res))
   .catch(err => console.error(err));

--- a/packages/httpsnippet-client-api/test/__datasets__/full-many-query-params/har.json
+++ b/packages/httpsnippet-client-api/test/__datasets__/full-many-query-params/har.json
@@ -32,11 +32,11 @@
           ],
           "cookies": [
             {
-              "name": "foo",
+              "name": "foo-cookie",
               "value": "bar"
             },
             {
-              "name": "bar",
+              "name": "bar-cookie",
               "value": "baz"
             }
           ],

--- a/packages/httpsnippet-client-api/test/__datasets__/full-many-query-params/output.js
+++ b/packages/httpsnippet-client-api/test/__datasets__/full-many-query-params/output.js
@@ -9,6 +9,8 @@ sdk.post('/anything', {
   foo: ['bar', 'baz'],
   baz: 'abc',
   key: 'value',
+  'bar-cookie': 'baz',
+  'foo-cookie': 'bar',
   accept: 'application/json'
 })
   .then(res => console.log(res))

--- a/packages/httpsnippet-client-api/test/__datasets__/full/har.json
+++ b/packages/httpsnippet-client-api/test/__datasets__/full/har.json
@@ -32,11 +32,11 @@
           ],
           "cookies": [
             {
-              "name": "foo",
+              "name": "foo-cookie",
               "value": "bar"
             },
             {
-              "name": "bar",
+              "name": "bar-cookie",
               "value": "baz"
             }
           ],

--- a/packages/httpsnippet-client-api/test/__datasets__/full/output.js
+++ b/packages/httpsnippet-client-api/test/__datasets__/full/output.js
@@ -4,6 +4,8 @@ sdk.post('/anything', {foo: 'bar'}, {
   foo: ['bar', 'baz'],
   baz: 'abc',
   key: 'value',
+  'bar-cookie': 'baz',
+  'foo-cookie': 'bar',
   accept: 'application/json'
 })
   .then(res => console.log(res))

--- a/packages/httpsnippet-client-api/test/index.test.js
+++ b/packages/httpsnippet-client-api/test/index.test.js
@@ -111,11 +111,6 @@ describe('httpsnippet-client-api', function () {
   describe('snippets', function () {
     SNIPPETS.forEach(snippet => {
       it(`should generate \`${snippet}\` snippet`, async function () {
-        // Cookies test needs to get built out.
-        if (snippet === 'cookies') {
-          this.skip();
-        }
-
         const [har, definition] = await getSnippetDataset(snippet);
         const expected = await fs.readFile(path.join(DATASETS_DIR, snippet, 'output.js'), 'utf-8');
 


### PR DESCRIPTION
| 🚥 Fix RM-3946 |
| :-- |

## 🧰 Changes

This adds support for both cookie auth and cookie parameters in `api` snippets. This work was previously added to `api` in #393 but, contrary to what that PR says, snippets have never supported it.

## 🧬 QA & Testing

* [ ] See the test I added for cookie auth.
* [ ] I uncommented and fixed the existing cookie parameter test we had and that's passing now.