### PR TITLE
perf: codegen performance improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1689,12 +1689,6 @@
         "@types/unist": "*"
       }
     },
-    "node_modules/@types/memoizee": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/@types/memoizee/-/memoizee-0.4.7.tgz",
-      "integrity": "sha512-EMtvWnRC/W0KYmXxbPJAMg/M1OXkFboSpd/IzkNMDXfoFPE4uom1RHFl8q7m/4R0y9eG1yaoaIPiMHk0vMA0eA==",
-      "dev": true
-    },
     "node_modules/@types/minimatch": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
@@ -1736,6 +1730,12 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
+      "dev": true
+    },
+    "node_modules/@types/object-hash": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@types/object-hash/-/object-hash-2.2.1.tgz",
+      "integrity": "sha512-i/rtaJFCsPljrZvP/akBqEwUP2y5cZLOmvO+JaYnz01aPknrQ+hB5MRcO7iqCUsFaYfTG8kGfKUyboA07xeDHQ==",
       "dev": true
     },
     "node_modules/@types/parse-json": {
@@ -9415,9 +9415,9 @@
       }
     },
     "node_modules/oas": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-18.1.0.tgz",
-      "integrity": "sha512-p1R6NnOFCnorHm6b6Sz+DuxpmYHLUBfsFQ9k9IkJkQagYpWmRNmsHHExNolqTFans1Nue+B8Fzzo+BMQSzDNCA==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-18.2.0.tgz",
+      "integrity": "sha512-Zpn3rLWiJa0ATxPAXe3ec8bLEIKeblGTpcpBT6/aAp64O2VM9QSVR28V4ab6DkVgDRUm2oDP2+WYIVzd3exsBw==",
       "dependencies": {
         "@readme/json-schema-ref-parser": "^1.1.0",
         "@types/json-schema": "^7.0.11",
@@ -9527,6 +9527,14 @@
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/object-inspect": {
@@ -13081,8 +13089,8 @@
         "json-schema-traverse": "^1.0.0",
         "lodash.merge": "^4.6.2",
         "make-dir": "^3.1.0",
-        "memoizee": "^0.4.15",
-        "oas": "^18.1.0",
+        "oas": "^18.2.0",
+        "object-hash": "^3.0.0",
         "ts-morph": "^14.0.0"
       },
       "devDependencies": {
@@ -13092,8 +13100,8 @@
         "@types/find-cache-dir": "^3.2.1",
         "@types/js-yaml": "^4.0.5",
         "@types/lodash.merge": "^4.6.6",
-        "@types/memoizee": "^0.4.7",
         "@types/mocha": "^9.1.0",
+        "@types/object-hash": "^2.2.1",
         "chai": "^4.3.6",
         "eslint": "^8.10.0",
         "mocha": "^9.2.1",
@@ -14491,12 +14499,6 @@
         "@types/unist": "*"
       }
     },
-    "@types/memoizee": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/@types/memoizee/-/memoizee-0.4.7.tgz",
-      "integrity": "sha512-EMtvWnRC/W0KYmXxbPJAMg/M1OXkFboSpd/IzkNMDXfoFPE4uom1RHFl8q7m/4R0y9eG1yaoaIPiMHk0vMA0eA==",
-      "dev": true
-    },
     "@types/minimatch": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
@@ -14538,6 +14540,12 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
+      "dev": true
+    },
+    "@types/object-hash": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@types/object-hash/-/object-hash-2.2.1.tgz",
+      "integrity": "sha512-i/rtaJFCsPljrZvP/akBqEwUP2y5cZLOmvO+JaYnz01aPknrQ+hB5MRcO7iqCUsFaYfTG8kGfKUyboA07xeDHQ==",
       "dev": true
     },
     "@types/parse-json": {
@@ -14934,8 +14942,8 @@
         "@types/find-cache-dir": "^3.2.1",
         "@types/js-yaml": "^4.0.5",
         "@types/lodash.merge": "^4.6.6",
-        "@types/memoizee": "^0.4.7",
         "@types/mocha": "^9.1.0",
+        "@types/object-hash": "^2.2.1",
         "chai": "^4.3.6",
         "datauri": "^4.1.0",
         "eslint": "^8.10.0",
@@ -14950,13 +14958,13 @@
         "json-schema-traverse": "^1.0.0",
         "lodash.merge": "^4.6.2",
         "make-dir": "^3.1.0",
-        "memoizee": "^0.4.15",
         "mocha": "^9.2.1",
         "mocha-chai-jest-snapshot": "^1.1.3",
         "mock-require": "^3.0.3",
         "nock": "^13.2.4",
         "nyc": "^15.1.0",
-        "oas": "^18.1.0",
+        "oas": "^18.2.0",
+        "object-hash": "^3.0.0",
         "prettier": "^2.5.1",
         "ts-morph": "^14.0.0",
         "typescript": "^4.6.2",
@@ -20172,9 +20180,9 @@
       }
     },
     "oas": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-18.1.0.tgz",
-      "integrity": "sha512-p1R6NnOFCnorHm6b6Sz+DuxpmYHLUBfsFQ9k9IkJkQagYpWmRNmsHHExNolqTFans1Nue+B8Fzzo+BMQSzDNCA==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-18.2.0.tgz",
+      "integrity": "sha512-Zpn3rLWiJa0ATxPAXe3ec8bLEIKeblGTpcpBT6/aAp64O2VM9QSVR28V4ab6DkVgDRUm2oDP2+WYIVzd3exsBw==",
       "requires": {
         "@readme/json-schema-ref-parser": "^1.1.0",
         "@types/json-schema": "^7.0.11",
@@ -20258,6 +20266,11 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw=="
     },
     "object-inspect": {
       "version": "1.12.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9415,9 +9415,9 @@
       }
     },
     "node_modules/oas": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-18.2.0.tgz",
-      "integrity": "sha512-Zpn3rLWiJa0ATxPAXe3ec8bLEIKeblGTpcpBT6/aAp64O2VM9QSVR28V4ab6DkVgDRUm2oDP2+WYIVzd3exsBw==",
+      "version": "18.2.1",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-18.2.1.tgz",
+      "integrity": "sha512-SE/OCOy7leB68y1tyGqnHigMf+DFtvY1kHDwEYUnozeRjKzgEj4DcykCIzk4tIzd4Qnp0gJxt67SjCI4uzYj2g==",
       "dependencies": {
         "@readme/json-schema-ref-parser": "^1.1.0",
         "@types/json-schema": "^7.0.11",
@@ -13089,7 +13089,7 @@
         "json-schema-traverse": "^1.0.0",
         "lodash.merge": "^4.6.2",
         "make-dir": "^3.1.0",
-        "oas": "^18.2.0",
+        "oas": "^18.2.1",
         "object-hash": "^3.0.0",
         "ts-morph": "^14.0.0"
       },
@@ -14963,7 +14963,7 @@
         "mock-require": "^3.0.3",
         "nock": "^13.2.4",
         "nyc": "^15.1.0",
-        "oas": "^18.2.0",
+        "oas": "^18.2.1",
         "object-hash": "^3.0.0",
         "prettier": "^2.5.1",
         "ts-morph": "^14.0.0",
@@ -20180,9 +20180,9 @@
       }
     },
     "oas": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-18.2.0.tgz",
-      "integrity": "sha512-Zpn3rLWiJa0ATxPAXe3ec8bLEIKeblGTpcpBT6/aAp64O2VM9QSVR28V4ab6DkVgDRUm2oDP2+WYIVzd3exsBw==",
+      "version": "18.2.1",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-18.2.1.tgz",
+      "integrity": "sha512-SE/OCOy7leB68y1tyGqnHigMf+DFtvY1kHDwEYUnozeRjKzgEj4DcykCIzk4tIzd4Qnp0gJxt67SjCI4uzYj2g==",
       "requires": {
         "@readme/json-schema-ref-parser": "^1.1.0",
         "@types/json-schema": "^7.0.11",

--- a/packages/api/.mocharc.json
+++ b/packages/api/.mocharc.json
@@ -9,5 +9,5 @@
   "watch-files": ["src/**/*.ts", "test/**/*.ts"],
   "recursive": true,
   "reporter": "spec",
-  "timeout": 60000
+  "timeout": 200000
 }

--- a/packages/api/package-lock.json
+++ b/packages/api/package-lock.json
@@ -23,7 +23,7 @@
         "json-schema-traverse": "^1.0.0",
         "lodash.merge": "^4.6.2",
         "make-dir": "^3.1.0",
-        "oas": "^18.2.0",
+        "oas": "^18.2.1",
         "object-hash": "^3.0.0",
         "ts-morph": "^14.0.0"
       },
@@ -6997,9 +6997,9 @@
       }
     },
     "node_modules/oas": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-18.2.0.tgz",
-      "integrity": "sha512-Zpn3rLWiJa0ATxPAXe3ec8bLEIKeblGTpcpBT6/aAp64O2VM9QSVR28V4ab6DkVgDRUm2oDP2+WYIVzd3exsBw==",
+      "version": "18.2.1",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-18.2.1.tgz",
+      "integrity": "sha512-SE/OCOy7leB68y1tyGqnHigMf+DFtvY1kHDwEYUnozeRjKzgEj4DcykCIzk4tIzd4Qnp0gJxt67SjCI4uzYj2g==",
       "dependencies": {
         "@readme/json-schema-ref-parser": "^1.1.0",
         "@types/json-schema": "^7.0.11",
@@ -14108,9 +14108,9 @@
       }
     },
     "oas": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-18.2.0.tgz",
-      "integrity": "sha512-Zpn3rLWiJa0ATxPAXe3ec8bLEIKeblGTpcpBT6/aAp64O2VM9QSVR28V4ab6DkVgDRUm2oDP2+WYIVzd3exsBw==",
+      "version": "18.2.1",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-18.2.1.tgz",
+      "integrity": "sha512-SE/OCOy7leB68y1tyGqnHigMf+DFtvY1kHDwEYUnozeRjKzgEj4DcykCIzk4tIzd4Qnp0gJxt67SjCI4uzYj2g==",
       "requires": {
         "@readme/json-schema-ref-parser": "^1.1.0",
         "@types/json-schema": "^7.0.11",

--- a/packages/api/package-lock.json
+++ b/packages/api/package-lock.json
@@ -23,8 +23,8 @@
         "json-schema-traverse": "^1.0.0",
         "lodash.merge": "^4.6.2",
         "make-dir": "^3.1.0",
-        "memoizee": "^0.4.15",
-        "oas": "^18.1.0",
+        "oas": "^18.2.0",
+        "object-hash": "^3.0.0",
         "ts-morph": "^14.0.0"
       },
       "devDependencies": {
@@ -34,8 +34,8 @@
         "@types/find-cache-dir": "^3.2.1",
         "@types/js-yaml": "^4.0.5",
         "@types/lodash.merge": "^4.6.6",
-        "@types/memoizee": "^0.4.7",
         "@types/mocha": "^9.1.0",
+        "@types/object-hash": "^2.2.1",
         "chai": "^4.3.6",
         "eslint": "^8.10.0",
         "mocha": "^9.2.1",
@@ -1453,12 +1453,6 @@
         "@types/lodash": "*"
       }
     },
-    "node_modules/@types/memoizee": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/@types/memoizee/-/memoizee-0.4.7.tgz",
-      "integrity": "sha512-EMtvWnRC/W0KYmXxbPJAMg/M1OXkFboSpd/IzkNMDXfoFPE4uom1RHFl8q7m/4R0y9eG1yaoaIPiMHk0vMA0eA==",
-      "dev": true
-    },
     "node_modules/@types/minimatch": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
@@ -1479,6 +1473,12 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
+      "dev": true
+    },
+    "node_modules/@types/object-hash": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@types/object-hash/-/object-hash-2.2.1.tgz",
+      "integrity": "sha512-i/rtaJFCsPljrZvP/akBqEwUP2y5cZLOmvO+JaYnz01aPknrQ+hB5MRcO7iqCUsFaYfTG8kGfKUyboA07xeDHQ==",
       "dev": true
     },
     "node_modules/@types/prettier": {
@@ -6997,9 +6997,9 @@
       }
     },
     "node_modules/oas": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-18.1.0.tgz",
-      "integrity": "sha512-p1R6NnOFCnorHm6b6Sz+DuxpmYHLUBfsFQ9k9IkJkQagYpWmRNmsHHExNolqTFans1Nue+B8Fzzo+BMQSzDNCA==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-18.2.0.tgz",
+      "integrity": "sha512-Zpn3rLWiJa0ATxPAXe3ec8bLEIKeblGTpcpBT6/aAp64O2VM9QSVR28V4ab6DkVgDRUm2oDP2+WYIVzd3exsBw==",
       "dependencies": {
         "@readme/json-schema-ref-parser": "^1.1.0",
         "@types/json-schema": "^7.0.11",
@@ -7198,6 +7198,14 @@
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/object-inspect": {
@@ -10056,12 +10064,6 @@
         "@types/lodash": "*"
       }
     },
-    "@types/memoizee": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/@types/memoizee/-/memoizee-0.4.7.tgz",
-      "integrity": "sha512-EMtvWnRC/W0KYmXxbPJAMg/M1OXkFboSpd/IzkNMDXfoFPE4uom1RHFl8q7m/4R0y9eG1yaoaIPiMHk0vMA0eA==",
-      "dev": true
-    },
     "@types/minimatch": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
@@ -10082,6 +10084,12 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
+      "dev": true
+    },
+    "@types/object-hash": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@types/object-hash/-/object-hash-2.2.1.tgz",
+      "integrity": "sha512-i/rtaJFCsPljrZvP/akBqEwUP2y5cZLOmvO+JaYnz01aPknrQ+hB5MRcO7iqCUsFaYfTG8kGfKUyboA07xeDHQ==",
       "dev": true
     },
     "@types/prettier": {
@@ -14100,9 +14108,9 @@
       }
     },
     "oas": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-18.1.0.tgz",
-      "integrity": "sha512-p1R6NnOFCnorHm6b6Sz+DuxpmYHLUBfsFQ9k9IkJkQagYpWmRNmsHHExNolqTFans1Nue+B8Fzzo+BMQSzDNCA==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-18.2.0.tgz",
+      "integrity": "sha512-Zpn3rLWiJa0ATxPAXe3ec8bLEIKeblGTpcpBT6/aAp64O2VM9QSVR28V4ab6DkVgDRUm2oDP2+WYIVzd3exsBw==",
       "requires": {
         "@readme/json-schema-ref-parser": "^1.1.0",
         "@types/json-schema": "^7.0.11",
@@ -14252,6 +14260,11 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw=="
     },
     "object-inspect": {
       "version": "1.11.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -43,8 +43,8 @@
     "json-schema-traverse": "^1.0.0",
     "lodash.merge": "^4.6.2",
     "make-dir": "^3.1.0",
-    "memoizee": "^0.4.15",
-    "oas": "^18.1.0",
+    "oas": "^18.2.0",
+    "object-hash": "^3.0.0",
     "ts-morph": "^14.0.0"
   },
   "devDependencies": {
@@ -54,8 +54,8 @@
     "@types/find-cache-dir": "^3.2.1",
     "@types/js-yaml": "^4.0.5",
     "@types/lodash.merge": "^4.6.6",
-    "@types/memoizee": "^0.4.7",
     "@types/mocha": "^9.1.0",
+    "@types/object-hash": "^2.2.1",
     "chai": "^4.3.6",
     "eslint": "^8.10.0",
     "mocha": "^9.2.1",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -43,7 +43,7 @@
     "json-schema-traverse": "^1.0.0",
     "lodash.merge": "^4.6.2",
     "make-dir": "^3.1.0",
-    "oas": "^18.2.0",
+    "oas": "^18.2.1",
     "object-hash": "^3.0.0",
     "ts-morph": "^14.0.0"
   },

