### PR TITLE
fix(auth): remove the ability to have auth chained with each request

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ All you need to use `api` is to supply it an OpenAPI definition and then use the
 ```js
 const sdk = require('api')('https://raw.githubusercontent.com/readmeio/oas/master/packages/examples/3.0/json/petstore.json');
 
-sdk.listPets().then(res => res.json()).then(res => {
+sdk.listPets().then(res => {
   console.log(`My pets name is ${res[0].name}!`);
 });
 ```
@@ -33,10 +33,11 @@ sdk.listPets().then(res => res.json()).then(res => {
 The OpenAPI definition is automatically downloaded, cached, and transformed into a chainable [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) Promise that you can use to make API requests.
 
 ### Authentication
-`api` supports API authentication through an `.auth()` method that you can chain to your requests, as such:
+`api` supports API authentication through an `.auth()` method:
 
 ```js
-sdk.auth('myApiToken').listPets().then(...);
+sdk.auth('myApiToken');
+sdk.listPets().then(...);
 ```
 
 With the exception of OpenID, it supports all forms of authentication supported by the OpenAPI specification! Supply `.auth()` with your auth credentials and it'll magically figure out how to use it according to the API you're using. 🧙‍♀️
@@ -46,6 +47,8 @@ For example:
 * HTTP Basic auth: `sdk.auth('username', 'password')`
 * Bearer tokens (HTTP or OAuth 2): `sdk.auth('myBearerToken')`
 * API Keys: `sdk.auth('myApiKey')`
+
+> ℹ️ Note that `sdk.auth()` is not chainable.
 
 ### Parameters and Payloads
 When supplying parameters and/or request body payloads to an API request, you don't need to explicitly define what goes where since the API definition contains all that information. All you need to do is supply either one or two objects:

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -25,7 +25,7 @@ All you need to use `api` is to supply it an OpenAPI definition and then use the
 ```js
 const sdk = require('api')('https://raw.githubusercontent.com/readmeio/oas/master/packages/examples/3.0/json/petstore.json');
 
-sdk.listPets().then(res => res.json()).then(res => {
+sdk.listPets().then(res => {
   console.log(`My pets name is ${res[0].name}!`);
 });
 ```
@@ -33,10 +33,11 @@ sdk.listPets().then(res => res.json()).then(res => {
 The OpenAPI definition is automatically downloaded, cached, and transformed into a chainable [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) Promise that you can use to make API requests.
 
 ### Authentication
-`api` supports API authentication through an `.auth()` method that you can chain to your requests, as such:
+`api` supports API authentication through an `.auth()` method:
 
 ```js
-sdk.auth('myApiToken').listPets().then(...);
+sdk.auth('myApiToken');
+sdk.listPets().then(...);
 ```
 
 With the exception of OpenID, it supports all forms of authentication supported by the OpenAPI specification! Supply `.auth()` with your auth credentials and it'll magically figure out how to use it according to the API you're using. 🧙‍♀️
@@ -46,6 +47,8 @@ For example:
 * HTTP Basic auth: `sdk.auth('username', 'password')`
 * Bearer tokens (HTTP or OAuth 2): `sdk.auth('myBearerToken')`
 * API Keys: `sdk.auth('myApiKey')`
+
+> ℹ️ Note that `sdk.auth()` is not chainable.
 
 ### Parameters and Payloads
 When supplying parameters and/or request body payloads to an API request, you don't need to explicitly define what goes where since the API definition contains all that information. All you need to do is supply either one or two objects:

--- a/packages/api/src/core/index.ts
+++ b/packages/api/src/core/index.ts
@@ -26,7 +26,7 @@ export { getJSONSchemaDefaults, parseResponse, prepareAuth, prepareParams, prepa
 export default class APICore {
   spec: Oas;
 
-  private auth: (number | string)[][] = [];
+  private auth: (number | string)[] = [];
 
   private server:
     | false
@@ -59,7 +59,7 @@ export default class APICore {
   }
 
   setAuth(...values: string[] | number[]) {
-    this.auth.push(values);
+    this.auth = values;
     return this;
   }
 

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -156,7 +156,6 @@ class Sdk {
        */
       auth: (...values: string[] | number[]) => {
         core.setAuth(...values);
-        return new Proxy(sdk, sdkProxy);
       },
 
       /**

--- a/packages/api/test/auth.test.ts
+++ b/packages/api/test/auth.test.ts
@@ -39,15 +39,6 @@ describe('#auth()', function () {
         mock.done();
       });
 
-      it.skip('should allow you to supply auth when chained with an operation', async function () {
-        const mock = nock('https://httpbin.org')
-          .get(/\/anything\/apiKey/)
-          .reply(200, uri => uri);
-
-        expect(await sdk.auth(apiKey).get('/anything/apiKey')).to.equal('/anything/apiKey?apiKey=123457890');
-        mock.done();
-      });
-
       it('should throw if you supply multiple auth keys', async function () {
         sdk.auth(apiKey, apiKey);
 
@@ -70,17 +61,6 @@ describe('#auth()', function () {
 
         sdk.auth(apiKey);
         expect(await sdk.put('/anything/apiKey')).to.have.deep.property('x-api-key', ['123457890']);
-        mock.done();
-      });
-
-      it.skip('should allow you to supply auth when chained with an operation', async function () {
-        const mock = nock('https://httpbin.org')
-          .put('/anything/apiKey')
-          .reply(200, function () {
-            return this.req.headers;
-          });
-
-        expect(await sdk.auth(apiKey).put('/anything/apiKey')).to.have.deep.property('x-api-key', ['123457890']);
         mock.done();
       });
 
@@ -113,19 +93,6 @@ describe('#auth()', function () {
         mock.done();
       });
 
-      it.skip('should allow you to supply auth when chained with an operation', async function () {
-        const authHeader = `Basic ${Buffer.from(`${user}:${pass}`).toString('base64')}`;
-
-        const mock = nock('https://httpbin.org')
-          .post('/anything/basic')
-          .reply(200, function () {
-            return this.req.headers;
-          });
-
-        expect(await sdk.auth(user, pass).post('/anything/basic')).to.have.deep.property('authorization', [authHeader]);
-        mock.done();
-      });
-
       it('should allow you to not pass in a password', async function () {
         const mock = nock('https://httpbin.org')
           .post('/anything/basic')
@@ -155,19 +122,6 @@ describe('#auth()', function () {
         mock.done();
       });
 
-      it.skip('should allow you to supply auth when chained with an operation', async function () {
-        const mock = nock('https://httpbin.org')
-          .post('/anything/bearer')
-          .reply(200, function () {
-            return this.req.headers;
-          });
-
-        expect(await sdk.auth(apiKey).post('/anything/bearer')).to.have.deep.property('authorization', [
-          `Bearer ${apiKey}`,
-        ]);
-        mock.done();
-      });
-
       it('should throw if you pass in multiple bearer tokens', async function () {
         sdk.auth(apiKey, apiKey);
         await sdk
@@ -191,19 +145,6 @@ describe('#auth()', function () {
       sdk.auth(apiKey);
 
       expect(await sdk.post('/anything/oauth2')).to.have.deep.property('authorization', [`Bearer ${apiKey}`]);
-      mock.done();
-    });
-
-    it.skip('should allow you to supply auth when chained with an operation', async function () {
-      const mock = nock('https://httpbin.org')
-        .post('/anything/oauth2')
-        .reply(200, function () {
-          return this.req.headers;
-        });
-
-      expect(await sdk.auth(apiKey).post('/anything/oauth2')).to.have.deep.property('authorization', [
-        `Bearer ${apiKey}`,
-      ]);
       mock.done();
     });
 
@@ -239,25 +180,5 @@ describe('#auth()', function () {
 
     sdk.auth(apiKey2);
     await sdk.get('/anything/apiKey').then(() => mock2.done());
-  });
-
-  // TODO: in future add support for modifying auth for each call
-  // https://github.com/readmeio/api/issues/102
-  // https://github.com/readmeio/api/commit/56ce53e08d590d4a532a494e86e46a50efc4d891
-  it.skip('should allow multiple calls to have different keys', async function () {
-    const apiKey1 = '12345';
-    const apiKey2 = '67890';
-    const mock1 = nock('https://httpbin.org').get('/anything/apiKey').query({ apiKey: apiKey1 }).reply(200, {});
-    const mock2 = nock('https://httpbin.org').get('/anything/apiKey').query({ apiKey: apiKey2 }).reply(200, {});
-
-    await sdk
-      .auth(apiKey1)
-      .get('/anything/apiKey')
-      .then(() => mock1.done());
-
-    await sdk
-      .auth(apiKey2)
-      .get('/anything/apiKey')
-      .then(() => mock2.done());
   });
 });

--- a/packages/api/test/auth.test.ts
+++ b/packages/api/test/auth.test.ts
@@ -29,30 +29,29 @@ describe('#auth()', function () {
 
   describe('API Keys', function () {
     describe('in: query', function () {
-      [
-        ['should allow you to supply auth', false],
-        ['should allow you to supply auth when unchained from an operation', true],
-      ].forEach(([_, isChained]) => {
-        it(`${_}`, async function () {
-          const mock = nock('https://httpbin.org')
-            .get(/\/anything\/apiKey/)
-            .reply(200, uri => uri);
+      it('should allow you to supply auth', async function () {
+        const mock = nock('https://httpbin.org')
+          .get(/\/anything\/apiKey/)
+          .reply(200, uri => uri);
 
-          if (isChained) {
-            expect(await sdk.auth(apiKey).get('/anything/apiKey')).to.equal('/anything/apiKey?apiKey=123457890');
-            mock.done();
-            return;
-          }
+        sdk.auth(apiKey);
+        expect(await sdk.get('/anything/apiKey')).to.equal('/anything/apiKey?apiKey=123457890');
+        mock.done();
+      });
 
-          sdk.auth(apiKey);
-          expect(await sdk.get('/anything/apiKey')).to.equal('/anything/apiKey?apiKey=123457890');
-          mock.done();
-        });
+      it.skip('should allow you to supply auth when chained with an operation', async function () {
+        const mock = nock('https://httpbin.org')
+          .get(/\/anything\/apiKey/)
+          .reply(200, uri => uri);
+
+        expect(await sdk.auth(apiKey).get('/anything/apiKey')).to.equal('/anything/apiKey?apiKey=123457890');
+        mock.done();
       });
 
       it('should throw if you supply multiple auth keys', async function () {
+        sdk.auth(apiKey, apiKey);
+
         await sdk
-          .auth(apiKey, apiKey)
           .get('/anything/apiKey')
           .then(() => assert.fail())
           .catch(err => {
@@ -62,31 +61,33 @@ describe('#auth()', function () {
     });
 
     describe('in: header', function () {
-      [
-        ['should allow you to supply auth', false],
-        ['should allow you to supply auth when unchained from an operation', true],
-      ].forEach(([_, isChained]) => {
-        it(`${_}`, async function () {
-          const mock = nock('https://httpbin.org')
-            .put('/anything/apiKey')
-            .reply(200, function () {
-              return this.req.headers;
-            });
+      it('should allow you to supply auth', async function () {
+        const mock = nock('https://httpbin.org')
+          .put('/anything/apiKey')
+          .reply(200, function () {
+            return this.req.headers;
+          });
 
-          if (isChained) {
-            expect(await sdk.auth(apiKey).put('/anything/apiKey')).to.have.deep.property('x-api-key', ['123457890']);
-            mock.done();
-            return;
-          }
+        sdk.auth(apiKey);
+        expect(await sdk.put('/anything/apiKey')).to.have.deep.property('x-api-key', ['123457890']);
+        mock.done();
+      });
 
-          sdk.auth(apiKey);
-          expect(await sdk.put('/anything/apiKey')).to.have.deep.property('x-api-key', ['123457890']);
-        });
+      it.skip('should allow you to supply auth when chained with an operation', async function () {
+        const mock = nock('https://httpbin.org')
+          .put('/anything/apiKey')
+          .reply(200, function () {
+            return this.req.headers;
+          });
+
+        expect(await sdk.auth(apiKey).put('/anything/apiKey')).to.have.deep.property('x-api-key', ['123457890']);
+        mock.done();
       });
 
       it('should throw if you supply multiple auth keys', async function () {
+        sdk.auth(apiKey, apiKey);
+
         await sdk
-          .auth(apiKey, apiKey)
           .put('/anything/apiKey')
           .then(() => assert.fail())
           .catch(err => {
@@ -98,30 +99,31 @@ describe('#auth()', function () {
 
   describe('HTTP', function () {
     describe('scheme: basic', function () {
-      [
-        ['should allow you to supply auth', false],
-        ['should allow you to supply auth when unchained from an operation', true],
-      ].forEach(([_, isChained]) => {
-        it(`${_}`, async function () {
-          const authHeader = `Basic ${Buffer.from(`${user}:${pass}`).toString('base64')}`;
-          const mock = nock('https://httpbin.org')
-            .post('/anything/basic')
-            .reply(200, function () {
-              return this.req.headers;
-            });
+      it('should allow you to supply auth', async function () {
+        const authHeader = `Basic ${Buffer.from(`${user}:${pass}`).toString('base64')}`;
 
-          if (isChained) {
-            expect(await sdk.auth(user, pass).post('/anything/basic')).to.have.deep.property('authorization', [
-              authHeader,
-            ]);
-            mock.done();
-            return;
-          }
+        const mock = nock('https://httpbin.org')
+          .post('/anything/basic')
+          .reply(200, function () {
+            return this.req.headers;
+          });
 
-          sdk.auth(user, pass);
-          expect(await sdk.post('/anything/basic')).to.have.deep.property('authorization', [authHeader]);
-          mock.done();
-        });
+        sdk.auth(user, pass);
+        expect(await sdk.post('/anything/basic')).to.have.deep.property('authorization', [authHeader]);
+        mock.done();
+      });
+
+      it.skip('should allow you to supply auth when chained with an operation', async function () {
+        const authHeader = `Basic ${Buffer.from(`${user}:${pass}`).toString('base64')}`;
+
+        const mock = nock('https://httpbin.org')
+          .post('/anything/basic')
+          .reply(200, function () {
+            return this.req.headers;
+          });
+
+        expect(await sdk.auth(user, pass).post('/anything/basic')).to.have.deep.property('authorization', [authHeader]);
+        mock.done();
       });
 
       it('should allow you to not pass in a password', async function () {
@@ -131,7 +133,9 @@ describe('#auth()', function () {
             return this.req.headers;
           });
 
-        expect(await sdk.auth(user).post('/anything/basic')).to.have.deep.property('authorization', [
+        sdk.auth(user);
+
+        expect(await sdk.post('/anything/basic')).to.have.deep.property('authorization', [
           `Basic ${Buffer.from(`${user}:`).toString('base64')}`,
         ]);
         mock.done();
@@ -139,34 +143,34 @@ describe('#auth()', function () {
     });
 
     describe('scheme: bearer', function () {
-      [
-        ['should allow you to supply auth', false],
-        ['should allow you to supply auth when unchained from an operation', true],
-      ].forEach(([_, isChained]) => {
-        it(`${_}`, async function () {
-          const mock = nock('https://httpbin.org')
-            .post('/anything/bearer')
-            .reply(200, function () {
-              return this.req.headers;
-            });
+      it('should allow you to supply auth', async function () {
+        const mock = nock('https://httpbin.org')
+          .post('/anything/bearer')
+          .reply(200, function () {
+            return this.req.headers;
+          });
 
-          if (isChained) {
-            expect(await sdk.auth(apiKey).post('/anything/bearer')).to.have.deep.property('authorization', [
-              `Bearer ${apiKey}`,
-            ]);
-            mock.done();
-            return;
-          }
+        sdk.auth(apiKey);
+        expect(await sdk.post('/anything/bearer')).to.have.deep.property('authorization', [`Bearer ${apiKey}`]);
+        mock.done();
+      });
 
-          sdk.auth(apiKey);
-          expect(await sdk.post('/anything/bearer')).to.have.deep.property('authorization', [`Bearer ${apiKey}`]);
-          mock.done();
-        });
+      it.skip('should allow you to supply auth when chained with an operation', async function () {
+        const mock = nock('https://httpbin.org')
+          .post('/anything/bearer')
+          .reply(200, function () {
+            return this.req.headers;
+          });
+
+        expect(await sdk.auth(apiKey).post('/anything/bearer')).to.have.deep.property('authorization', [
+          `Bearer ${apiKey}`,
+        ]);
+        mock.done();
       });
 
       it('should throw if you pass in multiple bearer tokens', async function () {
+        sdk.auth(apiKey, apiKey);
         await sdk
-          .auth(apiKey, apiKey)
           .post('/anything/bearer')
           .then(() => assert.fail())
           .catch(err => {
@@ -177,39 +181,83 @@ describe('#auth()', function () {
   });
 
   describe('OAuth 2', function () {
-    [
-      ['should allow you to supply auth', false],
-      ['should allow you to supply auth when unchained from an operation', true],
-    ].forEach(([_, isChained]) => {
-      it(`${_}`, async function () {
-        const mock = nock('https://httpbin.org')
-          .post('/anything/oauth2')
-          .reply(200, function () {
-            return this.req.headers;
-          });
+    it('should allow you to supply auth', async function () {
+      const mock = nock('https://httpbin.org')
+        .post('/anything/oauth2')
+        .reply(200, function () {
+          return this.req.headers;
+        });
 
-        if (isChained) {
-          expect(await sdk.auth(apiKey).post('/anything/oauth2')).to.have.deep.property('authorization', [
-            `Bearer ${apiKey}`,
-          ]);
-          mock.done();
-          return;
-        }
+      sdk.auth(apiKey);
 
-        sdk.auth(apiKey);
-        expect(await sdk.post('/anything/oauth2')).to.have.deep.property('authorization', [`Bearer ${apiKey}`]);
-        mock.done();
-      });
+      expect(await sdk.post('/anything/oauth2')).to.have.deep.property('authorization', [`Bearer ${apiKey}`]);
+      mock.done();
+    });
+
+    it.skip('should allow you to supply auth when chained with an operation', async function () {
+      const mock = nock('https://httpbin.org')
+        .post('/anything/oauth2')
+        .reply(200, function () {
+          return this.req.headers;
+        });
+
+      expect(await sdk.auth(apiKey).post('/anything/oauth2')).to.have.deep.property('authorization', [
+        `Bearer ${apiKey}`,
+      ]);
+      mock.done();
     });
 
     it('should throw if you pass in multiple bearer tokens', async function () {
+      sdk.auth(apiKey, apiKey);
       await sdk
-        .auth(apiKey, apiKey)
         .post('/anything/oauth2')
         .then(() => assert.fail())
         .catch(err => {
           expect(err.message).to.match(/only a single token is needed/i);
         });
     });
+  });
+
+  it('should allow multiple calls to share an API key', async function () {
+    const mock1 = nock('https://httpbin.org').get('/anything/apiKey').query({ apiKey }).reply(200, {});
+    const mock2 = nock('https://httpbin.org').get('/anything/apiKey').query({ apiKey }).reply(200, {});
+
+    sdk.auth(apiKey);
+
+    await sdk.get('/anything/apiKey').then(() => mock1.done());
+    await sdk.get('/anything/apiKey').then(() => mock2.done());
+  });
+
+  it('should allow auth to be called again to change the key', async function () {
+    const apiKey1 = '12345';
+    const apiKey2 = '67890';
+    const mock1 = nock('https://httpbin.org').get('/anything/apiKey').query({ apiKey: apiKey1 }).reply(200, {});
+    const mock2 = nock('https://httpbin.org').get('/anything/apiKey').query({ apiKey: apiKey2 }).reply(200, {});
+
+    sdk.auth(apiKey1);
+    await sdk.get('/anything/apiKey').then(() => mock1.done());
+
+    sdk.auth(apiKey2);
+    await sdk.get('/anything/apiKey').then(() => mock2.done());
+  });
+
+  // TODO: in future add support for modifying auth for each call
+  // https://github.com/readmeio/api/issues/102
+  // https://github.com/readmeio/api/commit/56ce53e08d590d4a532a494e86e46a50efc4d891
+  it.skip('should allow multiple calls to have different keys', async function () {
+    const apiKey1 = '12345';
+    const apiKey2 = '67890';
+    const mock1 = nock('https://httpbin.org').get('/anything/apiKey').query({ apiKey: apiKey1 }).reply(200, {});
+    const mock2 = nock('https://httpbin.org').get('/anything/apiKey').query({ apiKey: apiKey2 }).reply(200, {});
+
+    await sdk
+      .auth(apiKey1)
+      .get('/anything/apiKey')
+      .then(() => mock1.done());
+
+    await sdk
+      .auth(apiKey2)
+      .get('/anything/apiKey')
+      .then(() => mock2.done());
   });
 });

--- a/packages/api/test/core/prepareAuth.test.ts
+++ b/packages/api/test/core/prepareAuth.test.ts
@@ -15,7 +15,7 @@ describe('#prepareAuth()', function () {
     describe('in: query', function () {
       it('should support query auth', function () {
         const operation = oas.operation('/anything/apiKey', 'get');
-        const authKeys = [[apiKey]];
+        const authKeys = [apiKey];
 
         expect(prepareAuth(authKeys, operation)).to.deep.equal({
           apiKey_query: '123457890',
@@ -24,7 +24,7 @@ describe('#prepareAuth()', function () {
 
       it('should throw if you supply multiple auth keys', function () {
         const operation = oas.operation('/anything/apiKey', 'get');
-        const authKeys = [[apiKey, apiKey]];
+        const authKeys = [apiKey, apiKey];
 
         expect(() => {
           prepareAuth(authKeys, operation);
@@ -35,7 +35,7 @@ describe('#prepareAuth()', function () {
     describe('in: header', function () {
       it('should support header auth', function () {
         const operation = oas.operation('/anything/apiKey', 'put');
-        const authKeys = [[apiKey]];
+        const authKeys = [apiKey];
 
         expect(prepareAuth(authKeys, operation)).to.deep.equal({
           apiKey_header: '123457890',
@@ -44,7 +44,7 @@ describe('#prepareAuth()', function () {
 
       it('should throw if you supply multiple auth keys', function () {
         const operation = oas.operation('/anything/apiKey', 'put');
-        const authKeys = [[apiKey, apiKey]];
+        const authKeys = [apiKey, apiKey];
 
         expect(() => {
           prepareAuth(authKeys, operation);
@@ -55,7 +55,7 @@ describe('#prepareAuth()', function () {
     describe('in: cookie', function () {
       it('should support cookie auth', function () {
         const operation = oas.operation('/anything/apiKey', 'post');
-        const authKeys = [[apiKey]];
+        const authKeys = [apiKey];
 
         expect(prepareAuth(authKeys, operation)).to.deep.equal({
           apiKey_cookie: '123457890',
@@ -64,7 +64,7 @@ describe('#prepareAuth()', function () {
 
       it('should throw if you supply multiple auth keys', function () {
         const operation = oas.operation('/anything/apiKey', 'post');
-        const authKeys = [[apiKey, apiKey]];
+        const authKeys = [apiKey, apiKey];
 
         expect(() => {
           prepareAuth(authKeys, operation);
@@ -80,7 +80,7 @@ describe('#prepareAuth()', function () {
 
       it('should supprot basic auth', function () {
         const operation = oas.operation('/anything/basic', 'post');
-        const authKeys = [[user, pass]];
+        const authKeys = [user, pass];
 
         expect(prepareAuth(authKeys, operation)).to.deep.equal({
           basic: {
@@ -92,7 +92,7 @@ describe('#prepareAuth()', function () {
 
       it('should allow you to not pass in a password', function () {
         const operation = oas.operation('/anything/basic', 'post');
-        const authKeys = [[user]];
+        const authKeys = [user];
 
         expect(prepareAuth(authKeys, operation)).to.deep.equal({
           basic: {
@@ -108,7 +108,7 @@ describe('#prepareAuth()', function () {
 
       it('should support bearer auth', function () {
         const operation = oas.operation('/anything/bearer', 'post');
-        const authKeys = [[apiKey]];
+        const authKeys = [apiKey];
 
         expect(prepareAuth(authKeys, operation)).to.deep.equal({
           bearer: '123457890',
@@ -117,7 +117,7 @@ describe('#prepareAuth()', function () {
 
       it('should throw if you pass in multiple bearer tokens', function () {
         const operation = oas.operation('/anything/bearer', 'post');
-        const authKeys = [[apiKey, apiKey]];
+        const authKeys = [apiKey, apiKey];
 
         expect(() => {
           prepareAuth(authKeys, operation);
@@ -133,7 +133,7 @@ describe('#prepareAuth()', function () {
 
     it('should support oauth2 auth', function () {
       const operation = oas.operation('/anything/oauth2', 'post');
-      const authKeys = [[apiKey]];
+      const authKeys = [apiKey];
 
       expect(prepareAuth(authKeys, operation)).to.deep.equal({
         oauth2: '123457890',
@@ -142,7 +142,7 @@ describe('#prepareAuth()', function () {
 
     it('should throw if you pass in multiple bearer tokens', function () {
       const operation = oas.operation('/anything/oauth2', 'post');
-      const authKeys = [[apiKey, apiKey]];
+      const authKeys = [apiKey, apiKey];
 
       expect(() => {
         prepareAuth(authKeys, operation);


### PR DESCRIPTION
## 🧰 Changes
There's [a bug](https://github.com/readmeio/api/issues/102) with chaining auth calls due to the fact that we have a global state, and calling auth() again appends on to the state and breaks prepareAuth.

This PR removes the ability to call auth() in a chainable fashion, and only allows auth to be called at the top level.

I'd like to figure out a way to bring this back eventually, but the current API design doesn't support it in a clean way. We can revisit this when we look to support operations with multiple auth mechanisms.

This should probably be a major version bump due to removing functionality.

Fixes https://github.com/readmeio/api/issues/102

## 🧬 QA & Testing

Does CI pass? 🟢
