### PR TITLE
test: run `build` in pretest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,5 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build dists
-        run: npm run build
-
       - name: Run tests
         run: npm test

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint:docs": "alex . .github/",
     "prepare": "husky install",
     "publish": "npx lerna publish",
-    "pretest": "npm run lint:docs",
+    "pretest": "npm run lint:docs && npm run build",
     "test": "npx lerna run test --stream",
     "version": "npx conventional-changelog-cli --pkg lerna.json -i CHANGELOG.md -s && git add CHANGELOG.md"
   },


### PR DESCRIPTION
## 🧰 Changes

Running `npm test` in a repo without the generated dist/ folder caused a
few lint errors that meant the tests would fail:

```
api: ~/code/api/packages/api/test/dist.test.ts
api:   7:17  error  Missing file extension for "../dist"        import/extensions
api:   7:17  error  Unable to resolve path to module '../dist'  import/no-unresolved
```

I had to check CI to see what was wrong with it: https://github.com/readmeio/api/runs/5888639545?check_suite_focus=true

## 🧬 QA & Testing

Does QA still pass? 🟢