--- a/packages/api/test/__fixtures__/sdk/petstore/index.ts
+++ b/packages/api/test/__fixtures__/sdk/petstore/index.ts
@@ -91,6 +91,21 @@ export default class SDK {
    */
   post<T = unknown>(path: string, metadata: UpdatePetWithFormMetadataParam): Promise<T>;
   /**
+   * Uploads an image
+   *
+   */
+  post(path: string, body: UploadFileBodyParam, metadata: UploadFileMetadataParam): Promise<ApiResponse>;
+  /**
+   * Uploads an image
+   *
+   */
+  post(path: string, metadata: UploadFileMetadataParam): Promise<ApiResponse>;
+  /**
+   * Place an order for a pet
+   *
+   */
+  post(path: string, body: Order): Promise<Order>;
+  /**
    * This can only be done by the logged in user.
    *
    * @summary Create user
@@ -106,21 +121,6 @@ export default class SDK {
    *
    */
   post<T = unknown>(path: string, body: CreateUsersWithListInputBodyParam): Promise<T>;
-  /**
-   * Uploads an image
-   *
-   */
-  post(path: string, body: UploadFileBodyParam, metadata: UploadFileMetadataParam): Promise<ApiResponse>;
-  /**
-   * Uploads an image
-   *
-   */
-  post(path: string, metadata: UploadFileMetadataParam): Promise<ApiResponse>;
-  /**
-   * Place an order for a pet
-   *
-   */
-  post(path: string, body: Order): Promise<Order>;
   /**
    * Access any post endpoint on your API.
    *
@@ -155,17 +155,6 @@ export default class SDK {
   }
 
   /**
-   * Logs out current logged in user session
-   *
-   */
-  get<T = unknown>(path: string): Promise<T>;
-  /**
-   * Returns a map of status codes to quantities
-   *
-   * @summary Returns pet inventories by status
-   */
-  get(path: string): Promise<GetInventory_Response_200>;
-  /**
    * Multiple status values can be provided with comma separated strings
    *
    * @summary Finds Pets by status
@@ -184,6 +173,12 @@ export default class SDK {
    */
   get(path: string, metadata: GetPetByIdMetadataParam): Promise<Pet>;
   /**
+   * Returns a map of status codes to quantities
+   *
+   * @summary Returns pet inventories by status
+   */
+  get(path: string): Promise<GetInventory_Response_200>;
+  /**
    * For valid response try integer IDs with value >= 1 and <= 10. Other values will generated exceptions
    *
    * @summary Find purchase order by ID
@@ -194,6 +189,11 @@ export default class SDK {
    *
    */
   get(path: string, metadata: LoginUserMetadataParam): Promise<LoginUser_Response_200>;
+  /**
+   * Logs out current logged in user session
+   *
+   */
+  get<T = unknown>(path: string): Promise<T>;
   /**
    * Get user by user name
    *
@@ -238,23 +238,6 @@ export default class SDK {
   }
 
   /**
-   * Logs out current logged in user session
-   *
-   */
-  logoutUser<T = unknown>(): Promise<T> {
-    return this.core.fetch('/user/logout', 'get');
-  }
-
-  /**
-   * Returns a map of status codes to quantities
-   *
-   * @summary Returns pet inventories by status
-   */
-  getInventory(): Promise<GetInventory_Response_200> {
-    return this.core.fetch('/store/inventory', 'get');
-  }
-
-  /**
    * Add a new pet to the store
    *
    */
@@ -268,6 +251,33 @@ export default class SDK {
    */
   updatePet<T = unknown>(body: Pet): Promise<T> {
     return this.core.fetch('/pet', 'put', body);
+  }
+
+  /**
+   * Multiple status values can be provided with comma separated strings
+   *
+   * @summary Finds Pets by status
+   */
+  findPetsByStatus(metadata: FindPetsByStatusMetadataParam): Promise<FindPetsByStatus_Response_200> {
+    return this.core.fetch('/pet/findByStatus', 'get', metadata);
+  }
+
+  /**
+   * Muliple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+   *
+   * @summary Finds Pets by tags
+   */
+  findPetsByTags(metadata: FindPetsByTagsMetadataParam): Promise<FindPetsByTags_Response_200> {
+    return this.core.fetch('/pet/findByTags', 'get', metadata);
+  }
+
+  /**
+   * Returns a single pet
+   *
+   * @summary Find pet by ID
+   */
+  getPetById(metadata: GetPetByIdMetadataParam): Promise<Pet> {
+    return this.core.fetch('/pet/{petId}', 'get', metadata);
   }
 
   /**
@@ -300,6 +310,50 @@ export default class SDK {
    */
   deletePet<T = unknown>(metadata: DeletePetMetadataParam): Promise<T> {
     return this.core.fetch('/pet/{petId}', 'delete', metadata);
+  }
+
+  /**
+   * Uploads an image
+   *
+   */
+  uploadFile(body: UploadFileBodyParam, metadata: UploadFileMetadataParam): Promise<ApiResponse>;
+  /**
+   * Uploads an image
+   *
+   */
+  uploadFile(metadata: UploadFileMetadataParam): Promise<ApiResponse>;
+  /**
+   * Uploads an image
+   *
+   */
+  uploadFile(body?: UploadFileBodyParam, metadata?: UploadFileMetadataParam): Promise<ApiResponse> {
+    return this.core.fetch('/pet/{petId}/uploadImage', 'post', body, metadata);
+  }
+
+  /**
+   * Returns a map of status codes to quantities
+   *
+   * @summary Returns pet inventories by status
+   */
+  getInventory(): Promise<GetInventory_Response_200> {
+    return this.core.fetch('/store/inventory', 'get');
+  }
+
+  /**
+   * Place an order for a pet
+   *
+   */
+  placeOrder(body: Order): Promise<Order> {
+    return this.core.fetch('/store/order', 'post', body);
+  }
+
+  /**
+   * For valid response try integer IDs with value >= 1 and <= 10. Other values will generated exceptions
+   *
+   * @summary Find purchase order by ID
+   */
+  getOrderById(metadata: GetOrderByIdMetadataParam): Promise<Order> {
+    return this.core.fetch('/store/order/{orderId}', 'get', metadata);
   }
 
   /**
@@ -337,6 +391,30 @@ export default class SDK {
   }
 
   /**
+   * Logs user into the system
+   *
+   */
+  loginUser(metadata: LoginUserMetadataParam): Promise<LoginUser_Response_200> {
+    return this.core.fetch('/user/login', 'get', metadata);
+  }
+
+  /**
+   * Logs out current logged in user session
+   *
+   */
+  logoutUser<T = unknown>(): Promise<T> {
+    return this.core.fetch('/user/logout', 'get');
+  }
+
+  /**
+   * Get user by user name
+   *
+   */
+  getUserByName(metadata: GetUserByNameMetadataParam): Promise<User> {
+    return this.core.fetch('/user/{username}', 'get', metadata);
+  }
+
+  /**
    * This can only be done by the logged in user.
    *
    * @summary Updated user
@@ -352,84 +430,6 @@ export default class SDK {
    */
   deleteUser<T = unknown>(metadata: DeleteUserMetadataParam): Promise<T> {
     return this.core.fetch('/user/{username}', 'delete', metadata);
-  }
-
-  /**
-   * Multiple status values can be provided with comma separated strings
-   *
-   * @summary Finds Pets by status
-   */
-  findPetsByStatus(metadata: FindPetsByStatusMetadataParam): Promise<FindPetsByStatus_Response_200> {
-    return this.core.fetch('/pet/findByStatus', 'get', metadata);
-  }
-
-  /**
-   * Muliple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
-   *
-   * @summary Finds Pets by tags
-   */
-  findPetsByTags(metadata: FindPetsByTagsMetadataParam): Promise<FindPetsByTags_Response_200> {
-    return this.core.fetch('/pet/findByTags', 'get', metadata);
-  }
-
-  /**
-   * Returns a single pet
-   *
-   * @summary Find pet by ID
-   */
-  getPetById(metadata: GetPetByIdMetadataParam): Promise<Pet> {
-    return this.core.fetch('/pet/{petId}', 'get', metadata);
-  }
-
-  /**
-   * Uploads an image
-   *
-   */
-  uploadFile(body: UploadFileBodyParam, metadata: UploadFileMetadataParam): Promise<ApiResponse>;
-  /**
-   * Uploads an image
-   *
-   */
-  uploadFile(metadata: UploadFileMetadataParam): Promise<ApiResponse>;
-  /**
-   * Uploads an image
-   *
-   */
-  uploadFile(body?: UploadFileBodyParam, metadata?: UploadFileMetadataParam): Promise<ApiResponse> {
-    return this.core.fetch('/pet/{petId}/uploadImage', 'post', body, metadata);
-  }
-
-  /**
-   * Place an order for a pet
-   *
-   */
-  placeOrder(body: Order): Promise<Order> {
-    return this.core.fetch('/store/order', 'post', body);
-  }
-
-  /**
-   * For valid response try integer IDs with value >= 1 and <= 10. Other values will generated exceptions
-   *
-   * @summary Find purchase order by ID
-   */
-  getOrderById(metadata: GetOrderByIdMetadataParam): Promise<Order> {
-    return this.core.fetch('/store/order/{orderId}', 'get', metadata);
-  }
-
-  /**
-   * Logs user into the system
-   *
-   */
-  loginUser(metadata: LoginUserMetadataParam): Promise<LoginUser_Response_200> {
-    return this.core.fetch('/user/login', 'get', metadata);
-  }
-
-  /**
-   * Get user by user name
-   *
-   */
-  getUserByName(metadata: GetUserByNameMetadataParam): Promise<User> {
-    return this.core.fetch('/user/{username}', 'get', metadata);
   }
 }
 
@@ -469,6 +469,7 @@ export type FindPetsByStatusMetadataParam = {
   status: ('available' | 'pending' | 'sold')[];
   [k: string]: unknown;
 };
+export type FindPetsByStatus_Response_200 = Pet[];
 export type FindPetsByTagsMetadataParam = {
   /**
    * Tags to filter by
@@ -476,6 +477,7 @@ export type FindPetsByTagsMetadataParam = {
   tags: string[];
   [k: string]: unknown;
 };
+export type FindPetsByTags_Response_200 = Pet[];
 export type GetPetByIdMetadataParam = {
   /**
    * ID of pet to return
@@ -529,6 +531,12 @@ export type UploadFileMetadataParam = {
   petId: number;
   [k: string]: unknown;
 };
+export interface ApiResponse {
+  code?: number;
+  type?: string;
+  message?: string;
+  [k: string]: unknown;
+}
 export interface GetInventory_Response_200 {
   [k: string]: number;
 }
@@ -585,6 +593,7 @@ export type LoginUserMetadataParam = {
   password: string;
   [k: string]: unknown;
 };
+export type LoginUser_Response_200 = string;
 export type GetUserByNameMetadataParam = {
   /**
    * The name that needs to be fetched. Use user1 for testing.
@@ -606,12 +615,3 @@ export type DeleteUserMetadataParam = {
   username: string;
   [k: string]: unknown;
 };
-export type FindPetsByStatus_Response_200 = Pet[];
-export type FindPetsByTags_Response_200 = Pet[];
-export interface ApiResponse {
-  code?: number;
-  type?: string;
-  message?: string;
-  [k: string]: unknown;
-}
-export type LoginUser_Response_200 = string;

--- a/packages/api/test/__fixtures__/sdk/readme/index.ts
+++ b/packages/api/test/__fixtures__/sdk/readme/index.ts
@@ -72,36 +72,6 @@ export default class SDK {
   }
 
   /**
-   * Returns all the roles we're hiring for at ReadMe!
-   *
-   * @summary Get open roles
-   */
-  get(path: string): Promise<GetOpenRoles_Response_200>;
-  /**
-   * Returns with all of the error page types for this project
-   *
-   * @summary Get errors
-   */
-  get(path: string): Promise<GetErrors_Response_401 | GetErrors_Response_403>;
-  /**
-   * Returns project data for API key
-   *
-   * @summary Get metadata about the current project
-   */
-  get(path: string): Promise<CondensedProjectData | GetProject_Response_401 | GetProject_Response_403>;
-  /**
-   * Retrieve a list of versions associated with a project API key
-   *
-   * @summary Get versions
-   */
-  get(path: string): Promise<GetVersions_Response_401 | GetVersions_Response_403>;
-  /**
-   * Returns the changelog with this slug
-   *
-   * @summary Get changelog
-   */
-  get<T = unknown>(path: string, metadata: GetChangelogMetadataParam): Promise<T>;
-  /**
    * Get an API definition file that's been uploaded to ReadMe
    *
    * @summary Retrieve an entry from the API Registry
@@ -126,6 +96,12 @@ export default class SDK {
     | Error_VERSION_NOTFOUND
   >;
   /**
+   * Returns all the roles we're hiring for at ReadMe!
+   *
+   * @summary Get open roles
+   */
+  get(path: string): Promise<GetOpenRoles_Response_200>;
+  /**
    * Returns all the categories for a specified version
    *
    * @summary Get all categories
@@ -149,6 +125,12 @@ export default class SDK {
    * @summary Get changelogs
    */
   get(path: string, metadata?: GetChangelogsMetadataParam): Promise<GetChangelogs_Response_200>;
+  /**
+   * Returns the changelog with this slug
+   *
+   * @summary Get changelog
+   */
+  get<T = unknown>(path: string, metadata: GetChangelogMetadataParam): Promise<T>;
   /**
    * Returns a list of custom pages associated with the project API key
    *
@@ -177,6 +159,24 @@ export default class SDK {
     metadata: GetDocMetadataParam
   ): Promise<GetDoc_Response_401 | GetDoc_Response_403 | Error_DOC_NOTFOUND>;
   /**
+   * Returns with all of the error page types for this project
+   *
+   * @summary Get errors
+   */
+  get(path: string): Promise<GetErrors_Response_401 | GetErrors_Response_403>;
+  /**
+   * Returns project data for API key
+   *
+   * @summary Get metadata about the current project
+   */
+  get(path: string): Promise<CondensedProjectData | GetProject_Response_401 | GetProject_Response_403>;
+  /**
+   * Retrieve a list of versions associated with a project API key
+   *
+   * @summary Get versions
+   */
+  get(path: string): Promise<GetVersions_Response_401 | GetVersions_Response_403>;
+  /**
    * Returns the version with this version ID
    *
    * @summary Get version
@@ -196,18 +196,6 @@ export default class SDK {
   }
 
   /**
-   * This endpoint will let you apply to a job at ReadMe programatically, without having to go through our UI!
-   *
-   * @summary Submit your application!
-   */
-  post<T = unknown>(path: string, body: Apply): Promise<T>;
-  /**
-   * Create a new changelog inside of this project
-   *
-   * @summary Create changelog
-   */
-  post<T = unknown>(path: string, body: Changelog): Promise<T>;
-  /**
    * Upload an API specification to ReadMe. Or, to use a newer solution see https://docs.readme.com/docs/automatically-sync-api-specification-with-github
    *
    * @summary Upload specification
@@ -223,11 +211,23 @@ export default class SDK {
     | Error_SPEC_TIMEOUT
   >;
   /**
+   * This endpoint will let you apply to a job at ReadMe programatically, without having to go through our UI!
+   *
+   * @summary Submit your application!
+   */
+  post<T = unknown>(path: string, body: Apply): Promise<T>;
+  /**
    * Create a new category inside of this project
    *
    * @summary Create category
    */
   post(path: string, body: Category, metadata?: CreateCategoryMetadataParam): Promise<Error_CATEGORY_INVALID>;
+  /**
+   * Create a new changelog inside of this project
+   *
+   * @summary Create changelog
+   */
+  post<T = unknown>(path: string, body: Changelog): Promise<T>;
   /**
    * Create a new custom page inside of this project
    *
@@ -276,12 +276,6 @@ export default class SDK {
   }
 
   /**
-   * Update a changelog with this slug
-   *
-   * @summary Update changelog
-   */
-  put<T = unknown>(path: string, body: Changelog, metadata: UpdateChangelogMetadataParam): Promise<T>;
-  /**
    * Update an API specification in ReadMe
    *
    * @summary Update specification
@@ -306,6 +300,12 @@ export default class SDK {
     body: Category,
     metadata: UpdateCategoryMetadataParam
   ): Promise<Error_CATEGORY_INVALID | Error_CATEGORY_NOTFOUND>;
+  /**
+   * Update a changelog with this slug
+   *
+   * @summary Update changelog
+   */
+  put<T = unknown>(path: string, body: Changelog, metadata: UpdateChangelogMetadataParam): Promise<T>;
   /**
    * Update a custom page with this slug
    *
@@ -352,12 +352,6 @@ export default class SDK {
   }
 
   /**
-   * Delete the changelog with this slug
-   *
-   * @summary Delete changelog
-   */
-  delete<T = unknown>(path: string, metadata: DeleteChangelogMetadataParam): Promise<T>;
-  /**
    * Delete an API specification in ReadMe
    *
    * @summary Delete specification
@@ -379,6 +373,12 @@ export default class SDK {
    * @summary Delete category
    */
   delete(path: string, metadata: DeleteCategoryMetadataParam): Promise<Error_CATEGORY_NOTFOUND>;
+  /**
+   * Delete the changelog with this slug
+   *
+   * @summary Delete changelog
+   */
+  delete<T = unknown>(path: string, metadata: DeleteChangelogMetadataParam): Promise<T>;
   /**
    * Delete the custom page with this slug
    *
@@ -417,87 +417,6 @@ export default class SDK {
    */
   delete<T = unknown>(path: string, body?: unknown, metadata?: Record<string, unknown>): Promise<T> {
     return this.core.fetch(path, 'delete', body, metadata);
-  }
-
-  /**
-   * Returns all the roles we're hiring for at ReadMe!
-   *
-   * @summary Get open roles
-   */
-  getOpenRoles(): Promise<GetOpenRoles_Response_200> {
-    return this.core.fetch('/apply', 'get');
-  }
-
-  /**
-   * Returns with all of the error page types for this project
-   *
-   * @summary Get errors
-   */
-  getErrors(): Promise<GetErrors_Response_401 | GetErrors_Response_403> {
-    return this.core.fetch('/errors', 'get');
-  }
-
-  /**
-   * Returns project data for API key
-   *
-   * @summary Get metadata about the current project
-   */
-  getProject(): Promise<CondensedProjectData | GetProject_Response_401 | GetProject_Response_403> {
-    return this.core.fetch('/', 'get');
-  }
-
-  /**
-   * Retrieve a list of versions associated with a project API key
-   *
-   * @summary Get versions
-   */
-  getVersions(): Promise<GetVersions_Response_401 | GetVersions_Response_403> {
-    return this.core.fetch('/version', 'get');
-  }
-
-  /**
-   * This endpoint will let you apply to a job at ReadMe programatically, without having to go through our UI!
-   *
-   * @summary Submit your application!
-   */
-  applyToReadMe<T = unknown>(body: Apply): Promise<T> {
-    return this.core.fetch('/apply', 'post', body);
-  }
-
-  /**
-   * Create a new changelog inside of this project
-   *
-   * @summary Create changelog
-   */
-  createChangelog<T = unknown>(body: Changelog): Promise<T> {
-    return this.core.fetch('/changelogs', 'post', body);
-  }
-
-  /**
-   * Returns the changelog with this slug
-   *
-   * @summary Get changelog
-   */
-  getChangelog<T = unknown>(metadata: GetChangelogMetadataParam): Promise<T> {
-    return this.core.fetch('/changelogs/{slug}', 'get', metadata);
-  }
-
-  /**
-   * Update a changelog with this slug
-   *
-   * @summary Update changelog
-   */
-  updateChangelog<T = unknown>(body: Changelog, metadata: UpdateChangelogMetadataParam): Promise<T> {
-    return this.core.fetch('/changelogs/{slug}', 'put', body, metadata);
-  }
-
-  /**
-   * Delete the changelog with this slug
-   *
-   * @summary Delete changelog
-   */
-  deleteChangelog<T = unknown>(metadata: DeleteChangelogMetadataParam): Promise<T> {
-    return this.core.fetch('/changelogs/{slug}', 'delete', metadata);
   }
 
   /**
@@ -579,6 +498,24 @@ export default class SDK {
   }
 
   /**
+   * Returns all the roles we're hiring for at ReadMe!
+   *
+   * @summary Get open roles
+   */
+  getOpenRoles(): Promise<GetOpenRoles_Response_200> {
+    return this.core.fetch('/apply', 'get');
+  }
+
+  /**
+   * This endpoint will let you apply to a job at ReadMe programatically, without having to go through our UI!
+   *
+   * @summary Submit your application!
+   */
+  applyToReadMe<T = unknown>(body: Apply): Promise<T> {
+    return this.core.fetch('/apply', 'post', body);
+  }
+
+  /**
    * Returns all the categories for a specified version
    *
    * @summary Get all categories
@@ -644,6 +581,42 @@ export default class SDK {
    */
   getChangelogs(metadata?: GetChangelogsMetadataParam): Promise<GetChangelogs_Response_200> {
     return this.core.fetch('/changelogs', 'get', metadata);
+  }
+
+  /**
+   * Create a new changelog inside of this project
+   *
+   * @summary Create changelog
+   */
+  createChangelog<T = unknown>(body: Changelog): Promise<T> {
+    return this.core.fetch('/changelogs', 'post', body);
+  }
+
+  /**
+   * Returns the changelog with this slug
+   *
+   * @summary Get changelog
+   */
+  getChangelog<T = unknown>(metadata: GetChangelogMetadataParam): Promise<T> {
+    return this.core.fetch('/changelogs/{slug}', 'get', metadata);
+  }
+
+  /**
+   * Update a changelog with this slug
+   *
+   * @summary Update changelog
+   */
+  updateChangelog<T = unknown>(body: Changelog, metadata: UpdateChangelogMetadataParam): Promise<T> {
+    return this.core.fetch('/changelogs/{slug}', 'put', body, metadata);
+  }
+
+  /**
+   * Delete the changelog with this slug
+   *
+   * @summary Delete changelog
+   */
+  deleteChangelog<T = unknown>(metadata: DeleteChangelogMetadataParam): Promise<T> {
+    return this.core.fetch('/changelogs/{slug}', 'delete', metadata);
   }
 
   /**
@@ -758,6 +731,33 @@ export default class SDK {
   }
 
   /**
+   * Returns with all of the error page types for this project
+   *
+   * @summary Get errors
+   */
+  getErrors(): Promise<GetErrors_Response_401 | GetErrors_Response_403> {
+    return this.core.fetch('/errors', 'get');
+  }
+
+  /**
+   * Returns project data for API key
+   *
+   * @summary Get metadata about the current project
+   */
+  getProject(): Promise<CondensedProjectData | GetProject_Response_401 | GetProject_Response_403> {
+    return this.core.fetch('/', 'get');
+  }
+
+  /**
+   * Retrieve a list of versions associated with a project API key
+   *
+   * @summary Get versions
+   */
+  getVersions(): Promise<GetVersions_Response_401 | GetVersions_Response_403> {
+    return this.core.fetch('/version', 'get');
+  }
+
+  /**
    * Create a new version
    *
    * @summary Create version
@@ -823,6 +823,36 @@ export type GetAPIRegistryMetadataParam = {
   uuid: string;
   [k: string]: unknown;
 };
+export interface GetAPIRegistry_Response_200 {
+  [k: string]: unknown;
+}
+export interface Error_REGISTRY_NOTFOUND {
+  /**
+   * An error code unique to the error received.
+   */
+  error?: string;
+  /**
+   * The reason why the error occured.
+   */
+  message?: string;
+  /**
+   * A helpful suggestion for how to alleviate the error.
+   */
+  suggestion?: string;
+  /**
+   * A [ReadMe Metrics](https://readme.com/metrics/) log URL where you can see more information the request that you made. If we have metrics URLs unavailable for your request, this URL will be a URL to our API Reference.
+   */
+  docs?: string;
+  /**
+   * Information on where you can receive additional assistance from our wonderful support team.
+   */
+  help?: string;
+  /**
+   * A short poem we wrote you about your error.
+   */
+  poem?: string[];
+  [k: string]: unknown;
+}
 export type GetAPISpecificationMetadataParam = {
   /**
    * Number of items to include in pagination (up to 100, defaults to 10)
@@ -840,405 +870,45 @@ export type GetAPISpecificationMetadataParam = {
   'x-readme-version'?: string;
   [k: string]: unknown;
 };
-export interface UploadAPISpecificationBodyParam {
+export interface GetAPISpecification_Response_200 {
   /**
-   * OpenAPI/Swagger file
+   * Pagination information. See https://docs.readme.com/reference/pagination for more information.
    */
-  spec?: string;
+  Link?: string;
+  /**
+   * The total amount of results, ignoring pagination. See https://docs.readme.com/reference/pagination for more information about pagination.
+   */
+  'x-total-count'?: string;
   [k: string]: unknown;
 }
-export type UploadAPISpecificationMetadataParam = {
+export interface Error_VERSION_EMPTY {
   /**
-   * Version number of your docs project, for example, v3.0. By default the main project version is used. To see all valid versions for your docs project call https://docs.readme.com/reference/version#getversions.
+   * An error code unique to the error received.
    */
-  'x-readme-version'?: string;
-  [k: string]: unknown;
-};
-export interface UpdateAPISpecificationBodyParam {
+  error?: string;
   /**
-   * OpenAPI/Swagger file
+   * The reason why the error occured.
    */
-  spec?: string;
-  [k: string]: unknown;
-}
-export type UpdateAPISpecificationMetadataParam = {
+  message?: string;
   /**
-   * ID of the API specification. The unique ID for each API can be found by navigating to your **API Definitions** page.
+   * A helpful suggestion for how to alleviate the error.
    */
-  id: string;
-  [k: string]: unknown;
-};
-export type DeleteAPISpecificationMetadataParam = {
+  suggestion?: string;
   /**
-   * ID of the API specification. The unique ID for each API can be found by navigating to your **API Definitions** page.
+   * A [ReadMe Metrics](https://readme.com/metrics/) log URL where you can see more information the request that you made. If we have metrics URLs unavailable for your request, this URL will be a URL to our API Reference.
    */
-  id: string;
-  [k: string]: unknown;
-};
-export type GetOpenRoles_Response_200 = JobOpening[];
-export interface JobOpening {
+  docs?: string;
   /**
-   * A slugified version of the job opening title.
+   * Information on where you can receive additional assistance from our wonderful support team.
    */
-  slug?: string;
+  help?: string;
   /**
-   * The job opening position.
+   * A short poem we wrote you about your error.
    */
-  title?: string;
-  /**
-   * The description for this open position. This content is formatted as HTML.
-   */
-  description?: string;
-  /**
-   * A short pullquote for the open position.
-   */
-  pullquote?: string;
-  /**
-   * Where this position is located at.
-   */
-  location?: string;
-  /**
-   * The internal organization you'll be working in.
-   */
-  department?: string;
-  /**
-   * The place where you can apply for the position!
-   */
-  url?: string;
+  poem?: string[];
   [k: string]: unknown;
 }
-export interface Apply {
-  /**
-   * Your full name
-   */
-  name: string;
-  /**
-   * A valid email we can reach you at
-   */
-  email: string;
-  /**
-   * The job you're looking to apply for (https://readme.com/careers)
-   */
-  job:
-    | 'Content Marketing Manager'
-    | 'Engineering Manager'
-    | 'Head of People'
-    | 'Marketing Campaigns Manager'
-    | 'Marketing Designer'
-    | 'Product Designer'
-    | 'Product Education Manager'
-    | 'Sales Development Representative'
-    | 'Support Engineer (Weekends)';
-  /**
-   * Learn more at https://pronoun.is/
-   */
-  pronouns?: string;
-  /**
-   * What have you been up to the past few years?
-   */
-  linkedin?: string;
-  /**
-   * Or Bitbucket, Gitlab or anywhere else your code is hosted!
-   */
-  github?: string;
-  /**
-   * What should we know about you?
-   */
-  coverLetter?: string;
-  /**
-   * Want to play with the API but not actually apply? Set this to true.
-   */
-  dontReallyApply?: boolean;
-  [k: string]: unknown;
-}
-export type GetCategoriesMetadataParam = {
-  /**
-   * Number of items to include in pagination (up to 100, defaults to 10)
-   */
-  perPage?: number;
-  /**
-   * Used to specify further pages (starts at 1)
-   */
-  page?: number;
-  [k: string]: unknown;
-} & {
-  /**
-   * Version number of your docs project, for example, v3.0. By default the main project version is used. To see all valid versions for your docs project call https://docs.readme.com/reference/version#getversions.
-   */
-  'x-readme-version'?: string;
-  [k: string]: unknown;
-};
-export interface Category {
-  /**
-   * A short title for the category. This is what will show in the sidebar.
-   */
-  title?: string;
-  /**
-   * A category can be part of your reference or guide documentation, which is determined by this field.
-   */
-  type?: 'reference' | 'guide';
-  [k: string]: unknown;
-}
-export type CreateCategoryMetadataParam = {
-  /**
-   * Version number of your docs project, for example, v3.0. By default the main project version is used. To see all valid versions for your docs project call https://docs.readme.com/reference/version#getversions.
-   */
-  'x-readme-version'?: string;
-  [k: string]: unknown;
-};
-export type GetCategoryMetadataParam = {
-  /**
-   * A URL-safe representation of the category title. Slugs must be all lowercase, and replace spaces with hyphens. For example, for the the category "Getting Started", enter the slug "getting-started"
-   */
-  slug: string;
-  [k: string]: unknown;
-} & {
-  /**
-   * Version number of your docs project, for example, v3.0. By default the main project version is used. To see all valid versions for your docs project call https://docs.readme.com/reference/version#getversions.
-   */
-  'x-readme-version'?: string;
-  [k: string]: unknown;
-};
-export type UpdateCategoryMetadataParam = {
-  /**
-   * A URL-safe representation of the category title. Slugs must be all lowercase, and replace spaces with hyphens. For example, for the the category "Getting Started", enter the slug "getting-started"
-   */
-  slug: string;
-  [k: string]: unknown;
-} & {
-  /**
-   * Version number of your docs project, for example, v3.0. By default the main project version is used. To see all valid versions for your docs project call https://docs.readme.com/reference/version#getversions.
-   */
-  'x-readme-version'?: string;
-  [k: string]: unknown;
-};
-export type DeleteCategoryMetadataParam = {
-  /**
-   * A URL-safe representation of the category title. Slugs must be all lowercase, and replace spaces with hyphens. For example, for the the category "Getting Started", enter the slug "getting-started"
-   */
-  slug: string;
-  [k: string]: unknown;
-} & {
-  /**
-   * Version number of your docs project, for example, v3.0. By default the main project version is used. To see all valid versions for your docs project call https://docs.readme.com/reference/version#getversions.
-   */
-  'x-readme-version'?: string;
-  [k: string]: unknown;
-};
-export type GetCategoryDocsMetadataParam = {
-  /**
-   * A URL-safe representation of the category title. Slugs must be all lowercase, and replace spaces with hyphens. For example, for the the category "Getting Started", enter the slug "getting-started"
-   */
-  slug: string;
-  [k: string]: unknown;
-} & {
-  /**
-   * Version number of your docs project, for example, v3.0. By default the main project version is used. To see all valid versions for your docs project call https://docs.readme.com/reference/version#getversions.
-   */
-  'x-readme-version'?: string;
-  [k: string]: unknown;
-};
-export type GetChangelogsMetadataParam = {
-  /**
-   * Number of items to include in pagination (up to 100, defaults to 10)
-   */
-  perPage?: number;
-  /**
-   * Used to specify further pages (starts at 1)
-   */
-  page?: number;
-  [k: string]: unknown;
-};
-export interface Changelog {
-  /**
-   * Title of the changelog
-   */
-  title: string;
-  type?: '' | 'added' | 'fixed' | 'improved' | 'deprecated' | 'removed';
-  /**
-   * Body content of the changelog
-   */
-  body: string;
-  /**
-   * Visibility of the changelog
-   */
-  hidden?: boolean;
-  [k: string]: unknown;
-}
-export type GetChangelogMetadataParam = {
-  /**
-   * A URL-safe representation of the changelog title. Slugs must be all lowercase, and replace spaces with hyphens. For example, for the the changelog "Owlet Weekly Update", enter the slug "owlet-weekly-update"
-   */
-  slug: string;
-  [k: string]: unknown;
-};
-export type UpdateChangelogMetadataParam = {
-  /**
-   * A URL-safe representation of the changelog title. Slugs must be all lowercase, and replace spaces with hyphens. For example, for the the changelog "Owlet Weekly Update", enter the slug "owlet-weekly-update"
-   */
-  slug: string;
-  [k: string]: unknown;
-};
-export type DeleteChangelogMetadataParam = {
-  /**
-   * A URL-safe representation of the changelog title. Slugs must be all lowercase, and replace spaces with hyphens. For example, for the the changelog "Owlet Weekly Update", enter the slug "owlet-weekly-update"
-   */
-  slug: string;
-  [k: string]: unknown;
-};
-export type GetCustomPagesMetadataParam = {
-  /**
-   * Number of items to include in pagination (up to 100, defaults to 10)
-   */
-  perPage?: number;
-  /**
-   * Used to specify further pages (starts at 1)
-   */
-  page?: number;
-  [k: string]: unknown;
-};
-export interface CustomPage {
-  /**
-   * Title of the custom page
-   */
-  title: string;
-  /**
-   * Body formatted in Markdown (displayed by default).
-   */
-  body?: string;
-  /**
-   * Body formatted in HTML (sanitized, only displayed if `htmlmode` is **true**).
-   */
-  html?: string;
-  /**
-   * **true** if `html` should be displayed, **false** if `body` should be displayed.
-   */
-  htmlmode?: boolean;
-  /**
-   * Visibility of the custom page
-   */
-  hidden?: boolean;
-  [k: string]: unknown;
-}
-export type GetCustomPageMetadataParam = {
-  /**
-   * A URL-safe representation of the custom page title. Slugs must be all lowercase, and replace spaces with hyphens. For example, for the the custom page "Getting Started", enter the slug "getting-started"
-   */
-  slug: string;
-  [k: string]: unknown;
-};
-export type UpdateCustomPageMetadataParam = {
-  /**
-   * A URL-safe representation of the custom page title. Slugs must be all lowercase, and replace spaces with hyphens. For example, for the the custom page "Getting Started", enter the slug "getting-started"
-   */
-  slug: string;
-  [k: string]: unknown;
-};
-export type DeleteCustomPageMetadataParam = {
-  /**
-   * A URL-safe representation of the custom page title. Slugs must be all lowercase, and replace spaces with hyphens. For example, for the the custom page "Getting Started", enter the slug "getting-started"
-   */
-  slug: string;
-  [k: string]: unknown;
-};
-export type GetDocMetadataParam = {
-  /**
-   * A URL-safe representation of the doc title. Slugs must be all lowercase, and replace spaces with hyphens. For example, for the the doc "New Features", enter the slug "new-features"
-   */
-  slug: string;
-  [k: string]: unknown;
-} & {
-  /**
-   * Version number of your docs project, for example, v3.0. By default the main project version is used. To see all valid versions for your docs project call https://docs.readme.com/reference/version#getversions.
-   */
-  'x-readme-version'?: string;
-  [k: string]: unknown;
-};
-export interface Doc {
-  /**
-   * Title of the page
-   */
-  title: string;
-  /**
-   * Type of the page. The available types all show up under the /docs/ URL path of your docs project (also known as the "guides" section). Can be "basic" (most common), "error" (page desribing an API error), or "link" (page that redirects to an external link)
-   */
-  type?: 'basic' | 'error' | 'link';
-  /**
-   * Body content of the page, formatted in ReadMe or GitHub flavored Markdown. Accepts long page content, for example, greater than 100k characters
-   */
-  body?: string;
-  /**
-   * Category ID of the page, which you can get through https://docs.readme.com/reference/categories#getcategory
-   */
-  category: string;
-  /**
-   * Visibility of the page
-   */
-  hidden?: boolean;
-  /**
-   * The position of the page in your project sidebar.
-   */
-  order?: number;
-  /**
-   * For a subpage, specify the parent doc ID, which you can get through https://docs.readme.com/reference/docs#getdoc
-   */
-  parentDoc?: string;
-  error?: {
-    /**
-     * The error code for docs with the "error" type
-     */
-    code?: string;
-    [k: string]: unknown;
-  };
-  [k: string]: unknown;
-}
-export type UpdateDocMetadataParam = {
-  /**
-   * A URL-safe representation of the doc title. Slugs must be all lowercase, and replace spaces with hyphens. For example, for the the doc "New Features", enter the slug "new-features"
-   */
-  slug: string;
-  [k: string]: unknown;
-} & {
-  /**
-   * Version number of your docs project, for example, v3.0. By default the main project version is used. To see all valid versions for your docs project call https://docs.readme.com/reference/version#getversions.
-   */
-  'x-readme-version'?: string;
-  [k: string]: unknown;
-};
-export type DeleteDocMetadataParam = {
-  /**
-   * A URL-safe representation of the doc title. Slugs must be all lowercase, and replace spaces with hyphens. For example, for the the doc "New Features", enter the slug "new-features"
-   */
-  slug: string;
-  [k: string]: unknown;
-} & {
-  /**
-   * Version number of your docs project, for example, v3.0. By default the main project version is used. To see all valid versions for your docs project call https://docs.readme.com/reference/version#getversions.
-   */
-  'x-readme-version'?: string;
-  [k: string]: unknown;
-};
-export type CreateDocMetadataParam = {
-  /**
-   * Version number of your docs project, for example, v3.0. By default the main project version is used. To see all valid versions for your docs project call https://docs.readme.com/reference/version#getversions.
-   */
-  'x-readme-version'?: string;
-  [k: string]: unknown;
-};
-export type SearchDocsMetadataParam = {
-  /**
-   * Search string to look for
-   */
-  search: string;
-  [k: string]: unknown;
-} & {
-  /**
-   * Version number of your docs project, for example, v3.0. By default the main project version is used. To see all valid versions for your docs project call https://docs.readme.com/reference/version#getversions.
-   */
-  'x-readme-version'?: string;
-  [k: string]: unknown;
-};
-export type GetErrors_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
+export type GetAPISpecification_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
 export interface Error_APIKEY_EMPTY {
   /**
    * An error code unique to the error received.
@@ -1293,7 +963,7 @@ export interface Error_APIKEY_NOTFOUND {
   poem?: string[];
   [k: string]: unknown;
 }
-export type GetErrors_Response_403 = Error_APIKEY_MISMATCH;
+export type GetAPISpecification_Response_403 = Error_APIKEY_MISMATCH;
 export interface Error_APIKEY_MISMATCH {
   /**
    * An error code unique to the error received.
@@ -1321,140 +991,6 @@ export interface Error_APIKEY_MISMATCH {
   poem?: string[];
   [k: string]: unknown;
 }
-export interface CondensedProjectData {
-  name?: string;
-  subdomain?: string;
-  jwtSecret?: string;
-  /**
-   * The base URL for the project. If the project is not running under a custom domain, it will be `https://projectSubdomain.readme.io`, otherwise it can either be or `https://example.com` or, in the case of an enterprise child project `https://example.com/projectSubdomain`.
-   */
-  baseUrl?: string;
-  plan?: string;
-  [k: string]: unknown;
-}
-export type GetProject_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
-export type GetProject_Response_403 = Error_APIKEY_MISMATCH;
-export type GetVersions_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
-export type GetVersions_Response_403 = Error_APIKEY_MISMATCH;
-export interface Version {
-  /**
-   * Semantic Version
-   */
-  version: string;
-  /**
-   * Dubbed name of version
-   */
-  codename?: string;
-  /**
-   * Semantic Version to use as the base fork
-   */
-  from: string;
-  /**
-   * Should this be the **main** version
-   */
-  is_stable?: boolean;
-  is_beta?: boolean;
-  /**
-   * Should this be publically accessible?
-   */
-  is_hidden?: boolean;
-  /**
-   * Should this be deprecated? Only allowed in PUT operations
-   */
-  is_deprecated?: boolean;
-  [k: string]: unknown;
-}
-export type GetVersionMetadataParam = {
-  /**
-   * Semver identifier for the project version. For best results, use the formatted `version_clean` value listed in the response from the [Get Versions endpoint](/reference/getversions).
-   */
-  versionId: string;
-  [k: string]: unknown;
-};
-export type UpdateVersionMetadataParam = {
-  /**
-   * Semver identifier for the project version. For best results, use the formatted `version_clean` value listed in the response from the [Get Versions endpoint](/reference/getversions).
-   */
-  versionId: string;
-  [k: string]: unknown;
-};
-export type DeleteVersionMetadataParam = {
-  /**
-   * Semver identifier for the project version. For best results, use the formatted `version_clean` value listed in the response from the [Get Versions endpoint](/reference/getversions).
-   */
-  versionId: string;
-  [k: string]: unknown;
-};
-export interface GetAPIRegistry_Response_200 {
-  [k: string]: unknown;
-}
-export interface Error_REGISTRY_NOTFOUND {
-  /**
-   * An error code unique to the error received.
-   */
-  error?: string;
-  /**
-   * The reason why the error occured.
-   */
-  message?: string;
-  /**
-   * A helpful suggestion for how to alleviate the error.
-   */
-  suggestion?: string;
-  /**
-   * A [ReadMe Metrics](https://readme.com/metrics/) log URL where you can see more information the request that you made. If we have metrics URLs unavailable for your request, this URL will be a URL to our API Reference.
-   */
-  docs?: string;
-  /**
-   * Information on where you can receive additional assistance from our wonderful support team.
-   */
-  help?: string;
-  /**
-   * A short poem we wrote you about your error.
-   */
-  poem?: string[];
-  [k: string]: unknown;
-}
-export interface GetAPISpecification_Response_200 {
-  /**
-   * Pagination information. See https://docs.readme.com/reference/pagination for more information.
-   */
-  Link?: string;
-  /**
-   * The total amount of results, ignoring pagination. See https://docs.readme.com/reference/pagination for more information about pagination.
-   */
-  'x-total-count'?: string;
-  [k: string]: unknown;
-}
-export interface Error_VERSION_EMPTY {
-  /**
-   * An error code unique to the error received.
-   */
-  error?: string;
-  /**
-   * The reason why the error occured.
-   */
-  message?: string;
-  /**
-   * A helpful suggestion for how to alleviate the error.
-   */
-  suggestion?: string;
-  /**
-   * A [ReadMe Metrics](https://readme.com/metrics/) log URL where you can see more information the request that you made. If we have metrics URLs unavailable for your request, this URL will be a URL to our API Reference.
-   */
-  docs?: string;
-  /**
-   * Information on where you can receive additional assistance from our wonderful support team.
-   */
-  help?: string;
-  /**
-   * A short poem we wrote you about your error.
-   */
-  poem?: string[];
-  [k: string]: unknown;
-}
-export type GetAPISpecification_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
-export type GetAPISpecification_Response_403 = Error_APIKEY_MISMATCH;
 export interface Error_VERSION_NOTFOUND {
   /**
    * An error code unique to the error received.
@@ -1482,6 +1018,20 @@ export interface Error_VERSION_NOTFOUND {
   poem?: string[];
   [k: string]: unknown;
 }
+export interface UploadAPISpecificationBodyParam {
+  /**
+   * OpenAPI/Swagger file
+   */
+  spec?: string;
+  [k: string]: unknown;
+}
+export type UploadAPISpecificationMetadataParam = {
+  /**
+   * Version number of your docs project, for example, v3.0. By default the main project version is used. To see all valid versions for your docs project call https://docs.readme.com/reference/version#getversions.
+   */
+  'x-readme-version'?: string;
+  [k: string]: unknown;
+};
 export type UploadAPISpecification_Response_400 =
   | Error_SPEC_FILE_EMPTY
   | Error_SPEC_INVALID
@@ -1624,6 +1174,20 @@ export interface Error_SPEC_TIMEOUT {
   poem?: string[];
   [k: string]: unknown;
 }
+export interface UpdateAPISpecificationBodyParam {
+  /**
+   * OpenAPI/Swagger file
+   */
+  spec?: string;
+  [k: string]: unknown;
+}
+export type UpdateAPISpecificationMetadataParam = {
+  /**
+   * ID of the API specification. The unique ID for each API can be found by navigating to your **API Definitions** page.
+   */
+  id: string;
+  [k: string]: unknown;
+};
 export type UpdateAPISpecification_Response_400 =
   | Error_SPEC_FILE_EMPTY
   | Error_SPEC_ID_DUPLICATE
@@ -1687,6 +1251,13 @@ export interface Error_SPEC_ID_INVALID {
 }
 export type UpdateAPISpecification_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
 export type UpdateAPISpecification_Response_403 = Error_APIKEY_MISMATCH;
+export type DeleteAPISpecificationMetadataParam = {
+  /**
+   * ID of the API specification. The unique ID for each API can be found by navigating to your **API Definitions** page.
+   */
+  id: string;
+  [k: string]: unknown;
+};
 export type DeleteAPISpecification_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
 export type DeleteAPISpecification_Response_403 = Error_APIKEY_MISMATCH;
 export interface Error_SPEC_NOTFOUND {
@@ -1716,6 +1287,99 @@ export interface Error_SPEC_NOTFOUND {
   poem?: string[];
   [k: string]: unknown;
 }
+export type GetOpenRoles_Response_200 = JobOpening[];
+export interface JobOpening {
+  /**
+   * A slugified version of the job opening title.
+   */
+  slug?: string;
+  /**
+   * The job opening position.
+   */
+  title?: string;
+  /**
+   * The description for this open position. This content is formatted as HTML.
+   */
+  description?: string;
+  /**
+   * A short pullquote for the open position.
+   */
+  pullquote?: string;
+  /**
+   * Where this position is located at.
+   */
+  location?: string;
+  /**
+   * The internal organization you'll be working in.
+   */
+  department?: string;
+  /**
+   * The place where you can apply for the position!
+   */
+  url?: string;
+  [k: string]: unknown;
+}
+export interface Apply {
+  /**
+   * Your full name
+   */
+  name: string;
+  /**
+   * A valid email we can reach you at
+   */
+  email: string;
+  /**
+   * The job you're looking to apply for (https://readme.com/careers)
+   */
+  job:
+    | 'Content Marketing Manager'
+    | 'Engineering Manager'
+    | 'Head of People'
+    | 'Marketing Campaigns Manager'
+    | 'Marketing Designer'
+    | 'Product Designer'
+    | 'Product Education Manager'
+    | 'Sales Development Representative'
+    | 'Support Engineer (Weekends)';
+  /**
+   * Learn more at https://pronoun.is/
+   */
+  pronouns?: string;
+  /**
+   * What have you been up to the past few years?
+   */
+  linkedin?: string;
+  /**
+   * Or Bitbucket, Gitlab or anywhere else your code is hosted!
+   */
+  github?: string;
+  /**
+   * What should we know about you?
+   */
+  coverLetter?: string;
+  /**
+   * Want to play with the API but not actually apply? Set this to true.
+   */
+  dontReallyApply?: boolean;
+  [k: string]: unknown;
+}
+export type GetCategoriesMetadataParam = {
+  /**
+   * Number of items to include in pagination (up to 100, defaults to 10)
+   */
+  perPage?: number;
+  /**
+   * Used to specify further pages (starts at 1)
+   */
+  page?: number;
+  [k: string]: unknown;
+} & {
+  /**
+   * Version number of your docs project, for example, v3.0. By default the main project version is used. To see all valid versions for your docs project call https://docs.readme.com/reference/version#getversions.
+   */
+  'x-readme-version'?: string;
+  [k: string]: unknown;
+};
 export interface GetCategories_Response_200 {
   /**
    * Pagination information. See https://docs.readme.com/reference/pagination for more information.
@@ -1727,6 +1391,24 @@ export interface GetCategories_Response_200 {
   'x-total-count'?: string;
   [k: string]: unknown;
 }
+export interface Category {
+  /**
+   * A short title for the category. This is what will show in the sidebar.
+   */
+  title?: string;
+  /**
+   * A category can be part of your reference or guide documentation, which is determined by this field.
+   */
+  type?: 'reference' | 'guide';
+  [k: string]: unknown;
+}
+export type CreateCategoryMetadataParam = {
+  /**
+   * Version number of your docs project, for example, v3.0. By default the main project version is used. To see all valid versions for your docs project call https://docs.readme.com/reference/version#getversions.
+   */
+  'x-readme-version'?: string;
+  [k: string]: unknown;
+};
 export interface Error_CATEGORY_INVALID {
   /**
    * An error code unique to the error received.
@@ -1754,6 +1436,19 @@ export interface Error_CATEGORY_INVALID {
   poem?: string[];
   [k: string]: unknown;
 }
+export type GetCategoryMetadataParam = {
+  /**
+   * A URL-safe representation of the category title. Slugs must be all lowercase, and replace spaces with hyphens. For example, for the the category "Getting Started", enter the slug "getting-started"
+   */
+  slug: string;
+  [k: string]: unknown;
+} & {
+  /**
+   * Version number of your docs project, for example, v3.0. By default the main project version is used. To see all valid versions for your docs project call https://docs.readme.com/reference/version#getversions.
+   */
+  'x-readme-version'?: string;
+  [k: string]: unknown;
+};
 export interface Error_CATEGORY_NOTFOUND {
   /**
    * An error code unique to the error received.
@@ -1781,6 +1476,56 @@ export interface Error_CATEGORY_NOTFOUND {
   poem?: string[];
   [k: string]: unknown;
 }
+export type UpdateCategoryMetadataParam = {
+  /**
+   * A URL-safe representation of the category title. Slugs must be all lowercase, and replace spaces with hyphens. For example, for the the category "Getting Started", enter the slug "getting-started"
+   */
+  slug: string;
+  [k: string]: unknown;
+} & {
+  /**
+   * Version number of your docs project, for example, v3.0. By default the main project version is used. To see all valid versions for your docs project call https://docs.readme.com/reference/version#getversions.
+   */
+  'x-readme-version'?: string;
+  [k: string]: unknown;
+};
+export type DeleteCategoryMetadataParam = {
+  /**
+   * A URL-safe representation of the category title. Slugs must be all lowercase, and replace spaces with hyphens. For example, for the the category "Getting Started", enter the slug "getting-started"
+   */
+  slug: string;
+  [k: string]: unknown;
+} & {
+  /**
+   * Version number of your docs project, for example, v3.0. By default the main project version is used. To see all valid versions for your docs project call https://docs.readme.com/reference/version#getversions.
+   */
+  'x-readme-version'?: string;
+  [k: string]: unknown;
+};
+export type GetCategoryDocsMetadataParam = {
+  /**
+   * A URL-safe representation of the category title. Slugs must be all lowercase, and replace spaces with hyphens. For example, for the the category "Getting Started", enter the slug "getting-started"
+   */
+  slug: string;
+  [k: string]: unknown;
+} & {
+  /**
+   * Version number of your docs project, for example, v3.0. By default the main project version is used. To see all valid versions for your docs project call https://docs.readme.com/reference/version#getversions.
+   */
+  'x-readme-version'?: string;
+  [k: string]: unknown;
+};
+export type GetChangelogsMetadataParam = {
+  /**
+   * Number of items to include in pagination (up to 100, defaults to 10)
+   */
+  perPage?: number;
+  /**
+   * Used to specify further pages (starts at 1)
+   */
+  page?: number;
+  [k: string]: unknown;
+};
 export interface GetChangelogs_Response_200 {
   /**
    * Pagination information. See https://docs.readme.com/reference/pagination for more information.
@@ -1792,6 +1537,54 @@ export interface GetChangelogs_Response_200 {
   'x-total-count'?: string;
   [k: string]: unknown;
 }
+export interface Changelog {
+  /**
+   * Title of the changelog
+   */
+  title: string;
+  type?: '' | 'added' | 'fixed' | 'improved' | 'deprecated' | 'removed';
+  /**
+   * Body content of the changelog
+   */
+  body: string;
+  /**
+   * Visibility of the changelog
+   */
+  hidden?: boolean;
+  [k: string]: unknown;
+}
+export type GetChangelogMetadataParam = {
+  /**
+   * A URL-safe representation of the changelog title. Slugs must be all lowercase, and replace spaces with hyphens. For example, for the the changelog "Owlet Weekly Update", enter the slug "owlet-weekly-update"
+   */
+  slug: string;
+  [k: string]: unknown;
+};
+export type UpdateChangelogMetadataParam = {
+  /**
+   * A URL-safe representation of the changelog title. Slugs must be all lowercase, and replace spaces with hyphens. For example, for the the changelog "Owlet Weekly Update", enter the slug "owlet-weekly-update"
+   */
+  slug: string;
+  [k: string]: unknown;
+};
+export type DeleteChangelogMetadataParam = {
+  /**
+   * A URL-safe representation of the changelog title. Slugs must be all lowercase, and replace spaces with hyphens. For example, for the the changelog "Owlet Weekly Update", enter the slug "owlet-weekly-update"
+   */
+  slug: string;
+  [k: string]: unknown;
+};
+export type GetCustomPagesMetadataParam = {
+  /**
+   * Number of items to include in pagination (up to 100, defaults to 10)
+   */
+  perPage?: number;
+  /**
+   * Used to specify further pages (starts at 1)
+   */
+  page?: number;
+  [k: string]: unknown;
+};
 export interface GetCustomPages_Response_200 {
   /**
    * Pagination information. See https://docs.readme.com/reference/pagination for more information.
@@ -1805,6 +1598,29 @@ export interface GetCustomPages_Response_200 {
 }
 export type GetCustomPages_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
 export type GetCustomPages_Response_403 = Error_APIKEY_MISMATCH;
+export interface CustomPage {
+  /**
+   * Title of the custom page
+   */
+  title: string;
+  /**
+   * Body formatted in Markdown (displayed by default).
+   */
+  body?: string;
+  /**
+   * Body formatted in HTML (sanitized, only displayed if `htmlmode` is **true**).
+   */
+  html?: string;
+  /**
+   * **true** if `html` should be displayed, **false** if `body` should be displayed.
+   */
+  htmlmode?: boolean;
+  /**
+   * Visibility of the custom page
+   */
+  hidden?: boolean;
+  [k: string]: unknown;
+}
 export interface Error_CUSTOMPAGE_INVALID {
   /**
    * An error code unique to the error received.
@@ -1834,6 +1650,13 @@ export interface Error_CUSTOMPAGE_INVALID {
 }
 export type CreateCustomPage_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
 export type CreateCustomPage_Response_403 = Error_APIKEY_MISMATCH;
+export type GetCustomPageMetadataParam = {
+  /**
+   * A URL-safe representation of the custom page title. Slugs must be all lowercase, and replace spaces with hyphens. For example, for the the custom page "Getting Started", enter the slug "getting-started"
+   */
+  slug: string;
+  [k: string]: unknown;
+};
 export type GetCustomPage_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
 export type GetCustomPage_Response_403 = Error_APIKEY_MISMATCH;
 export interface Error_CUSTOMPAGE_NOTFOUND {
@@ -1863,10 +1686,37 @@ export interface Error_CUSTOMPAGE_NOTFOUND {
   poem?: string[];
   [k: string]: unknown;
 }
+export type UpdateCustomPageMetadataParam = {
+  /**
+   * A URL-safe representation of the custom page title. Slugs must be all lowercase, and replace spaces with hyphens. For example, for the the custom page "Getting Started", enter the slug "getting-started"
+   */
+  slug: string;
+  [k: string]: unknown;
+};
 export type UpdateCustomPage_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
 export type UpdateCustomPage_Response_403 = Error_APIKEY_MISMATCH;
+export type DeleteCustomPageMetadataParam = {
+  /**
+   * A URL-safe representation of the custom page title. Slugs must be all lowercase, and replace spaces with hyphens. For example, for the the custom page "Getting Started", enter the slug "getting-started"
+   */
+  slug: string;
+  [k: string]: unknown;
+};
 export type DeleteCustomPage_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
 export type DeleteCustomPage_Response_403 = Error_APIKEY_MISMATCH;
+export type GetDocMetadataParam = {
+  /**
+   * A URL-safe representation of the doc title. Slugs must be all lowercase, and replace spaces with hyphens. For example, for the the doc "New Features", enter the slug "new-features"
+   */
+  slug: string;
+  [k: string]: unknown;
+} & {
+  /**
+   * Version number of your docs project, for example, v3.0. By default the main project version is used. To see all valid versions for your docs project call https://docs.readme.com/reference/version#getversions.
+   */
+  'x-readme-version'?: string;
+  [k: string]: unknown;
+};
 export type GetDoc_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
 export type GetDoc_Response_403 = Error_APIKEY_MISMATCH;
 export interface Error_DOC_NOTFOUND {
@@ -1896,6 +1746,57 @@ export interface Error_DOC_NOTFOUND {
   poem?: string[];
   [k: string]: unknown;
 }
+export interface Doc {
+  /**
+   * Title of the page
+   */
+  title: string;
+  /**
+   * Type of the page. The available types all show up under the /docs/ URL path of your docs project (also known as the "guides" section). Can be "basic" (most common), "error" (page desribing an API error), or "link" (page that redirects to an external link)
+   */
+  type?: 'basic' | 'error' | 'link';
+  /**
+   * Body content of the page, formatted in ReadMe or GitHub flavored Markdown. Accepts long page content, for example, greater than 100k characters
+   */
+  body?: string;
+  /**
+   * Category ID of the page, which you can get through https://docs.readme.com/reference/categories#getcategory
+   */
+  category: string;
+  /**
+   * Visibility of the page
+   */
+  hidden?: boolean;
+  /**
+   * The position of the page in your project sidebar.
+   */
+  order?: number;
+  /**
+   * For a subpage, specify the parent doc ID, which you can get through https://docs.readme.com/reference/docs#getdoc
+   */
+  parentDoc?: string;
+  error?: {
+    /**
+     * The error code for docs with the "error" type
+     */
+    code?: string;
+    [k: string]: unknown;
+  };
+  [k: string]: unknown;
+}
+export type UpdateDocMetadataParam = {
+  /**
+   * A URL-safe representation of the doc title. Slugs must be all lowercase, and replace spaces with hyphens. For example, for the the doc "New Features", enter the slug "new-features"
+   */
+  slug: string;
+  [k: string]: unknown;
+} & {
+  /**
+   * Version number of your docs project, for example, v3.0. By default the main project version is used. To see all valid versions for your docs project call https://docs.readme.com/reference/version#getversions.
+   */
+  'x-readme-version'?: string;
+  [k: string]: unknown;
+};
 export interface Error_DOC_INVALID {
   /**
    * An error code unique to the error received.
@@ -1925,12 +1826,90 @@ export interface Error_DOC_INVALID {
 }
 export type UpdateDoc_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
 export type UpdateDoc_Response_403 = Error_APIKEY_MISMATCH;
+export type DeleteDocMetadataParam = {
+  /**
+   * A URL-safe representation of the doc title. Slugs must be all lowercase, and replace spaces with hyphens. For example, for the the doc "New Features", enter the slug "new-features"
+   */
+  slug: string;
+  [k: string]: unknown;
+} & {
+  /**
+   * Version number of your docs project, for example, v3.0. By default the main project version is used. To see all valid versions for your docs project call https://docs.readme.com/reference/version#getversions.
+   */
+  'x-readme-version'?: string;
+  [k: string]: unknown;
+};
 export type DeleteDoc_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
 export type DeleteDoc_Response_403 = Error_APIKEY_MISMATCH;
+export type CreateDocMetadataParam = {
+  /**
+   * Version number of your docs project, for example, v3.0. By default the main project version is used. To see all valid versions for your docs project call https://docs.readme.com/reference/version#getversions.
+   */
+  'x-readme-version'?: string;
+  [k: string]: unknown;
+};
 export type CreateDoc_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
 export type CreateDoc_Response_403 = Error_APIKEY_MISMATCH;
+export type SearchDocsMetadataParam = {
+  /**
+   * Search string to look for
+   */
+  search: string;
+  [k: string]: unknown;
+} & {
+  /**
+   * Version number of your docs project, for example, v3.0. By default the main project version is used. To see all valid versions for your docs project call https://docs.readme.com/reference/version#getversions.
+   */
+  'x-readme-version'?: string;
+  [k: string]: unknown;
+};
 export type SearchDocs_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
 export type SearchDocs_Response_403 = Error_APIKEY_MISMATCH;
+export type GetErrors_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
+export type GetErrors_Response_403 = Error_APIKEY_MISMATCH;
+export interface CondensedProjectData {
+  name?: string;
+  subdomain?: string;
+  jwtSecret?: string;
+  /**
+   * The base URL for the project. If the project is not running under a custom domain, it will be `https://projectSubdomain.readme.io`, otherwise it can either be or `https://example.com` or, in the case of an enterprise child project `https://example.com/projectSubdomain`.
+   */
+  baseUrl?: string;
+  plan?: string;
+  [k: string]: unknown;
+}
+export type GetProject_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
+export type GetProject_Response_403 = Error_APIKEY_MISMATCH;
+export type GetVersions_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
+export type GetVersions_Response_403 = Error_APIKEY_MISMATCH;
+export interface Version {
+  /**
+   * Semantic Version
+   */
+  version: string;
+  /**
+   * Dubbed name of version
+   */
+  codename?: string;
+  /**
+   * Semantic Version to use as the base fork
+   */
+  from: string;
+  /**
+   * Should this be the **main** version
+   */
+  is_stable?: boolean;
+  is_beta?: boolean;
+  /**
+   * Should this be publically accessible?
+   */
+  is_hidden?: boolean;
+  /**
+   * Should this be deprecated? Only allowed in PUT operations
+   */
+  is_deprecated?: boolean;
+  [k: string]: unknown;
+}
 export type CreateVersion_Response_400 = Error_VERSION_EMPTY | Error_VERSION_DUPLICATE | Error_VERSION_FORK_EMPTY;
 export interface Error_VERSION_DUPLICATE {
   /**
@@ -2015,8 +1994,22 @@ export interface Error_VERSION_FORK_NOTFOUND {
   poem?: string[];
   [k: string]: unknown;
 }
+export type GetVersionMetadataParam = {
+  /**
+   * Semver identifier for the project version. For best results, use the formatted `version_clean` value listed in the response from the [Get Versions endpoint](/reference/getversions).
+   */
+  versionId: string;
+  [k: string]: unknown;
+};
 export type GetVersion_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
 export type GetVersion_Response_403 = Error_APIKEY_MISMATCH;
+export type UpdateVersionMetadataParam = {
+  /**
+   * Semver identifier for the project version. For best results, use the formatted `version_clean` value listed in the response from the [Get Versions endpoint](/reference/getversions).
+   */
+  versionId: string;
+  [k: string]: unknown;
+};
 export interface Error_VERSION_CANT_DEMOTE_STABLE {
   /**
    * An error code unique to the error received.
@@ -2046,6 +2039,13 @@ export interface Error_VERSION_CANT_DEMOTE_STABLE {
 }
 export type UpdateVersion_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
 export type UpdateVersion_Response_403 = Error_APIKEY_MISMATCH;
+export type DeleteVersionMetadataParam = {
+  /**
+   * Semver identifier for the project version. For best results, use the formatted `version_clean` value listed in the response from the [Get Versions endpoint](/reference/getversions).
+   */
+  versionId: string;
+  [k: string]: unknown;
+};
 export interface Error_VERSION_CANT_REMOVE_STABLE {
   /**
    * An error code unique to the error received.

--- a/packages/api/test/__fixtures__/sdk/readme/index.ts
+++ b/packages/api/test/__fixtures__/sdk/readme/index.ts
@@ -1,0 +1,2077 @@
+import Oas from 'oas';
+import APICore from 'api/core';
+import definition from './readme.json';
+
+export default class SDK {
+  spec: Oas;
+  core: APICore;
+  authKeys: (number | string)[][] = [];
+
+  constructor() {
+    this.spec = Oas.init(definition);
+    this.core = new APICore(this.spec, 'api/1.0.0');
+  }
+
+  /**
+   * Optionally configure various options, such as response parsing, that the SDK allows.
+   *
+   * @param config Object of supported SDK options and toggles.
+   * @param config.parseResponse If responses are parsed according to its `Content-Type` header.
+   */
+  config(config: ConfigOptions) {
+    this.core.setConfig(config);
+  }
+
+  /**
+   * If the API you're using requires authentication you can supply the required credentials
+   * through this method and the library will magically determine how they should be used
+   * within your API request.
+   *
+   * With the exception of OpenID and MutualTLS, it supports all forms of authentication
+   * supported by the OpenAPI specification.
+   *
+   * @example <caption>HTTP Basic auth</caption>
+   * sdk.auth('username', 'password');
+   *
+   * @example <caption>Bearer tokens (HTTP or OAuth 2)</caption>
+   * sdk.auth('myBearerToken');
+   *
+   * @example <caption>API Keys</caption>
+   * sdk.auth('myApiKey');
+   *
+   * @see {@link https://spec.openapis.org/oas/v3.0.3#fixed-fields-22}
+   * @see {@link https://spec.openapis.org/oas/v3.1.0#fixed-fields-22}
+   * @param values Your auth credentials for the API; can specify up to two strings or numbers.
+   */
+  auth(...values: string[] | number[]) {
+    this.core.setAuth(...values);
+    return this;
+  }
+
+  /**
+   * If the API you're using offers alternate server URLs, and server variables, you can tell
+   * the SDK which one to use with this method. To use it you can supply either one of the
+   * server URLs that are contained within the OpenAPI definition (along with any server
+   * variables), or you can pass it a fully qualified URL to use (that may or may not exist
+   * within the OpenAPI definition).
+   *
+   * @example <caption>Server URL with server variables</caption>
+   * sdk.server('https://{region}.api.example.com/{basePath}', {
+   *   name: 'eu',
+   *   basePath: 'v14',
+   * });
+   *
+   * @example <caption>Fully qualified server URL</caption>
+   * sdk.server('https://eu.api.example.com/v14');
+   *
+   * @param url Server URL
+   * @param variables An object of variables to replace into the server URL.
+   */
+  server(url: string, variables = {}) {
+    this.core.setServer(url, variables);
+  }
+
+  /**
+   * Returns all the roles we're hiring for at ReadMe!
+   *
+   * @summary Get open roles
+   */
+  get(path: string): Promise<GetOpenRoles_Response_200>;
+  /**
+   * Returns with all of the error page types for this project
+   *
+   * @summary Get errors
+   */
+  get(path: string): Promise<GetErrors_Response_401 | GetErrors_Response_403>;
+  /**
+   * Returns project data for API key
+   *
+   * @summary Get metadata about the current project
+   */
+  get(path: string): Promise<CondensedProjectData | GetProject_Response_401 | GetProject_Response_403>;
+  /**
+   * Retrieve a list of versions associated with a project API key
+   *
+   * @summary Get versions
+   */
+  get(path: string): Promise<GetVersions_Response_401 | GetVersions_Response_403>;
+  /**
+   * Returns the changelog with this slug
+   *
+   * @summary Get changelog
+   */
+  get<T = unknown>(path: string, metadata: GetChangelogMetadataParam): Promise<T>;
+  /**
+   * Get an API definition file that's been uploaded to ReadMe
+   *
+   * @summary Retrieve an entry from the API Registry
+   */
+  get(
+    path: string,
+    metadata: GetAPIRegistryMetadataParam
+  ): Promise<GetAPIRegistry_Response_200 | Error_REGISTRY_NOTFOUND>;
+  /**
+   * Get API specification metadata
+   *
+   * @summary Get metadata
+   */
+  get(
+    path: string,
+    metadata?: GetAPISpecificationMetadataParam
+  ): Promise<
+    | GetAPISpecification_Response_200
+    | Error_VERSION_EMPTY
+    | GetAPISpecification_Response_401
+    | GetAPISpecification_Response_403
+    | Error_VERSION_NOTFOUND
+  >;
+  /**
+   * Returns all the categories for a specified version
+   *
+   * @summary Get all categories
+   */
+  get(path: string, metadata?: GetCategoriesMetadataParam): Promise<GetCategories_Response_200>;
+  /**
+   * Returns the category with this slug
+   *
+   * @summary Get category
+   */
+  get(path: string, metadata: GetCategoryMetadataParam): Promise<Error_CATEGORY_NOTFOUND>;
+  /**
+   * Returns the docs and children docs within this category
+   *
+   * @summary Get docs for category
+   */
+  get(path: string, metadata: GetCategoryDocsMetadataParam): Promise<Error_CATEGORY_NOTFOUND>;
+  /**
+   * Returns a list of changelogs associated with the project API key
+   *
+   * @summary Get changelogs
+   */
+  get(path: string, metadata?: GetChangelogsMetadataParam): Promise<GetChangelogs_Response_200>;
+  /**
+   * Returns a list of custom pages associated with the project API key
+   *
+   * @summary Get custom pages
+   */
+  get(
+    path: string,
+    metadata?: GetCustomPagesMetadataParam
+  ): Promise<GetCustomPages_Response_200 | GetCustomPages_Response_401 | GetCustomPages_Response_403>;
+  /**
+   * Returns the custom page with this slug
+   *
+   * @summary Get custom page
+   */
+  get(
+    path: string,
+    metadata: GetCustomPageMetadataParam
+  ): Promise<GetCustomPage_Response_401 | GetCustomPage_Response_403 | Error_CUSTOMPAGE_NOTFOUND>;
+  /**
+   * Returns the doc with this slug
+   *
+   * @summary Get doc
+   */
+  get(
+    path: string,
+    metadata: GetDocMetadataParam
+  ): Promise<GetDoc_Response_401 | GetDoc_Response_403 | Error_DOC_NOTFOUND>;
+  /**
+   * Returns the version with this version ID
+   *
+   * @summary Get version
+   */
+  get(
+    path: string,
+    metadata: GetVersionMetadataParam
+  ): Promise<GetVersion_Response_401 | GetVersion_Response_403 | Error_VERSION_NOTFOUND>;
+  /**
+   * Access any get endpoint on your API.
+   *
+   * @param path API path to make a request against.
+   * @param metadata Object containing all path, query, header, and cookie parameters to supply.
+   */
+  get<T = unknown>(path: string, metadata?: Record<string, unknown>): Promise<T> {
+    return this.core.fetch(path, 'get', metadata);
+  }
+
+  /**
+   * This endpoint will let you apply to a job at ReadMe programatically, without having to go through our UI!
+   *
+   * @summary Submit your application!
+   */
+  post<T = unknown>(path: string, body: Apply): Promise<T>;
+  /**
+   * Create a new changelog inside of this project
+   *
+   * @summary Create changelog
+   */
+  post<T = unknown>(path: string, body: Changelog): Promise<T>;
+  /**
+   * Upload an API specification to ReadMe. Or, to use a newer solution see https://docs.readme.com/docs/automatically-sync-api-specification-with-github
+   *
+   * @summary Upload specification
+   */
+  post(
+    path: string,
+    body: UploadAPISpecificationBodyParam,
+    metadata?: UploadAPISpecificationMetadataParam
+  ): Promise<
+    | UploadAPISpecification_Response_400
+    | UploadAPISpecification_Response_401
+    | UploadAPISpecification_Response_403
+    | Error_SPEC_TIMEOUT
+  >;
+  /**
+   * Create a new category inside of this project
+   *
+   * @summary Create category
+   */
+  post(path: string, body: Category, metadata?: CreateCategoryMetadataParam): Promise<Error_CATEGORY_INVALID>;
+  /**
+   * Create a new custom page inside of this project
+   *
+   * @summary Create custom page
+   */
+  post(
+    path: string,
+    body: CustomPage
+  ): Promise<Error_CUSTOMPAGE_INVALID | CreateCustomPage_Response_401 | CreateCustomPage_Response_403>;
+  /**
+   * Create a new doc inside of this project
+   *
+   * @summary Create doc
+   */
+  post(
+    path: string,
+    body: Doc,
+    metadata?: CreateDocMetadataParam
+  ): Promise<Error_DOC_INVALID | CreateDoc_Response_401 | CreateDoc_Response_403>;
+  /**
+   * Returns all docs that match the search
+   *
+   * @summary Search docs
+   */
+  post(path: string, metadata: SearchDocsMetadataParam): Promise<SearchDocs_Response_401 | SearchDocs_Response_403>;
+  /**
+   * Create a new version
+   *
+   * @summary Create version
+   */
+  post(
+    path: string,
+    body: Version
+  ): Promise<
+    CreateVersion_Response_400 | CreateVersion_Response_401 | CreateVersion_Response_403 | Error_VERSION_FORK_NOTFOUND
+  >;
+  /**
+   * Access any post endpoint on your API.
+   *
+   * @param path API path to make a request against.
+   * @param body Request body payload data.
+   * @param metadata Object containing all path, query, header, and cookie parameters to supply.
+   */
+  post<T = unknown>(path: string, body?: unknown, metadata?: Record<string, unknown>): Promise<T> {
+    return this.core.fetch(path, 'post', body, metadata);
+  }
+
+  /**
+   * Update a changelog with this slug
+   *
+   * @summary Update changelog
+   */
+  put<T = unknown>(path: string, body: Changelog, metadata: UpdateChangelogMetadataParam): Promise<T>;
+  /**
+   * Update an API specification in ReadMe
+   *
+   * @summary Update specification
+   */
+  put(
+    path: string,
+    body: UpdateAPISpecificationBodyParam,
+    metadata: UpdateAPISpecificationMetadataParam
+  ): Promise<
+    | UpdateAPISpecification_Response_400
+    | UpdateAPISpecification_Response_401
+    | UpdateAPISpecification_Response_403
+    | Error_SPEC_TIMEOUT
+  >;
+  /**
+   * Change the properties of a category.
+   *
+   * @summary Update category
+   */
+  put(
+    path: string,
+    body: Category,
+    metadata: UpdateCategoryMetadataParam
+  ): Promise<Error_CATEGORY_INVALID | Error_CATEGORY_NOTFOUND>;
+  /**
+   * Update a custom page with this slug
+   *
+   * @summary Update custom page
+   */
+  put(
+    path: string,
+    body: CustomPage,
+    metadata: UpdateCustomPageMetadataParam
+  ): Promise<
+    Error_CUSTOMPAGE_INVALID | UpdateCustomPage_Response_401 | UpdateCustomPage_Response_403 | Error_CUSTOMPAGE_NOTFOUND
+  >;
+  /**
+   * Update a doc with this slug
+   *
+   * @summary Update doc
+   */
+  put(
+    path: string,
+    body: Doc,
+    metadata: UpdateDocMetadataParam
+  ): Promise<Error_DOC_INVALID | UpdateDoc_Response_401 | UpdateDoc_Response_403 | Error_DOC_NOTFOUND>;
+  /**
+   * Update an existing version
+   *
+   * @summary Update version
+   */
+  put(
+    path: string,
+    body: Version,
+    metadata: UpdateVersionMetadataParam
+  ): Promise<
+    Error_VERSION_CANT_DEMOTE_STABLE | UpdateVersion_Response_401 | UpdateVersion_Response_403 | Error_VERSION_NOTFOUND
+  >;
+  /**
+   * Access any put endpoint on your API.
+   *
+   * @param path API path to make a request against.
+   * @param body Request body payload data.
+   * @param metadata Object containing all path, query, header, and cookie parameters to supply.
+   */
+  put<T = unknown>(path: string, body?: unknown, metadata?: Record<string, unknown>): Promise<T> {
+    return this.core.fetch(path, 'put', body, metadata);
+  }
+
+  /**
+   * Delete the changelog with this slug
+   *
+   * @summary Delete changelog
+   */
+  delete<T = unknown>(path: string, metadata: DeleteChangelogMetadataParam): Promise<T>;
+  /**
+   * Delete an API specification in ReadMe
+   *
+   * @summary Delete specification
+   */
+  delete(
+    path: string,
+    metadata: DeleteAPISpecificationMetadataParam
+  ): Promise<
+    | Error_SPEC_ID_INVALID
+    | DeleteAPISpecification_Response_401
+    | DeleteAPISpecification_Response_403
+    | Error_SPEC_NOTFOUND
+  >;
+  /**
+   * Delete the category with this slug.
+   * >⚠️Heads Up!
+   * > This will also delete all of the docs within this category.
+   *
+   * @summary Delete category
+   */
+  delete(path: string, metadata: DeleteCategoryMetadataParam): Promise<Error_CATEGORY_NOTFOUND>;
+  /**
+   * Delete the custom page with this slug
+   *
+   * @summary Delete custom page
+   */
+  delete(
+    path: string,
+    metadata: DeleteCustomPageMetadataParam
+  ): Promise<DeleteCustomPage_Response_401 | DeleteCustomPage_Response_403 | Error_CUSTOMPAGE_NOTFOUND>;
+  /**
+   * Delete the doc with this slug
+   *
+   * @summary Delete doc
+   */
+  delete(
+    path: string,
+    metadata: DeleteDocMetadataParam
+  ): Promise<DeleteDoc_Response_401 | DeleteDoc_Response_403 | Error_DOC_NOTFOUND>;
+  /**
+   * Delete a version
+   *
+   * @summary Delete version
+   */
+  delete(
+    path: string,
+    metadata: DeleteVersionMetadataParam
+  ): Promise<
+    Error_VERSION_CANT_REMOVE_STABLE | DeleteVersion_Response_401 | DeleteVersion_Response_403 | Error_VERSION_NOTFOUND
+  >;
+  /**
+   * Access any delete endpoint on your API.
+   *
+   * @param path API path to make a request against.
+   * @param body Request body payload data.
+   * @param metadata Object containing all path, query, header, and cookie parameters to supply.
+   */
+  delete<T = unknown>(path: string, body?: unknown, metadata?: Record<string, unknown>): Promise<T> {
+    return this.core.fetch(path, 'delete', body, metadata);
+  }
+
+  /**
+   * Returns all the roles we're hiring for at ReadMe!
+   *
+   * @summary Get open roles
+   */
+  getOpenRoles(): Promise<GetOpenRoles_Response_200> {
+    return this.core.fetch('/apply', 'get');
+  }
+
+  /**
+   * Returns with all of the error page types for this project
+   *
+   * @summary Get errors
+   */
+  getErrors(): Promise<GetErrors_Response_401 | GetErrors_Response_403> {
+    return this.core.fetch('/errors', 'get');
+  }
+
+  /**
+   * Returns project data for API key
+   *
+   * @summary Get metadata about the current project
+   */
+  getProject(): Promise<CondensedProjectData | GetProject_Response_401 | GetProject_Response_403> {
+    return this.core.fetch('/', 'get');
+  }
+
+  /**
+   * Retrieve a list of versions associated with a project API key
+   *
+   * @summary Get versions
+   */
+  getVersions(): Promise<GetVersions_Response_401 | GetVersions_Response_403> {
+    return this.core.fetch('/version', 'get');
+  }
+
+  /**
+   * This endpoint will let you apply to a job at ReadMe programatically, without having to go through our UI!
+   *
+   * @summary Submit your application!
+   */
+  applyToReadMe<T = unknown>(body: Apply): Promise<T> {
+    return this.core.fetch('/apply', 'post', body);
+  }
+
+  /**
+   * Create a new changelog inside of this project
+   *
+   * @summary Create changelog
+   */
+  createChangelog<T = unknown>(body: Changelog): Promise<T> {
+    return this.core.fetch('/changelogs', 'post', body);
+  }
+
+  /**
+   * Returns the changelog with this slug
+   *
+   * @summary Get changelog
+   */
+  getChangelog<T = unknown>(metadata: GetChangelogMetadataParam): Promise<T> {
+    return this.core.fetch('/changelogs/{slug}', 'get', metadata);
+  }
+
+  /**
+   * Update a changelog with this slug
+   *
+   * @summary Update changelog
+   */
+  updateChangelog<T = unknown>(body: Changelog, metadata: UpdateChangelogMetadataParam): Promise<T> {
+    return this.core.fetch('/changelogs/{slug}', 'put', body, metadata);
+  }
+
+  /**
+   * Delete the changelog with this slug
+   *
+   * @summary Delete changelog
+   */
+  deleteChangelog<T = unknown>(metadata: DeleteChangelogMetadataParam): Promise<T> {
+    return this.core.fetch('/changelogs/{slug}', 'delete', metadata);
+  }
+
+  /**
+   * Get an API definition file that's been uploaded to ReadMe
+   *
+   * @summary Retrieve an entry from the API Registry
+   */
+  getAPIRegistry(
+    metadata: GetAPIRegistryMetadataParam
+  ): Promise<GetAPIRegistry_Response_200 | Error_REGISTRY_NOTFOUND> {
+    return this.core.fetch('/api-registry/{uuid}', 'get', metadata);
+  }
+
+  /**
+   * Get API specification metadata
+   *
+   * @summary Get metadata
+   */
+  getAPISpecification(
+    metadata?: GetAPISpecificationMetadataParam
+  ): Promise<
+    | GetAPISpecification_Response_200
+    | Error_VERSION_EMPTY
+    | GetAPISpecification_Response_401
+    | GetAPISpecification_Response_403
+    | Error_VERSION_NOTFOUND
+  > {
+    return this.core.fetch('/api-specification', 'get', metadata);
+  }
+
+  /**
+   * Upload an API specification to ReadMe. Or, to use a newer solution see https://docs.readme.com/docs/automatically-sync-api-specification-with-github
+   *
+   * @summary Upload specification
+   */
+  uploadAPISpecification(
+    body: UploadAPISpecificationBodyParam,
+    metadata?: UploadAPISpecificationMetadataParam
+  ): Promise<
+    | UploadAPISpecification_Response_400
+    | UploadAPISpecification_Response_401
+    | UploadAPISpecification_Response_403
+    | Error_SPEC_TIMEOUT
+  > {
+    return this.core.fetch('/api-specification', 'post', body, metadata);
+  }
+
+  /**
+   * Update an API specification in ReadMe
+   *
+   * @summary Update specification
+   */
+  updateAPISpecification(
+    body: UpdateAPISpecificationBodyParam,
+    metadata: UpdateAPISpecificationMetadataParam
+  ): Promise<
+    | UpdateAPISpecification_Response_400
+    | UpdateAPISpecification_Response_401
+    | UpdateAPISpecification_Response_403
+    | Error_SPEC_TIMEOUT
+  > {
+    return this.core.fetch('/api-specification/{id}', 'put', body, metadata);
+  }
+
+  /**
+   * Delete an API specification in ReadMe
+   *
+   * @summary Delete specification
+   */
+  deleteAPISpecification(
+    metadata: DeleteAPISpecificationMetadataParam
+  ): Promise<
+    | Error_SPEC_ID_INVALID
+    | DeleteAPISpecification_Response_401
+    | DeleteAPISpecification_Response_403
+    | Error_SPEC_NOTFOUND
+  > {
+    return this.core.fetch('/api-specification/{id}', 'delete', metadata);
+  }
+
+  /**
+   * Returns all the categories for a specified version
+   *
+   * @summary Get all categories
+   */
+  getCategories(metadata?: GetCategoriesMetadataParam): Promise<GetCategories_Response_200> {
+    return this.core.fetch('/categories', 'get', metadata);
+  }
+
+  /**
+   * Create a new category inside of this project
+   *
+   * @summary Create category
+   */
+  createCategory(body: Category, metadata?: CreateCategoryMetadataParam): Promise<Error_CATEGORY_INVALID> {
+    return this.core.fetch('/categories', 'post', body, metadata);
+  }
+
+  /**
+   * Returns the category with this slug
+   *
+   * @summary Get category
+   */
+  getCategory(metadata: GetCategoryMetadataParam): Promise<Error_CATEGORY_NOTFOUND> {
+    return this.core.fetch('/categories/{slug}', 'get', metadata);
+  }
+
+  /**
+   * Change the properties of a category.
+   *
+   * @summary Update category
+   */
+  updateCategory(
+    body: Category,
+    metadata: UpdateCategoryMetadataParam
+  ): Promise<Error_CATEGORY_INVALID | Error_CATEGORY_NOTFOUND> {
+    return this.core.fetch('/categories/{slug}', 'put', body, metadata);
+  }
+
+  /**
+   * Delete the category with this slug.
+   * >⚠️Heads Up!
+   * > This will also delete all of the docs within this category.
+   *
+   * @summary Delete category
+   */
+  deleteCategory(metadata: DeleteCategoryMetadataParam): Promise<Error_CATEGORY_NOTFOUND> {
+    return this.core.fetch('/categories/{slug}', 'delete', metadata);
+  }
+
+  /**
+   * Returns the docs and children docs within this category
+   *
+   * @summary Get docs for category
+   */
+  getCategoryDocs(metadata: GetCategoryDocsMetadataParam): Promise<Error_CATEGORY_NOTFOUND> {
+    return this.core.fetch('/categories/{slug}/docs', 'get', metadata);
+  }
+
+  /**
+   * Returns a list of changelogs associated with the project API key
+   *
+   * @summary Get changelogs
+   */
+  getChangelogs(metadata?: GetChangelogsMetadataParam): Promise<GetChangelogs_Response_200> {
+    return this.core.fetch('/changelogs', 'get', metadata);
+  }
+
+  /**
+   * Returns a list of custom pages associated with the project API key
+   *
+   * @summary Get custom pages
+   */
+  getCustomPages(
+    metadata?: GetCustomPagesMetadataParam
+  ): Promise<GetCustomPages_Response_200 | GetCustomPages_Response_401 | GetCustomPages_Response_403> {
+    return this.core.fetch('/custompages', 'get', metadata);
+  }
+
+  /**
+   * Create a new custom page inside of this project
+   *
+   * @summary Create custom page
+   */
+  createCustomPage(
+    body: CustomPage
+  ): Promise<Error_CUSTOMPAGE_INVALID | CreateCustomPage_Response_401 | CreateCustomPage_Response_403> {
+    return this.core.fetch('/custompages', 'post', body);
+  }
+
+  /**
+   * Returns the custom page with this slug
+   *
+   * @summary Get custom page
+   */
+  getCustomPage(
+    metadata: GetCustomPageMetadataParam
+  ): Promise<GetCustomPage_Response_401 | GetCustomPage_Response_403 | Error_CUSTOMPAGE_NOTFOUND> {
+    return this.core.fetch('/custompages/{slug}', 'get', metadata);
+  }
+
+  /**
+   * Update a custom page with this slug
+   *
+   * @summary Update custom page
+   */
+  updateCustomPage(
+    body: CustomPage,
+    metadata: UpdateCustomPageMetadataParam
+  ): Promise<
+    Error_CUSTOMPAGE_INVALID | UpdateCustomPage_Response_401 | UpdateCustomPage_Response_403 | Error_CUSTOMPAGE_NOTFOUND
+  > {
+    return this.core.fetch('/custompages/{slug}', 'put', body, metadata);
+  }
+
+  /**
+   * Delete the custom page with this slug
+   *
+   * @summary Delete custom page
+   */
+  deleteCustomPage(
+    metadata: DeleteCustomPageMetadataParam
+  ): Promise<DeleteCustomPage_Response_401 | DeleteCustomPage_Response_403 | Error_CUSTOMPAGE_NOTFOUND> {
+    return this.core.fetch('/custompages/{slug}', 'delete', metadata);
+  }
+
+  /**
+   * Returns the doc with this slug
+   *
+   * @summary Get doc
+   */
+  getDoc(metadata: GetDocMetadataParam): Promise<GetDoc_Response_401 | GetDoc_Response_403 | Error_DOC_NOTFOUND> {
+    return this.core.fetch('/docs/{slug}', 'get', metadata);
+  }
+
+  /**
+   * Update a doc with this slug
+   *
+   * @summary Update doc
+   */
+  updateDoc(
+    body: Doc,
+    metadata: UpdateDocMetadataParam
+  ): Promise<Error_DOC_INVALID | UpdateDoc_Response_401 | UpdateDoc_Response_403 | Error_DOC_NOTFOUND> {
+    return this.core.fetch('/docs/{slug}', 'put', body, metadata);
+  }
+
+  /**
+   * Delete the doc with this slug
+   *
+   * @summary Delete doc
+   */
+  deleteDoc(
+    metadata: DeleteDocMetadataParam
+  ): Promise<DeleteDoc_Response_401 | DeleteDoc_Response_403 | Error_DOC_NOTFOUND> {
+    return this.core.fetch('/docs/{slug}', 'delete', metadata);
+  }
+
+  /**
+   * Create a new doc inside of this project
+   *
+   * @summary Create doc
+   */
+  createDoc(
+    body: Doc,
+    metadata?: CreateDocMetadataParam
+  ): Promise<Error_DOC_INVALID | CreateDoc_Response_401 | CreateDoc_Response_403> {
+    return this.core.fetch('/docs', 'post', body, metadata);
+  }
+
+  /**
+   * Returns all docs that match the search
+   *
+   * @summary Search docs
+   */
+  searchDocs(metadata: SearchDocsMetadataParam): Promise<SearchDocs_Response_401 | SearchDocs_Response_403> {
+    return this.core.fetch('/docs/search', 'post', metadata);
+  }
+
+  /**
+   * Create a new version
+   *
+   * @summary Create version
+   */
+  createVersion(
+    body: Version
+  ): Promise<
+    CreateVersion_Response_400 | CreateVersion_Response_401 | CreateVersion_Response_403 | Error_VERSION_FORK_NOTFOUND
+  > {
+    return this.core.fetch('/version', 'post', body);
+  }
+
+  /**
+   * Returns the version with this version ID
+   *
+   * @summary Get version
+   */
+  getVersion(
+    metadata: GetVersionMetadataParam
+  ): Promise<GetVersion_Response_401 | GetVersion_Response_403 | Error_VERSION_NOTFOUND> {
+    return this.core.fetch('/version/{versionId}', 'get', metadata);
+  }
+
+  /**
+   * Update an existing version
+   *
+   * @summary Update version
+   */
+  updateVersion(
+    body: Version,
+    metadata: UpdateVersionMetadataParam
+  ): Promise<
+    Error_VERSION_CANT_DEMOTE_STABLE | UpdateVersion_Response_401 | UpdateVersion_Response_403 | Error_VERSION_NOTFOUND
+  > {
+    return this.core.fetch('/version/{versionId}', 'put', body, metadata);
+  }
+
+  /**
+   * Delete a version
+   *
+   * @summary Delete version
+   */
+  deleteVersion(
+    metadata: DeleteVersionMetadataParam
+  ): Promise<
+    Error_VERSION_CANT_REMOVE_STABLE | DeleteVersion_Response_401 | DeleteVersion_Response_403 | Error_VERSION_NOTFOUND
+  > {
+    return this.core.fetch('/version/{versionId}', 'delete', metadata);
+  }
+}
+
+interface ConfigOptions {
+  /**
+   * By default we parse the response based on the `Content-Type` header of the request. You
+   * can disable this functionality by negating this option.
+   */
+  parseResponse: boolean;
+}
+export type GetAPIRegistryMetadataParam = {
+  /**
+   * An API Registry UUID. This can be found by navigating to your API Reference page and viewing code snippets for Node with the `api` library.
+   */
+  uuid: string;
+  [k: string]: unknown;
+};
+export type GetAPISpecificationMetadataParam = {
+  /**
+   * Number of items to include in pagination (up to 100, defaults to 10)
+   */
+  perPage?: number;
+  /**
+   * Used to specify further pages (starts at 1)
+   */
+  page?: number;
+  [k: string]: unknown;
+} & {
+  /**
+   * Version number of your docs project, for example, v3.0. By default the main project version is used. To see all valid versions for your docs project call https://docs.readme.com/reference/version#getversions.
+   */
+  'x-readme-version'?: string;
+  [k: string]: unknown;
+};
+export interface UploadAPISpecificationBodyParam {
+  /**
+   * OpenAPI/Swagger file
+   */
+  spec?: string;
+  [k: string]: unknown;
+}
+export type UploadAPISpecificationMetadataParam = {
+  /**
+   * Version number of your docs project, for example, v3.0. By default the main project version is used. To see all valid versions for your docs project call https://docs.readme.com/reference/version#getversions.
+   */
+  'x-readme-version'?: string;
+  [k: string]: unknown;
+};
+export interface UpdateAPISpecificationBodyParam {
+  /**
+   * OpenAPI/Swagger file
+   */
+  spec?: string;
+  [k: string]: unknown;
+}
+export type UpdateAPISpecificationMetadataParam = {
+  /**
+   * ID of the API specification. The unique ID for each API can be found by navigating to your **API Definitions** page.
+   */
+  id: string;
+  [k: string]: unknown;
+};
+export type DeleteAPISpecificationMetadataParam = {
+  /**
+   * ID of the API specification. The unique ID for each API can be found by navigating to your **API Definitions** page.
+   */
+  id: string;
+  [k: string]: unknown;
+};
+export type GetOpenRoles_Response_200 = JobOpening[];
+export interface JobOpening {
+  /**
+   * A slugified version of the job opening title.
+   */
+  slug?: string;
+  /**
+   * The job opening position.
+   */
+  title?: string;
+  /**
+   * The description for this open position. This content is formatted as HTML.
+   */
+  description?: string;
+  /**
+   * A short pullquote for the open position.
+   */
+  pullquote?: string;
+  /**
+   * Where this position is located at.
+   */
+  location?: string;
+  /**
+   * The internal organization you'll be working in.
+   */
+  department?: string;
+  /**
+   * The place where you can apply for the position!
+   */
+  url?: string;
+  [k: string]: unknown;
+}
+export interface Apply {
+  /**
+   * Your full name
+   */
+  name: string;
+  /**
+   * A valid email we can reach you at
+   */
+  email: string;
+  /**
+   * The job you're looking to apply for (https://readme.com/careers)
+   */
+  job:
+    | 'Content Marketing Manager'
+    | 'Engineering Manager'
+    | 'Head of People'
+    | 'Marketing Campaigns Manager'
+    | 'Marketing Designer'
+    | 'Product Designer'
+    | 'Product Education Manager'
+    | 'Sales Development Representative'
+    | 'Support Engineer (Weekends)';
+  /**
+   * Learn more at https://pronoun.is/
+   */
+  pronouns?: string;
+  /**
+   * What have you been up to the past few years?
+   */
+  linkedin?: string;
+  /**
+   * Or Bitbucket, Gitlab or anywhere else your code is hosted!
+   */
+  github?: string;
+  /**
+   * What should we know about you?
+   */
+  coverLetter?: string;
+  /**
+   * Want to play with the API but not actually apply? Set this to true.
+   */
+  dontReallyApply?: boolean;
+  [k: string]: unknown;
+}
+export type GetCategoriesMetadataParam = {
+  /**
+   * Number of items to include in pagination (up to 100, defaults to 10)
+   */
+  perPage?: number;
+  /**
+   * Used to specify further pages (starts at 1)
+   */
+  page?: number;
+  [k: string]: unknown;
+} & {
+  /**
+   * Version number of your docs project, for example, v3.0. By default the main project version is used. To see all valid versions for your docs project call https://docs.readme.com/reference/version#getversions.
+   */
+  'x-readme-version'?: string;
+  [k: string]: unknown;
+};
+export interface Category {
+  /**
+   * A short title for the category. This is what will show in the sidebar.
+   */
+  title?: string;
+  /**
+   * A category can be part of your reference or guide documentation, which is determined by this field.
+   */
+  type?: 'reference' | 'guide';
+  [k: string]: unknown;
+}
+export type CreateCategoryMetadataParam = {
+  /**
+   * Version number of your docs project, for example, v3.0. By default the main project version is used. To see all valid versions for your docs project call https://docs.readme.com/reference/version#getversions.
+   */
+  'x-readme-version'?: string;
+  [k: string]: unknown;
+};
+export type GetCategoryMetadataParam = {
+  /**
+   * A URL-safe representation of the category title. Slugs must be all lowercase, and replace spaces with hyphens. For example, for the the category "Getting Started", enter the slug "getting-started"
+   */
+  slug: string;
+  [k: string]: unknown;
+} & {
+  /**
+   * Version number of your docs project, for example, v3.0. By default the main project version is used. To see all valid versions for your docs project call https://docs.readme.com/reference/version#getversions.
+   */
+  'x-readme-version'?: string;
+  [k: string]: unknown;
+};
+export type UpdateCategoryMetadataParam = {
+  /**
+   * A URL-safe representation of the category title. Slugs must be all lowercase, and replace spaces with hyphens. For example, for the the category "Getting Started", enter the slug "getting-started"
+   */
+  slug: string;
+  [k: string]: unknown;
+} & {
+  /**
+   * Version number of your docs project, for example, v3.0. By default the main project version is used. To see all valid versions for your docs project call https://docs.readme.com/reference/version#getversions.
+   */
+  'x-readme-version'?: string;
+  [k: string]: unknown;
+};
+export type DeleteCategoryMetadataParam = {
+  /**
+   * A URL-safe representation of the category title. Slugs must be all lowercase, and replace spaces with hyphens. For example, for the the category "Getting Started", enter the slug "getting-started"
+   */
+  slug: string;
+  [k: string]: unknown;
+} & {
+  /**
+   * Version number of your docs project, for example, v3.0. By default the main project version is used. To see all valid versions for your docs project call https://docs.readme.com/reference/version#getversions.
+   */
+  'x-readme-version'?: string;
+  [k: string]: unknown;
+};
+export type GetCategoryDocsMetadataParam = {
+  /**
+   * A URL-safe representation of the category title. Slugs must be all lowercase, and replace spaces with hyphens. For example, for the the category "Getting Started", enter the slug "getting-started"
+   */
+  slug: string;
+  [k: string]: unknown;
+} & {
+  /**
+   * Version number of your docs project, for example, v3.0. By default the main project version is used. To see all valid versions for your docs project call https://docs.readme.com/reference/version#getversions.
+   */
+  'x-readme-version'?: string;
+  [k: string]: unknown;
+};
+export type GetChangelogsMetadataParam = {
+  /**
+   * Number of items to include in pagination (up to 100, defaults to 10)
+   */
+  perPage?: number;
+  /**
+   * Used to specify further pages (starts at 1)
+   */
+  page?: number;
+  [k: string]: unknown;
+};
+export interface Changelog {
+  /**
+   * Title of the changelog
+   */
+  title: string;
+  type?: '' | 'added' | 'fixed' | 'improved' | 'deprecated' | 'removed';
+  /**
+   * Body content of the changelog
+   */
+  body: string;
+  /**
+   * Visibility of the changelog
+   */
+  hidden?: boolean;
+  [k: string]: unknown;
+}
+export type GetChangelogMetadataParam = {
+  /**
+   * A URL-safe representation of the changelog title. Slugs must be all lowercase, and replace spaces with hyphens. For example, for the the changelog "Owlet Weekly Update", enter the slug "owlet-weekly-update"
+   */
+  slug: string;
+  [k: string]: unknown;
+};
+export type UpdateChangelogMetadataParam = {
+  /**
+   * A URL-safe representation of the changelog title. Slugs must be all lowercase, and replace spaces with hyphens. For example, for the the changelog "Owlet Weekly Update", enter the slug "owlet-weekly-update"
+   */
+  slug: string;
+  [k: string]: unknown;
+};
+export type DeleteChangelogMetadataParam = {
+  /**
+   * A URL-safe representation of the changelog title. Slugs must be all lowercase, and replace spaces with hyphens. For example, for the the changelog "Owlet Weekly Update", enter the slug "owlet-weekly-update"
+   */
+  slug: string;
+  [k: string]: unknown;
+};
+export type GetCustomPagesMetadataParam = {
+  /**
+   * Number of items to include in pagination (up to 100, defaults to 10)
+   */
+  perPage?: number;
+  /**
+   * Used to specify further pages (starts at 1)
+   */
+  page?: number;
+  [k: string]: unknown;
+};
+export interface CustomPage {
+  /**
+   * Title of the custom page
+   */
+  title: string;
+  /**
+   * Body formatted in Markdown (displayed by default).
+   */
+  body?: string;
+  /**
+   * Body formatted in HTML (sanitized, only displayed if `htmlmode` is **true**).
+   */
+  html?: string;
+  /**
+   * **true** if `html` should be displayed, **false** if `body` should be displayed.
+   */
+  htmlmode?: boolean;
+  /**
+   * Visibility of the custom page
+   */
+  hidden?: boolean;
+  [k: string]: unknown;
+}
+export type GetCustomPageMetadataParam = {
+  /**
+   * A URL-safe representation of the custom page title. Slugs must be all lowercase, and replace spaces with hyphens. For example, for the the custom page "Getting Started", enter the slug "getting-started"
+   */
+  slug: string;
+  [k: string]: unknown;
+};
+export type UpdateCustomPageMetadataParam = {
+  /**
+   * A URL-safe representation of the custom page title. Slugs must be all lowercase, and replace spaces with hyphens. For example, for the the custom page "Getting Started", enter the slug "getting-started"
+   */
+  slug: string;
+  [k: string]: unknown;
+};
+export type DeleteCustomPageMetadataParam = {
+  /**
+   * A URL-safe representation of the custom page title. Slugs must be all lowercase, and replace spaces with hyphens. For example, for the the custom page "Getting Started", enter the slug "getting-started"
+   */
+  slug: string;
+  [k: string]: unknown;
+};
+export type GetDocMetadataParam = {
+  /**
+   * A URL-safe representation of the doc title. Slugs must be all lowercase, and replace spaces with hyphens. For example, for the the doc "New Features", enter the slug "new-features"
+   */
+  slug: string;
+  [k: string]: unknown;
+} & {
+  /**
+   * Version number of your docs project, for example, v3.0. By default the main project version is used. To see all valid versions for your docs project call https://docs.readme.com/reference/version#getversions.
+   */
+  'x-readme-version'?: string;
+  [k: string]: unknown;
+};
+export interface Doc {
+  /**
+   * Title of the page
+   */
+  title: string;
+  /**
+   * Type of the page. The available types all show up under the /docs/ URL path of your docs project (also known as the "guides" section). Can be "basic" (most common), "error" (page desribing an API error), or "link" (page that redirects to an external link)
+   */
+  type?: 'basic' | 'error' | 'link';
+  /**
+   * Body content of the page, formatted in ReadMe or GitHub flavored Markdown. Accepts long page content, for example, greater than 100k characters
+   */
+  body?: string;
+  /**
+   * Category ID of the page, which you can get through https://docs.readme.com/reference/categories#getcategory
+   */
+  category: string;
+  /**
+   * Visibility of the page
+   */
+  hidden?: boolean;
+  /**
+   * The position of the page in your project sidebar.
+   */
+  order?: number;
+  /**
+   * For a subpage, specify the parent doc ID, which you can get through https://docs.readme.com/reference/docs#getdoc
+   */
+  parentDoc?: string;
+  error?: {
+    /**
+     * The error code for docs with the "error" type
+     */
+    code?: string;
+    [k: string]: unknown;
+  };
+  [k: string]: unknown;
+}
+export type UpdateDocMetadataParam = {
+  /**
+   * A URL-safe representation of the doc title. Slugs must be all lowercase, and replace spaces with hyphens. For example, for the the doc "New Features", enter the slug "new-features"
+   */
+  slug: string;
+  [k: string]: unknown;
+} & {
+  /**
+   * Version number of your docs project, for example, v3.0. By default the main project version is used. To see all valid versions for your docs project call https://docs.readme.com/reference/version#getversions.
+   */
+  'x-readme-version'?: string;
+  [k: string]: unknown;
+};
+export type DeleteDocMetadataParam = {
+  /**
+   * A URL-safe representation of the doc title. Slugs must be all lowercase, and replace spaces with hyphens. For example, for the the doc "New Features", enter the slug "new-features"
+   */
+  slug: string;
+  [k: string]: unknown;
+} & {
+  /**
+   * Version number of your docs project, for example, v3.0. By default the main project version is used. To see all valid versions for your docs project call https://docs.readme.com/reference/version#getversions.
+   */
+  'x-readme-version'?: string;
+  [k: string]: unknown;
+};
+export type CreateDocMetadataParam = {
+  /**
+   * Version number of your docs project, for example, v3.0. By default the main project version is used. To see all valid versions for your docs project call https://docs.readme.com/reference/version#getversions.
+   */
+  'x-readme-version'?: string;
+  [k: string]: unknown;
+};
+export type SearchDocsMetadataParam = {
+  /**
+   * Search string to look for
+   */
+  search: string;
+  [k: string]: unknown;
+} & {
+  /**
+   * Version number of your docs project, for example, v3.0. By default the main project version is used. To see all valid versions for your docs project call https://docs.readme.com/reference/version#getversions.
+   */
+  'x-readme-version'?: string;
+  [k: string]: unknown;
+};
+export type GetErrors_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
+export interface Error_APIKEY_EMPTY {
+  /**
+   * An error code unique to the error received.
+   */
+  error?: string;
+  /**
+   * The reason why the error occured.
+   */
+  message?: string;
+  /**
+   * A helpful suggestion for how to alleviate the error.
+   */
+  suggestion?: string;
+  /**
+   * A [ReadMe Metrics](https://readme.com/metrics/) log URL where you can see more information the request that you made. If we have metrics URLs unavailable for your request, this URL will be a URL to our API Reference.
+   */
+  docs?: string;
+  /**
+   * Information on where you can receive additional assistance from our wonderful support team.
+   */
+  help?: string;
+  /**
+   * A short poem we wrote you about your error.
+   */
+  poem?: string[];
+  [k: string]: unknown;
+}
+export interface Error_APIKEY_NOTFOUND {
+  /**
+   * An error code unique to the error received.
+   */
+  error?: string;
+  /**
+   * The reason why the error occured.
+   */
+  message?: string;
+  /**
+   * A helpful suggestion for how to alleviate the error.
+   */
+  suggestion?: string;
+  /**
+   * A [ReadMe Metrics](https://readme.com/metrics/) log URL where you can see more information the request that you made. If we have metrics URLs unavailable for your request, this URL will be a URL to our API Reference.
+   */
+  docs?: string;
+  /**
+   * Information on where you can receive additional assistance from our wonderful support team.
+   */
+  help?: string;
+  /**
+   * A short poem we wrote you about your error.
+   */
+  poem?: string[];
+  [k: string]: unknown;
+}
+export type GetErrors_Response_403 = Error_APIKEY_MISMATCH;
+export interface Error_APIKEY_MISMATCH {
+  /**
+   * An error code unique to the error received.
+   */
+  error?: string;
+  /**
+   * The reason why the error occured.
+   */
+  message?: string;
+  /**
+   * A helpful suggestion for how to alleviate the error.
+   */
+  suggestion?: string;
+  /**
+   * A [ReadMe Metrics](https://readme.com/metrics/) log URL where you can see more information the request that you made. If we have metrics URLs unavailable for your request, this URL will be a URL to our API Reference.
+   */
+  docs?: string;
+  /**
+   * Information on where you can receive additional assistance from our wonderful support team.
+   */
+  help?: string;
+  /**
+   * A short poem we wrote you about your error.
+   */
+  poem?: string[];
+  [k: string]: unknown;
+}
+export interface CondensedProjectData {
+  name?: string;
+  subdomain?: string;
+  jwtSecret?: string;
+  /**
+   * The base URL for the project. If the project is not running under a custom domain, it will be `https://projectSubdomain.readme.io`, otherwise it can either be or `https://example.com` or, in the case of an enterprise child project `https://example.com/projectSubdomain`.
+   */
+  baseUrl?: string;
+  plan?: string;
+  [k: string]: unknown;
+}
+export type GetProject_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
+export type GetProject_Response_403 = Error_APIKEY_MISMATCH;
+export type GetVersions_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
+export type GetVersions_Response_403 = Error_APIKEY_MISMATCH;
+export interface Version {
+  /**
+   * Semantic Version
+   */
+  version: string;
+  /**
+   * Dubbed name of version
+   */
+  codename?: string;
+  /**
+   * Semantic Version to use as the base fork
+   */
+  from: string;
+  /**
+   * Should this be the **main** version
+   */
+  is_stable?: boolean;
+  is_beta?: boolean;
+  /**
+   * Should this be publically accessible?
+   */
+  is_hidden?: boolean;
+  /**
+   * Should this be deprecated? Only allowed in PUT operations
+   */
+  is_deprecated?: boolean;
+  [k: string]: unknown;
+}
+export type GetVersionMetadataParam = {
+  /**
+   * Semver identifier for the project version. For best results, use the formatted `version_clean` value listed in the response from the [Get Versions endpoint](/reference/getversions).
+   */
+  versionId: string;
+  [k: string]: unknown;
+};
+export type UpdateVersionMetadataParam = {
+  /**
+   * Semver identifier for the project version. For best results, use the formatted `version_clean` value listed in the response from the [Get Versions endpoint](/reference/getversions).
+   */
+  versionId: string;
+  [k: string]: unknown;
+};
+export type DeleteVersionMetadataParam = {
+  /**
+   * Semver identifier for the project version. For best results, use the formatted `version_clean` value listed in the response from the [Get Versions endpoint](/reference/getversions).
+   */
+  versionId: string;
+  [k: string]: unknown;
+};
+export interface GetAPIRegistry_Response_200 {
+  [k: string]: unknown;
+}
+export interface Error_REGISTRY_NOTFOUND {
+  /**
+   * An error code unique to the error received.
+   */
+  error?: string;
+  /**
+   * The reason why the error occured.
+   */
+  message?: string;
+  /**
+   * A helpful suggestion for how to alleviate the error.
+   */
+  suggestion?: string;
+  /**
+   * A [ReadMe Metrics](https://readme.com/metrics/) log URL where you can see more information the request that you made. If we have metrics URLs unavailable for your request, this URL will be a URL to our API Reference.
+   */
+  docs?: string;
+  /**
+   * Information on where you can receive additional assistance from our wonderful support team.
+   */
+  help?: string;
+  /**
+   * A short poem we wrote you about your error.
+   */
+  poem?: string[];
+  [k: string]: unknown;
+}
+export interface GetAPISpecification_Response_200 {
+  /**
+   * Pagination information. See https://docs.readme.com/reference/pagination for more information.
+   */
+  Link?: string;
+  /**
+   * The total amount of results, ignoring pagination. See https://docs.readme.com/reference/pagination for more information about pagination.
+   */
+  'x-total-count'?: string;
+  [k: string]: unknown;
+}
+export interface Error_VERSION_EMPTY {
+  /**
+   * An error code unique to the error received.
+   */
+  error?: string;
+  /**
+   * The reason why the error occured.
+   */
+  message?: string;
+  /**
+   * A helpful suggestion for how to alleviate the error.
+   */
+  suggestion?: string;
+  /**
+   * A [ReadMe Metrics](https://readme.com/metrics/) log URL where you can see more information the request that you made. If we have metrics URLs unavailable for your request, this URL will be a URL to our API Reference.
+   */
+  docs?: string;
+  /**
+   * Information on where you can receive additional assistance from our wonderful support team.
+   */
+  help?: string;
+  /**
+   * A short poem we wrote you about your error.
+   */
+  poem?: string[];
+  [k: string]: unknown;
+}
+export type GetAPISpecification_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
+export type GetAPISpecification_Response_403 = Error_APIKEY_MISMATCH;
+export interface Error_VERSION_NOTFOUND {
+  /**
+   * An error code unique to the error received.
+   */
+  error?: string;
+  /**
+   * The reason why the error occured.
+   */
+  message?: string;
+  /**
+   * A helpful suggestion for how to alleviate the error.
+   */
+  suggestion?: string;
+  /**
+   * A [ReadMe Metrics](https://readme.com/metrics/) log URL where you can see more information the request that you made. If we have metrics URLs unavailable for your request, this URL will be a URL to our API Reference.
+   */
+  docs?: string;
+  /**
+   * Information on where you can receive additional assistance from our wonderful support team.
+   */
+  help?: string;
+  /**
+   * A short poem we wrote you about your error.
+   */
+  poem?: string[];
+  [k: string]: unknown;
+}
+export type UploadAPISpecification_Response_400 =
+  | Error_SPEC_FILE_EMPTY
+  | Error_SPEC_INVALID
+  | Error_SPEC_INVALID_SCHEMA
+  | Error_SPEC_VERSION_NOTFOUND;
+export interface Error_SPEC_FILE_EMPTY {
+  /**
+   * An error code unique to the error received.
+   */
+  error?: string;
+  /**
+   * The reason why the error occured.
+   */
+  message?: string;
+  /**
+   * A helpful suggestion for how to alleviate the error.
+   */
+  suggestion?: string;
+  /**
+   * A [ReadMe Metrics](https://readme.com/metrics/) log URL where you can see more information the request that you made. If we have metrics URLs unavailable for your request, this URL will be a URL to our API Reference.
+   */
+  docs?: string;
+  /**
+   * Information on where you can receive additional assistance from our wonderful support team.
+   */
+  help?: string;
+  /**
+   * A short poem we wrote you about your error.
+   */
+  poem?: string[];
+  [k: string]: unknown;
+}
+export interface Error_SPEC_INVALID {
+  /**
+   * An error code unique to the error received.
+   */
+  error?: string;
+  /**
+   * The reason why the error occured.
+   */
+  message?: string;
+  /**
+   * A helpful suggestion for how to alleviate the error.
+   */
+  suggestion?: string;
+  /**
+   * A [ReadMe Metrics](https://readme.com/metrics/) log URL where you can see more information the request that you made. If we have metrics URLs unavailable for your request, this URL will be a URL to our API Reference.
+   */
+  docs?: string;
+  /**
+   * Information on where you can receive additional assistance from our wonderful support team.
+   */
+  help?: string;
+  /**
+   * A short poem we wrote you about your error.
+   */
+  poem?: string[];
+  [k: string]: unknown;
+}
+export interface Error_SPEC_INVALID_SCHEMA {
+  /**
+   * An error code unique to the error received.
+   */
+  error?: string;
+  /**
+   * The reason why the error occured.
+   */
+  message?: string;
+  /**
+   * A helpful suggestion for how to alleviate the error.
+   */
+  suggestion?: string;
+  /**
+   * A [ReadMe Metrics](https://readme.com/metrics/) log URL where you can see more information the request that you made. If we have metrics URLs unavailable for your request, this URL will be a URL to our API Reference.
+   */
+  docs?: string;
+  /**
+   * Information on where you can receive additional assistance from our wonderful support team.
+   */
+  help?: string;
+  /**
+   * A short poem we wrote you about your error.
+   */
+  poem?: string[];
+  [k: string]: unknown;
+}
+export interface Error_SPEC_VERSION_NOTFOUND {
+  /**
+   * An error code unique to the error received.
+   */
+  error?: string;
+  /**
+   * The reason why the error occured.
+   */
+  message?: string;
+  /**
+   * A helpful suggestion for how to alleviate the error.
+   */
+  suggestion?: string;
+  /**
+   * A [ReadMe Metrics](https://readme.com/metrics/) log URL where you can see more information the request that you made. If we have metrics URLs unavailable for your request, this URL will be a URL to our API Reference.
+   */
+  docs?: string;
+  /**
+   * Information on where you can receive additional assistance from our wonderful support team.
+   */
+  help?: string;
+  /**
+   * A short poem we wrote you about your error.
+   */
+  poem?: string[];
+  [k: string]: unknown;
+}
+export type UploadAPISpecification_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
+export type UploadAPISpecification_Response_403 = Error_APIKEY_MISMATCH;
+export interface Error_SPEC_TIMEOUT {
+  /**
+   * An error code unique to the error received.
+   */
+  error?: string;
+  /**
+   * The reason why the error occured.
+   */
+  message?: string;
+  /**
+   * A helpful suggestion for how to alleviate the error.
+   */
+  suggestion?: string;
+  /**
+   * A [ReadMe Metrics](https://readme.com/metrics/) log URL where you can see more information the request that you made. If we have metrics URLs unavailable for your request, this URL will be a URL to our API Reference.
+   */
+  docs?: string;
+  /**
+   * Information on where you can receive additional assistance from our wonderful support team.
+   */
+  help?: string;
+  /**
+   * A short poem we wrote you about your error.
+   */
+  poem?: string[];
+  [k: string]: unknown;
+}
+export type UpdateAPISpecification_Response_400 =
+  | Error_SPEC_FILE_EMPTY
+  | Error_SPEC_ID_DUPLICATE
+  | Error_SPEC_ID_INVALID
+  | Error_SPEC_INVALID
+  | Error_SPEC_INVALID_SCHEMA
+  | Error_SPEC_VERSION_NOTFOUND;
+export interface Error_SPEC_ID_DUPLICATE {
+  /**
+   * An error code unique to the error received.
+   */
+  error?: string;
+  /**
+   * The reason why the error occured.
+   */
+  message?: string;
+  /**
+   * A helpful suggestion for how to alleviate the error.
+   */
+  suggestion?: string;
+  /**
+   * A [ReadMe Metrics](https://readme.com/metrics/) log URL where you can see more information the request that you made. If we have metrics URLs unavailable for your request, this URL will be a URL to our API Reference.
+   */
+  docs?: string;
+  /**
+   * Information on where you can receive additional assistance from our wonderful support team.
+   */
+  help?: string;
+  /**
+   * A short poem we wrote you about your error.
+   */
+  poem?: string[];
+  [k: string]: unknown;
+}
+export interface Error_SPEC_ID_INVALID {
+  /**
+   * An error code unique to the error received.
+   */
+  error?: string;
+  /**
+   * The reason why the error occured.
+   */
+  message?: string;
+  /**
+   * A helpful suggestion for how to alleviate the error.
+   */
+  suggestion?: string;
+  /**
+   * A [ReadMe Metrics](https://readme.com/metrics/) log URL where you can see more information the request that you made. If we have metrics URLs unavailable for your request, this URL will be a URL to our API Reference.
+   */
+  docs?: string;
+  /**
+   * Information on where you can receive additional assistance from our wonderful support team.
+   */
+  help?: string;
+  /**
+   * A short poem we wrote you about your error.
+   */
+  poem?: string[];
+  [k: string]: unknown;
+}
+export type UpdateAPISpecification_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
+export type UpdateAPISpecification_Response_403 = Error_APIKEY_MISMATCH;
+export type DeleteAPISpecification_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
+export type DeleteAPISpecification_Response_403 = Error_APIKEY_MISMATCH;
+export interface Error_SPEC_NOTFOUND {
+  /**
+   * An error code unique to the error received.
+   */
+  error?: string;
+  /**
+   * The reason why the error occured.
+   */
+  message?: string;
+  /**
+   * A helpful suggestion for how to alleviate the error.
+   */
+  suggestion?: string;
+  /**
+   * A [ReadMe Metrics](https://readme.com/metrics/) log URL where you can see more information the request that you made. If we have metrics URLs unavailable for your request, this URL will be a URL to our API Reference.
+   */
+  docs?: string;
+  /**
+   * Information on where you can receive additional assistance from our wonderful support team.
+   */
+  help?: string;
+  /**
+   * A short poem we wrote you about your error.
+   */
+  poem?: string[];
+  [k: string]: unknown;
+}
+export interface GetCategories_Response_200 {
+  /**
+   * Pagination information. See https://docs.readme.com/reference/pagination for more information.
+   */
+  Link?: string;
+  /**
+   * The total amount of results, ignoring pagination. See https://docs.readme.com/reference/pagination for more information about pagination.
+   */
+  'x-total-count'?: string;
+  [k: string]: unknown;
+}
+export interface Error_CATEGORY_INVALID {
+  /**
+   * An error code unique to the error received.
+   */
+  error?: string;
+  /**
+   * The reason why the error occured.
+   */
+  message?: string;
+  /**
+   * A helpful suggestion for how to alleviate the error.
+   */
+  suggestion?: string;
+  /**
+   * A [ReadMe Metrics](https://readme.com/metrics/) log URL where you can see more information the request that you made. If we have metrics URLs unavailable for your request, this URL will be a URL to our API Reference.
+   */
+  docs?: string;
+  /**
+   * Information on where you can receive additional assistance from our wonderful support team.
+   */
+  help?: string;
+  /**
+   * A short poem we wrote you about your error.
+   */
+  poem?: string[];
+  [k: string]: unknown;
+}
+export interface Error_CATEGORY_NOTFOUND {
+  /**
+   * An error code unique to the error received.
+   */
+  error?: string;
+  /**
+   * The reason why the error occured.
+   */
+  message?: string;
+  /**
+   * A helpful suggestion for how to alleviate the error.
+   */
+  suggestion?: string;
+  /**
+   * A [ReadMe Metrics](https://readme.com/metrics/) log URL where you can see more information the request that you made. If we have metrics URLs unavailable for your request, this URL will be a URL to our API Reference.
+   */
+  docs?: string;
+  /**
+   * Information on where you can receive additional assistance from our wonderful support team.
+   */
+  help?: string;
+  /**
+   * A short poem we wrote you about your error.
+   */
+  poem?: string[];
+  [k: string]: unknown;
+}
+export interface GetChangelogs_Response_200 {
+  /**
+   * Pagination information. See https://docs.readme.com/reference/pagination for more information.
+   */
+  Link?: string;
+  /**
+   * The total amount of results, ignoring pagination. See https://docs.readme.com/reference/pagination for more information about pagination.
+   */
+  'x-total-count'?: string;
+  [k: string]: unknown;
+}
+export interface GetCustomPages_Response_200 {
+  /**
+   * Pagination information. See https://docs.readme.com/reference/pagination for more information.
+   */
+  Link?: string;
+  /**
+   * The total amount of results, ignoring pagination. See https://docs.readme.com/reference/pagination for more information about pagination.
+   */
+  'x-total-count'?: string;
+  [k: string]: unknown;
+}
+export type GetCustomPages_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
+export type GetCustomPages_Response_403 = Error_APIKEY_MISMATCH;
+export interface Error_CUSTOMPAGE_INVALID {
+  /**
+   * An error code unique to the error received.
+   */
+  error?: string;
+  /**
+   * The reason why the error occured.
+   */
+  message?: string;
+  /**
+   * A helpful suggestion for how to alleviate the error.
+   */
+  suggestion?: string;
+  /**
+   * A [ReadMe Metrics](https://readme.com/metrics/) log URL where you can see more information the request that you made. If we have metrics URLs unavailable for your request, this URL will be a URL to our API Reference.
+   */
+  docs?: string;
+  /**
+   * Information on where you can receive additional assistance from our wonderful support team.
+   */
+  help?: string;
+  /**
+   * A short poem we wrote you about your error.
+   */
+  poem?: string[];
+  [k: string]: unknown;
+}
+export type CreateCustomPage_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
+export type CreateCustomPage_Response_403 = Error_APIKEY_MISMATCH;
+export type GetCustomPage_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
+export type GetCustomPage_Response_403 = Error_APIKEY_MISMATCH;
+export interface Error_CUSTOMPAGE_NOTFOUND {
+  /**
+   * An error code unique to the error received.
+   */
+  error?: string;
+  /**
+   * The reason why the error occured.
+   */
+  message?: string;
+  /**
+   * A helpful suggestion for how to alleviate the error.
+   */
+  suggestion?: string;
+  /**
+   * A [ReadMe Metrics](https://readme.com/metrics/) log URL where you can see more information the request that you made. If we have metrics URLs unavailable for your request, this URL will be a URL to our API Reference.
+   */
+  docs?: string;
+  /**
+   * Information on where you can receive additional assistance from our wonderful support team.
+   */
+  help?: string;
+  /**
+   * A short poem we wrote you about your error.
+   */
+  poem?: string[];
+  [k: string]: unknown;
+}
+export type UpdateCustomPage_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
+export type UpdateCustomPage_Response_403 = Error_APIKEY_MISMATCH;
+export type DeleteCustomPage_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
+export type DeleteCustomPage_Response_403 = Error_APIKEY_MISMATCH;
+export type GetDoc_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
+export type GetDoc_Response_403 = Error_APIKEY_MISMATCH;
+export interface Error_DOC_NOTFOUND {
+  /**
+   * An error code unique to the error received.
+   */
+  error?: string;
+  /**
+   * The reason why the error occured.
+   */
+  message?: string;
+  /**
+   * A helpful suggestion for how to alleviate the error.
+   */
+  suggestion?: string;
+  /**
+   * A [ReadMe Metrics](https://readme.com/metrics/) log URL where you can see more information the request that you made. If we have metrics URLs unavailable for your request, this URL will be a URL to our API Reference.
+   */
+  docs?: string;
+  /**
+   * Information on where you can receive additional assistance from our wonderful support team.
+   */
+  help?: string;
+  /**
+   * A short poem we wrote you about your error.
+   */
+  poem?: string[];
+  [k: string]: unknown;
+}
+export interface Error_DOC_INVALID {
+  /**
+   * An error code unique to the error received.
+   */
+  error?: string;
+  /**
+   * The reason why the error occured.
+   */
+  message?: string;
+  /**
+   * A helpful suggestion for how to alleviate the error.
+   */
+  suggestion?: string;
+  /**
+   * A [ReadMe Metrics](https://readme.com/metrics/) log URL where you can see more information the request that you made. If we have metrics URLs unavailable for your request, this URL will be a URL to our API Reference.
+   */
+  docs?: string;
+  /**
+   * Information on where you can receive additional assistance from our wonderful support team.
+   */
+  help?: string;
+  /**
+   * A short poem we wrote you about your error.
+   */
+  poem?: string[];
+  [k: string]: unknown;
+}
+export type UpdateDoc_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
+export type UpdateDoc_Response_403 = Error_APIKEY_MISMATCH;
+export type DeleteDoc_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
+export type DeleteDoc_Response_403 = Error_APIKEY_MISMATCH;
+export type CreateDoc_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
+export type CreateDoc_Response_403 = Error_APIKEY_MISMATCH;
+export type SearchDocs_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
+export type SearchDocs_Response_403 = Error_APIKEY_MISMATCH;
+export type CreateVersion_Response_400 = Error_VERSION_EMPTY | Error_VERSION_DUPLICATE | Error_VERSION_FORK_EMPTY;
+export interface Error_VERSION_DUPLICATE {
+  /**
+   * An error code unique to the error received.
+   */
+  error?: string;
+  /**
+   * The reason why the error occured.
+   */
+  message?: string;
+  /**
+   * A helpful suggestion for how to alleviate the error.
+   */
+  suggestion?: string;
+  /**
+   * A [ReadMe Metrics](https://readme.com/metrics/) log URL where you can see more information the request that you made. If we have metrics URLs unavailable for your request, this URL will be a URL to our API Reference.
+   */
+  docs?: string;
+  /**
+   * Information on where you can receive additional assistance from our wonderful support team.
+   */
+  help?: string;
+  /**
+   * A short poem we wrote you about your error.
+   */
+  poem?: string[];
+  [k: string]: unknown;
+}
+export interface Error_VERSION_FORK_EMPTY {
+  /**
+   * An error code unique to the error received.
+   */
+  error?: string;
+  /**
+   * The reason why the error occured.
+   */
+  message?: string;
+  /**
+   * A helpful suggestion for how to alleviate the error.
+   */
+  suggestion?: string;
+  /**
+   * A [ReadMe Metrics](https://readme.com/metrics/) log URL where you can see more information the request that you made. If we have metrics URLs unavailable for your request, this URL will be a URL to our API Reference.
+   */
+  docs?: string;
+  /**
+   * Information on where you can receive additional assistance from our wonderful support team.
+   */
+  help?: string;
+  /**
+   * A short poem we wrote you about your error.
+   */
+  poem?: string[];
+  [k: string]: unknown;
+}
+export type CreateVersion_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
+export type CreateVersion_Response_403 = Error_APIKEY_MISMATCH;
+export interface Error_VERSION_FORK_NOTFOUND {
+  /**
+   * An error code unique to the error received.
+   */
+  error?: string;
+  /**
+   * The reason why the error occured.
+   */
+  message?: string;
+  /**
+   * A helpful suggestion for how to alleviate the error.
+   */
+  suggestion?: string;
+  /**
+   * A [ReadMe Metrics](https://readme.com/metrics/) log URL where you can see more information the request that you made. If we have metrics URLs unavailable for your request, this URL will be a URL to our API Reference.
+   */
+  docs?: string;
+  /**
+   * Information on where you can receive additional assistance from our wonderful support team.
+   */
+  help?: string;
+  /**
+   * A short poem we wrote you about your error.
+   */
+  poem?: string[];
+  [k: string]: unknown;
+}
+export type GetVersion_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
+export type GetVersion_Response_403 = Error_APIKEY_MISMATCH;
+export interface Error_VERSION_CANT_DEMOTE_STABLE {
+  /**
+   * An error code unique to the error received.
+   */
+  error?: string;
+  /**
+   * The reason why the error occured.
+   */
+  message?: string;
+  /**
+   * A helpful suggestion for how to alleviate the error.
+   */
+  suggestion?: string;
+  /**
+   * A [ReadMe Metrics](https://readme.com/metrics/) log URL where you can see more information the request that you made. If we have metrics URLs unavailable for your request, this URL will be a URL to our API Reference.
+   */
+  docs?: string;
+  /**
+   * Information on where you can receive additional assistance from our wonderful support team.
+   */
+  help?: string;
+  /**
+   * A short poem we wrote you about your error.
+   */
+  poem?: string[];
+  [k: string]: unknown;
+}
+export type UpdateVersion_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
+export type UpdateVersion_Response_403 = Error_APIKEY_MISMATCH;
+export interface Error_VERSION_CANT_REMOVE_STABLE {
+  /**
+   * An error code unique to the error received.
+   */
+  error?: string;
+  /**
+   * The reason why the error occured.
+   */
+  message?: string;
+  /**
+   * A helpful suggestion for how to alleviate the error.
+   */
+  suggestion?: string;
+  /**
+   * A [ReadMe Metrics](https://readme.com/metrics/) log URL where you can see more information the request that you made. If we have metrics URLs unavailable for your request, this URL will be a URL to our API Reference.
+   */
+  docs?: string;
+  /**
+   * Information on where you can receive additional assistance from our wonderful support team.
+   */
+  help?: string;
+  /**
+   * A short poem we wrote you about your error.
+   */
+  poem?: string[];
+  [k: string]: unknown;
+}
+export type DeleteVersion_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
+export type DeleteVersion_Response_403 = Error_APIKEY_MISMATCH;

--- a/packages/api/test/codegen/typescript.test.ts
+++ b/packages/api/test/codegen/typescript.test.ts
@@ -30,4 +30,12 @@ describe('typescript generator', function () {
     const ts = new TSGenerator(oas, './petstore.json');
     expect(await ts.generator()).toMatchSDKFixture('petstore');
   });
+
+  it('should work against our OAS', async function () {
+    const oas = await import('@readme/oas-examples/3.0/json/readme.json').then(Oas.init);
+    await oas.dereference({ preserveRefAsJSONSchemaTitle: true });
+
+    const ts = new TSGenerator(oas, './readme.json');
+    expect(await ts.generator()).toMatchSDKFixture('readme');
+  });
 });


### PR DESCRIPTION
| 🚥 Fix RM-3929 |
| :-- |

## 🧰 Changes

This refactors how we're generating TS types during codegen to never generate TS code for the same schema more than once. This work doesn't make a huge dent in the still slow codegen process, but it's an improvement for huge specs.

#### Before

```
  typescript generator
    ✔ should generate typescript code (3137ms)
    ✔ should be able to generate valid TS when a body is optional but metadata isnt (2056ms)
    ✔ should work against the petstore (17054ms)
    ✔ should work against our OAS (78918ms)
```

#### After

```
  typescript generator
    ✔ should generate typescript code (4143ms)
    ✔ should be able to generate valid TS when a body is optional but metadata isnt (2323ms)
    ✔ should work against the petstore (16065ms)
    ✔ should work against our OAS (66688ms)
```