### PR TITLE
fix: relative paths in cache config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 4.5.0 (2022-05-17)
+
+* docs: updating docs on the new cacheDir option ([8863791](https://github.com/readmeio/api/commit/8863791))
+* feat: adding support for a customizable cache directory ([d4a7df3](https://github.com/readmeio/api/commit/d4a7df3))
+
+
+
 ## 4.4.0 (2022-04-25)
 
 * feat: backporting #431 to the v4 series ([4a1e077](https://github.com/readmeio/api/commit/4a1e077)), closes [#431](https://github.com/readmeio/api/issues/431)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## <small>4.2.1 (2022-03-18)</small>
+
+* fix: quirk with node 16 and `response.clone()` ([de8d964](https://github.com/readmeio/api/commit/de8d964))
+
+
+
 ## 4.2.0 (2022-01-03)
 
 * chore(deps-dev): bump @commitlint/cli from 15.0.0 to 16.0.1 (#372) ([2279bcf](https://github.com/readmeio/api/commit/2279bcf)), closes [#372](https://github.com/readmeio/api/issues/372)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## <small>4.5.1 (2022-05-18)</small>
+
+* fix: broken test ([723299e](https://github.com/readmeio/api/commit/723299e))
+* fix: broken test ([cc0a5c1](https://github.com/readmeio/api/commit/cc0a5c1))
+* fix: stop storing absolute paths in the cache store to where specs are ([40e1376](https://github.com/readmeio/api/commit/40e1376))
+
+
+
 ## 4.5.0 (2022-05-17)
 
 * docs: updating docs on the new cacheDir option ([8863791](https://github.com/readmeio/api/commit/8863791))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 4.3.0 (2022-04-05)
+
+* feat: ugprading oas dependencies on v4.2.1 ([c328fd4](https://github.com/readmeio/api/commit/c328fd4))
+
+
+
 ## <small>4.2.1 (2022-03-18)</small>
 
 * fix: quirk with node 16 and `response.clone()` ([de8d964](https://github.com/readmeio/api/commit/de8d964))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 4.4.0 (2022-04-25)
+
+* feat: backporting #431 to the v4 series ([4a1e077](https://github.com/readmeio/api/commit/4a1e077)), closes [#431](https://github.com/readmeio/api/issues/431)
+
+
+
 ## 4.3.0 (2022-04-05)
 
 * feat: ugprading oas dependencies on v4.2.1 ([c328fd4](https://github.com/readmeio/api/commit/c328fd4))

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ npm install api --save
 Using `api` is as simple as supplying it an OpenAPI and using the SDK as you would any other!
 
 ```js
-const sdk = require('api')('https://raw.githubusercontent.com/readmeio/oas/master/packages/examples/3.0/json/petstore.json');
+const sdk = require('api')('https://raw.githubusercontent.com/readmeio/oas-examples/main/3.0/json/petstore.json');
 
 sdk.listPets().then(res => {
   console.log(`My pets name is ${res[0].name}!`);
@@ -163,4 +163,18 @@ By default we parse the response based on the `content-type` header for you. You
 
 ```js
 sdk.config({ parseResponse: false });
+```
+
+#### Where is the cache stored?
+
+By default the cache is configured with the [find-cache-dir](https://npm.im/find-cache-dir) library so the cache will be in `node_modules/.cache/api`. If placing this cache within the `node_modules/` directory is a problem for your environment (maybe you use `npm prune`) you can configure this by supplying an additional argument to the SDK instantiator:
+
+```js
+const sdk = require('api')('https://raw.githubusercontent.com/readmeio/oas-examples/main/3.0/json/petstore.json', {
+  cacheDir: './path/to/my/custom/cache/dir',
+});
+
+sdk.listPets().then(res => {
+  console.log(`My pets name is ${res[0].name}!`);
+});
 ```

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Using `api` is as simple as supplying it an OpenAPI and using the SDK as you wou
 ```js
 const sdk = require('api')('https://raw.githubusercontent.com/readmeio/oas/master/packages/examples/3.0/json/petstore.json');
 
-sdk.listPets().then(res => res.json()).then(res => {
+sdk.listPets().then(res => {
   console.log(`My pets name is ${res[0].name}!`);
 });
 ```
@@ -33,10 +33,11 @@ sdk.listPets().then(res => res.json()).then(res => {
 The OpenAPI definition is automatically downloaded, cached, and transformed into a chainable [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) Promise that you can use to make API requests.
 
 ### Authentication
-`api` supports API authentication through an `.auth()` method that you can chain to your requests, as such:
+`api` supports API authentication through an `.auth()` method:
 
 ```js
-sdk.auth('myApiToken').listPets().then(...);
+sdk.auth('myApiToken');
+sdk.listPets().then(...);
 ```
 
 With the exception of OpenID, it supports all forms of authentication supported by the OpenAPI specification! Just give `.auth()` your credentials and it'll figure out how to use it according to the API you're using.
@@ -46,6 +47,8 @@ For example:
 * HTTP Basic auth: `sdk.auth('username', 'password')`
 * Bearer tokens (HTTP or OAuth 2): `sdk.auth('myBearerToken')`
 * API Keys: `sdk.auth('myApiKey')`
+
+> ℹ️ Note that `sdk.auth()` is not chainable.
 
 ### Parameters and Payloads
 When supplying parameters and/or request body payloads to an API request, you don't need to explicitly define what goes where since the API definition contains all that information. All you need to do is supply either one or two objects:

--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "4.2.0"
+  "version": "4.2.1"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "4.5.0"
+  "version": "4.5.1"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "4.2.1"
+  "version": "4.3.0"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "4.4.0"
+  "version": "4.5.0"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "4.3.0"
+  "version": "4.4.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -500,9 +500,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.0.tgz",
-      "integrity": "sha512-Nht8L0O8YCktmsDV6FqFue7vQLRx3Hb0B37lS5y0jDRqRxlBG4wIJHnf9/bgSE2UyipKFA01YtS+npRdTWBUyw==",
+      "version": "7.17.8",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.8.tgz",
+      "integrity": "sha512-dQpEpK0O9o6lj6oPu0gRDbbnk+4LeHlNcBpspf6Olzt3GIX4P1lWF1gS+pHLDFlaJvbR6q7jCfQ08zA4QJBnmA==",
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
       },
@@ -1191,9 +1191,9 @@
       }
     },
     "node_modules/@humanwhocodes/momoa": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/momoa/-/momoa-2.0.2.tgz",
-      "integrity": "sha512-mkMcsshJ7L17AyntqpyjLiGqhbG62w93B0StW+HSNVJ1WUeVFA2uPssV/GufEfDqN6lRKI1I+uDzBUw83C0VuA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/momoa/-/momoa-2.0.3.tgz",
+      "integrity": "sha512-SytjS6gJk+LXSWFuEm0V9ASdgxlX/BDq6A+6gfh7TaHM90xppBydjcM3SFaziZP4ikKmhUOhPkDi2KktzElnQQ==",
       "engines": {
         "node": ">=10.10.0"
       }
@@ -2364,13 +2364,13 @@
       }
     },
     "node_modules/@readme/better-ajv-errors": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@readme/better-ajv-errors/-/better-ajv-errors-1.4.1.tgz",
-      "integrity": "sha512-MPDca1lZBHuTvx3SntTIW4CPjJy4krgkOpF2TQLgx2pVnk1hqLTM39Kn6z5PWa0mPaLcK4HnPQ9Rdhk0qn1zIA==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@readme/better-ajv-errors/-/better-ajv-errors-1.4.5.tgz",
+      "integrity": "sha512-a3YAAP1bEs9yytoqCy9Kj6VuWJ7WocVxedRcxImdkwTP6NBjtbY/IdBwHakll2DZ1yMOZAAozRebD09Xgfqrsg==",
       "dependencies": {
         "@babel/code-frame": "^7.16.0",
-        "@babel/runtime": "^7.16.0",
-        "@humanwhocodes/momoa": "^2.0.2",
+        "@babel/runtime": "^7.17.8",
+        "@humanwhocodes/momoa": "^2.0.3",
         "chalk": "^4.1.2",
         "json-to-ast": "^2.0.3",
         "jsonpointer": "^5.0.0",
@@ -2475,9 +2475,9 @@
       }
     },
     "node_modules/@readme/json-schema-ref-parser": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@readme/json-schema-ref-parser/-/json-schema-ref-parser-1.0.0.tgz",
-      "integrity": "sha512-M3b8E4l6+MGFyhznQoQ1yoVFkre8vQEkk9doGGp4okHAwYLikwZRKeC/UWp88cGbr8+ZB1a7pMmHu2iteDWmPg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@readme/json-schema-ref-parser/-/json-schema-ref-parser-1.1.0.tgz",
+      "integrity": "sha512-T0DxTMSEfOQHAlpI68LqYCwSFfP3u0w7E6zXWf16YphmAgWSOhLKuvnMSLXAlh27uxwclRekIvQf8AAUoQSDiw==",
       "dependencies": {
         "@jsdevtools/ono": "^7.1.3",
         "@types/json-schema": "^7.0.6",
@@ -2508,40 +2508,41 @@
       "dev": true
     },
     "node_modules/@readme/oas-extensions": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/@readme/oas-extensions/-/oas-extensions-14.0.4.tgz",
-      "integrity": "sha512-mmybpXe+OwHh7+gdY+slFK0R8bD5rWZTlUAM4sXYz5wRG63hWtL46nMSXRmw5BOdyLw23G+1G7tGn4Zl7B+lgg==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/@readme/oas-extensions/-/oas-extensions-14.2.0.tgz",
+      "integrity": "sha512-gE+bQ1zrkNFhtlctKA7gCPnOB3dQ2iUO0BgAeVFMpxyFyotVU1ku4GQH6pnxTUsVq0PZDz1WojsT2VAPe+TkCg==",
       "engines": {
         "node": "^12 || ^14 || ^16"
       },
       "peerDependencies": {
-        "oas": "^17.1.0"
+        "oas": "^17.1.0 || ^18.0.0"
       }
     },
     "node_modules/@readme/oas-to-har": {
-      "version": "14.0.5",
-      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-14.0.5.tgz",
-      "integrity": "sha512-vASZe7v5x5wq9UFlgFpBfjJLK83VjEs2naGKWt7IOIK/F/22Li3Vz+NQh4eCGFjqqo0uAhEm3w0dp6O6d3pGlw==",
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-16.1.0.tgz",
+      "integrity": "sha512-gwyu5w41sigPhijmOxeQFgjfe7ItCLo6wwWuw/MzKfW5ma2GWANauT2c+tSlsZN7zNuPdjAK0wEfOxKSXxQE0g==",
       "dependencies": {
-        "@readme/oas-extensions": "^14.0.4",
-        "oas": "^17.4.1",
-        "parse-data-url": "^4.0.1"
+        "@readme/oas-extensions": "^14.2.0",
+        "oas": "^18.0.6",
+        "parse-data-url": "^4.0.1",
+        "remove-undefined-objects": "^1.1.0"
       },
       "engines": {
         "node": "^12 || ^14 || ^16"
       }
     },
     "node_modules/@readme/openapi-parser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@readme/openapi-parser/-/openapi-parser-2.0.0.tgz",
-      "integrity": "sha512-QzDeBmARj2+PVnJswWQmiEkTjJljNKwP8EBCOjp0+3GmJp6BDEzy6VUEppGYdUJRaVfrLgqdYoiY1aFWlCBMVQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@readme/openapi-parser/-/openapi-parser-2.1.0.tgz",
+      "integrity": "sha512-93HDSz0bzBWvG1RyWC0gfupTlqWJB+k5OvD05LB+37cGi7VSiSDH4mGPLiLP410+kXQLN3X1FwWVIhnW2f4DhQ==",
       "dependencies": {
         "@apidevtools/openapi-schemas": "^2.1.0",
         "@apidevtools/swagger-methods": "^3.0.2",
         "@jsdevtools/ono": "^7.1.3",
-        "@readme/better-ajv-errors": "^1.4.0",
-        "@readme/json-schema-ref-parser": "^1.0.0",
-        "ajv": "^8.6.3",
+        "@readme/better-ajv-errors": "^1.4.5",
+        "@readme/json-schema-ref-parser": "^1.1.0",
+        "ajv": "^8.11.0",
         "ajv-draft-04": "^1.0.0",
         "call-me-maybe": "^1.0.1"
       },
@@ -2553,9 +2554,9 @@
       }
     },
     "node_modules/@readme/openapi-parser/node_modules/ajv": {
-      "version": "8.8.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.2.tgz",
-      "integrity": "sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -2806,9 +2807,9 @@
       }
     },
     "node_modules/@types/json-schema": {
-      "version": "7.0.9",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
-      "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ=="
+      "version": "7.0.11",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
+      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -3735,9 +3736,9 @@
       }
     },
     "node_modules/comment-patterns": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/comment-patterns/-/comment-patterns-0.12.0.tgz",
-      "integrity": "sha512-LhP+aYhloN+w6fh+U/Vwb+zjRvz7igV6V9YDPtSkdIctaUWb2NDasssTu1ujU8Z6/X5oKE3vWjRCKjCPii2FCg==",
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/comment-patterns/-/comment-patterns-0.12.2.tgz",
+      "integrity": "sha512-yA1FeubMSK0MXzapPm1uNdxyGk0mTAn5qrsVS6uQUSDOpUgWVLCqsgZfA/lhRx6TCLr1MvxeRqXOb1peWXWg3Q==",
       "dependencies": {
         "lodash": "^4.17.11"
       }
@@ -4317,11 +4318,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/es-get-iterator/node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
     },
     "node_modules/es-to-primitive": {
       "version": "1.2.1",
@@ -6615,6 +6611,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -10697,12 +10698,12 @@
       "dev": true
     },
     "node_modules/oas": {
-      "version": "17.4.1",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-17.4.1.tgz",
-      "integrity": "sha512-7fUoZ3CVhgHBLYEfaanNB3SY2PDxzYz2VqIGcUeQOpQ3T2j96R1FzWOlLsmP1BIIz0eTij0hzXJ6eT2A3vMdtQ==",
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-18.1.0.tgz",
+      "integrity": "sha512-p1R6NnOFCnorHm6b6Sz+DuxpmYHLUBfsFQ9k9IkJkQagYpWmRNmsHHExNolqTFans1Nue+B8Fzzo+BMQSzDNCA==",
       "dependencies": {
-        "@apidevtools/json-schema-ref-parser": "^9.0.6",
-        "@types/json-schema": "^7.0.9",
+        "@readme/json-schema-ref-parser": "^1.1.0",
+        "@types/json-schema": "^7.0.11",
         "cardinal": "^2.1.1",
         "chalk": "^4.1.2",
         "glob": "^7.1.2",
@@ -10712,10 +10713,10 @@
         "jsonpointer": "^5.0.0",
         "memoizee": "^0.4.14",
         "minimist": "^1.2.0",
-        "oas-normalize": "^5.1.0",
+        "oas-normalize": "^5.2.0",
         "openapi-types": "^10.0.0",
         "path-to-regexp": "^6.2.0",
-        "swagger-inline": "^5.0.2"
+        "swagger-inline": "^5.2.0"
       },
       "bin": {
         "oas": "bin/oas"
@@ -10746,11 +10747,11 @@
       }
     },
     "node_modules/oas-normalize": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-5.1.0.tgz",
-      "integrity": "sha512-lPVcc+yUzQZOKMKm6SXjmXI69Fgx3rPoPwRo1c/iaGdaVaoOSyB3NlweaW0qqdfuIx+gRz6ssTo9rpHvjsmQmA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-5.2.0.tgz",
+      "integrity": "sha512-xgbNgaFtsK388B9Wh1yE03TaivPXwSl3oMZBHa1ix8g2ZAal7ogl1mj4hRISPGPUgfDt57IQ9JQwdsGJufYRnw==",
       "dependencies": {
-        "@readme/openapi-parser": "^2.0.0",
+        "@readme/openapi-parser": "^2.1.0",
         "js-yaml": "^4.1.0",
         "node-fetch": "^2.6.1",
         "swagger2openapi": "^7.0.8"
@@ -10819,17 +10820,6 @@
         "url": "https://github.com/Mermade/oas-kit?sponsor=1"
       }
     },
-    "node_modules/oas/node_modules/@apidevtools/json-schema-ref-parser": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.9.tgz",
-      "integrity": "sha512-GBD2Le9w2+lVFoc4vswGI/TjkNIZSVp7+9xPf+X3uidBfWnAeUWmquteSyt0+VCrhNMWj/FTABISQrD3Z/YA+w==",
-      "dependencies": {
-        "@jsdevtools/ono": "^7.1.3",
-        "@types/json-schema": "^7.0.6",
-        "call-me-maybe": "^1.0.1",
-        "js-yaml": "^4.1.0"
-      }
-    },
     "node_modules/oas/node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -10843,11 +10833,6 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
-    },
-    "node_modules/oas/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/oas/node_modules/chalk": {
       "version": "4.1.2",
@@ -10886,17 +10871,6 @@
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/oas/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/oas/node_modules/supports-color": {
@@ -11400,15 +11374,15 @@
       }
     },
     "node_modules/promise.any": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/promise.any/-/promise.any-2.0.2.tgz",
-      "integrity": "sha512-Punsyr4isT+hfleeMH6hqHd6RtsB5ZVuRw+pBIQBBlmQqyacoYyutA0zAAuSdZHSeHi64wIzUK6vvZrI963fFA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/promise.any/-/promise.any-2.0.3.tgz",
+      "integrity": "sha512-BTzZue0G5jWLe5YRxn5yEPm8WI+wI/Kp387Y0P70m4S3VPYRBFuQiQ5GEHgFbpWs0RsTk4pGhQKRaFqVoJfsDw==",
       "dependencies": {
-        "array.prototype.map": "^1.0.2",
+        "array.prototype.map": "^1.0.4",
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0",
-        "es-aggregate-error": "^1.0.3",
+        "es-abstract": "^1.19.1",
+        "es-aggregate-error": "^1.0.7",
         "get-intrinsic": "^1.1.1",
         "iterate-value": "^1.0.2"
       },
@@ -11681,6 +11655,14 @@
       "integrity": "sha512-/62tYiOe6DzS5BqVsNpH/nkGlX45C/Sp6V+NtiN6JQNS1Viay7cWkazmRkrQrdFj2eshDe96SIQNIoMxqhzBOg==",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/remove-undefined-objects": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-undefined-objects/-/remove-undefined-objects-1.1.0.tgz",
+      "integrity": "sha512-lZ8dJTI11nUE3M2l9lXHkXvhAxOquhLn/umJuBqu1Ea+4A10Wh0fymb36ioeze7UgCjYKIlZuSqjVZDtYa+FeQ==",
+      "engines": {
+        "node": "^12 || ^14 || ^16"
       }
     },
     "node_modules/require-directory": {
@@ -12362,9 +12344,9 @@
       }
     },
     "node_modules/swagger-inline": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/swagger-inline/-/swagger-inline-5.0.2.tgz",
-      "integrity": "sha512-Vdvuv9TzlnnRzue9ydXQBCe0otxh+rXz6vsLnUXwNqFjGWn/2OATYnyVEHojmKXS1fuMkaunVNsv0a9JT08UBw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/swagger-inline/-/swagger-inline-5.2.0.tgz",
+      "integrity": "sha512-QxM1D7QNwlCiT71YPW2Lncro44fgrZE1cPC/Lyjt9+ZplNBASw/4HjaxzNinQuOsCSJZtuE9njMVY09YmQd9Ug==",
       "dependencies": {
         "commander": "^6.0.0",
         "globby": "^11.0.1",
@@ -13177,11 +13159,11 @@
       }
     },
     "packages/api": {
-      "version": "4.1.3",
+      "version": "4.2.1",
       "license": "MIT",
       "dependencies": {
-        "@readme/oas-to-har": "^14.0.5",
-        "@readme/openapi-parser": "^2.0.0",
+        "@readme/oas-to-har": "^16.1.0",
+        "@readme/openapi-parser": "^2.1.0",
         "datauri": "^4.1.0",
         "fetch-har": "^5.0.5",
         "find-cache-dir": "^3.3.1",
@@ -13191,7 +13173,7 @@
         "make-dir": "^3.1.0",
         "mimer": "^2.0.2",
         "node-fetch": "^2.6.0",
-        "oas": "^17.4.1"
+        "oas": "^18.1.0"
       },
       "devDependencies": {
         "@readme/eslint-config": "^8.0.2",
@@ -13849,7 +13831,7 @@
       }
     },
     "packages/httpsnippet-client-api": {
-      "version": "4.1.3",
+      "version": "4.2.0",
       "license": "MIT",
       "dependencies": {
         "content-type": "^1.0.4",
@@ -13868,7 +13850,7 @@
       },
       "peerDependencies": {
         "@readme/httpsnippet": "^3.0.0",
-        "oas": "^17.1.0"
+        "oas": "^18.1.0"
       }
     },
     "packages/httpsnippet-client-api/node_modules/@eslint/eslintrc": {
@@ -14874,9 +14856,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.0.tgz",
-      "integrity": "sha512-Nht8L0O8YCktmsDV6FqFue7vQLRx3Hb0B37lS5y0jDRqRxlBG4wIJHnf9/bgSE2UyipKFA01YtS+npRdTWBUyw==",
+      "version": "7.17.8",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.8.tgz",
+      "integrity": "sha512-dQpEpK0O9o6lj6oPu0gRDbbnk+4LeHlNcBpspf6Olzt3GIX4P1lWF1gS+pHLDFlaJvbR6q7jCfQ08zA4QJBnmA==",
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -15399,9 +15381,9 @@
       }
     },
     "@humanwhocodes/momoa": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/momoa/-/momoa-2.0.2.tgz",
-      "integrity": "sha512-mkMcsshJ7L17AyntqpyjLiGqhbG62w93B0StW+HSNVJ1WUeVFA2uPssV/GufEfDqN6lRKI1I+uDzBUw83C0VuA=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/momoa/-/momoa-2.0.3.tgz",
+      "integrity": "sha512-SytjS6gJk+LXSWFuEm0V9ASdgxlX/BDq6A+6gfh7TaHM90xppBydjcM3SFaziZP4ikKmhUOhPkDi2KktzElnQQ=="
     },
     "@humanwhocodes/object-schema": {
       "version": "1.2.1",
@@ -16303,13 +16285,13 @@
       }
     },
     "@readme/better-ajv-errors": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@readme/better-ajv-errors/-/better-ajv-errors-1.4.1.tgz",
-      "integrity": "sha512-MPDca1lZBHuTvx3SntTIW4CPjJy4krgkOpF2TQLgx2pVnk1hqLTM39Kn6z5PWa0mPaLcK4HnPQ9Rdhk0qn1zIA==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@readme/better-ajv-errors/-/better-ajv-errors-1.4.5.tgz",
+      "integrity": "sha512-a3YAAP1bEs9yytoqCy9Kj6VuWJ7WocVxedRcxImdkwTP6NBjtbY/IdBwHakll2DZ1yMOZAAozRebD09Xgfqrsg==",
       "requires": {
         "@babel/code-frame": "^7.16.0",
-        "@babel/runtime": "^7.16.0",
-        "@humanwhocodes/momoa": "^2.0.2",
+        "@babel/runtime": "^7.17.8",
+        "@humanwhocodes/momoa": "^2.0.3",
         "chalk": "^4.1.2",
         "json-to-ast": "^2.0.3",
         "jsonpointer": "^5.0.0",
@@ -16383,9 +16365,9 @@
       }
     },
     "@readme/json-schema-ref-parser": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@readme/json-schema-ref-parser/-/json-schema-ref-parser-1.0.0.tgz",
-      "integrity": "sha512-M3b8E4l6+MGFyhznQoQ1yoVFkre8vQEkk9doGGp4okHAwYLikwZRKeC/UWp88cGbr8+ZB1a7pMmHu2iteDWmPg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@readme/json-schema-ref-parser/-/json-schema-ref-parser-1.1.0.tgz",
+      "integrity": "sha512-T0DxTMSEfOQHAlpI68LqYCwSFfP3u0w7E6zXWf16YphmAgWSOhLKuvnMSLXAlh27uxwclRekIvQf8AAUoQSDiw==",
       "requires": {
         "@jsdevtools/ono": "^7.1.3",
         "@types/json-schema": "^7.0.6",
@@ -16415,40 +16397,41 @@
       "dev": true
     },
     "@readme/oas-extensions": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/@readme/oas-extensions/-/oas-extensions-14.0.4.tgz",
-      "integrity": "sha512-mmybpXe+OwHh7+gdY+slFK0R8bD5rWZTlUAM4sXYz5wRG63hWtL46nMSXRmw5BOdyLw23G+1G7tGn4Zl7B+lgg==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/@readme/oas-extensions/-/oas-extensions-14.2.0.tgz",
+      "integrity": "sha512-gE+bQ1zrkNFhtlctKA7gCPnOB3dQ2iUO0BgAeVFMpxyFyotVU1ku4GQH6pnxTUsVq0PZDz1WojsT2VAPe+TkCg==",
       "requires": {}
     },
     "@readme/oas-to-har": {
-      "version": "14.0.5",
-      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-14.0.5.tgz",
-      "integrity": "sha512-vASZe7v5x5wq9UFlgFpBfjJLK83VjEs2naGKWt7IOIK/F/22Li3Vz+NQh4eCGFjqqo0uAhEm3w0dp6O6d3pGlw==",
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-16.1.0.tgz",
+      "integrity": "sha512-gwyu5w41sigPhijmOxeQFgjfe7ItCLo6wwWuw/MzKfW5ma2GWANauT2c+tSlsZN7zNuPdjAK0wEfOxKSXxQE0g==",
       "requires": {
-        "@readme/oas-extensions": "^14.0.4",
-        "oas": "^17.4.1",
-        "parse-data-url": "^4.0.1"
+        "@readme/oas-extensions": "^14.2.0",
+        "oas": "^18.0.6",
+        "parse-data-url": "^4.0.1",
+        "remove-undefined-objects": "^1.1.0"
       }
     },
     "@readme/openapi-parser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@readme/openapi-parser/-/openapi-parser-2.0.0.tgz",
-      "integrity": "sha512-QzDeBmARj2+PVnJswWQmiEkTjJljNKwP8EBCOjp0+3GmJp6BDEzy6VUEppGYdUJRaVfrLgqdYoiY1aFWlCBMVQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@readme/openapi-parser/-/openapi-parser-2.1.0.tgz",
+      "integrity": "sha512-93HDSz0bzBWvG1RyWC0gfupTlqWJB+k5OvD05LB+37cGi7VSiSDH4mGPLiLP410+kXQLN3X1FwWVIhnW2f4DhQ==",
       "requires": {
         "@apidevtools/openapi-schemas": "^2.1.0",
         "@apidevtools/swagger-methods": "^3.0.2",
         "@jsdevtools/ono": "^7.1.3",
-        "@readme/better-ajv-errors": "^1.4.0",
-        "@readme/json-schema-ref-parser": "^1.0.0",
-        "ajv": "^8.6.3",
+        "@readme/better-ajv-errors": "^1.4.5",
+        "@readme/json-schema-ref-parser": "^1.1.0",
+        "ajv": "^8.11.0",
         "ajv-draft-04": "^1.0.0",
         "call-me-maybe": "^1.0.1"
       },
       "dependencies": {
         "ajv": {
-          "version": "8.8.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.2.tgz",
-          "integrity": "sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==",
+          "version": "8.11.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+          "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -16665,9 +16648,9 @@
       }
     },
     "@types/json-schema": {
-      "version": "7.0.9",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
-      "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ=="
+      "version": "7.0.11",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
+      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="
     },
     "@types/json5": {
       "version": "0.0.29",
@@ -16828,8 +16811,8 @@
       "requires": {
         "@readme/eslint-config": "^8.0.2",
         "@readme/oas-examples": "^4.3.3",
-        "@readme/oas-to-har": "^14.0.5",
-        "@readme/openapi-parser": "^2.0.0",
+        "@readme/oas-to-har": "^16.1.0",
+        "@readme/openapi-parser": "^2.1.0",
         "datauri": "^4.1.0",
         "eslint": "^8.3.0",
         "fetch-har": "^5.0.5",
@@ -16843,7 +16826,7 @@
         "mimer": "^2.0.2",
         "nock": "^13.1.3",
         "node-fetch": "^2.6.0",
-        "oas": "^17.4.1",
+        "oas": "^18.1.0",
         "prettier": "^2.4.1"
       },
       "dependencies": {
@@ -17818,9 +17801,9 @@
       "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA=="
     },
     "comment-patterns": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/comment-patterns/-/comment-patterns-0.12.0.tgz",
-      "integrity": "sha512-LhP+aYhloN+w6fh+U/Vwb+zjRvz7igV6V9YDPtSkdIctaUWb2NDasssTu1ujU8Z6/X5oKE3vWjRCKjCPii2FCg==",
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/comment-patterns/-/comment-patterns-0.12.2.tgz",
+      "integrity": "sha512-yA1FeubMSK0MXzapPm1uNdxyGk0mTAn5qrsVS6uQUSDOpUgWVLCqsgZfA/lhRx6TCLr1MvxeRqXOb1peWXWg3Q==",
       "requires": {
         "lodash": "^4.17.11"
       }
@@ -18283,13 +18266,6 @@
         "is-set": "^2.0.2",
         "is-string": "^1.0.5",
         "isarray": "^2.0.5"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
-        }
       }
     },
     "es-to-primitive": {
@@ -20425,6 +20401,11 @@
       "requires": {
         "call-bind": "^1.0.0"
       }
+    },
+    "isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
     },
     "isexe": {
       "version": "2.0.0",
@@ -23572,12 +23553,12 @@
       "dev": true
     },
     "oas": {
-      "version": "17.4.1",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-17.4.1.tgz",
-      "integrity": "sha512-7fUoZ3CVhgHBLYEfaanNB3SY2PDxzYz2VqIGcUeQOpQ3T2j96R1FzWOlLsmP1BIIz0eTij0hzXJ6eT2A3vMdtQ==",
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-18.1.0.tgz",
+      "integrity": "sha512-p1R6NnOFCnorHm6b6Sz+DuxpmYHLUBfsFQ9k9IkJkQagYpWmRNmsHHExNolqTFans1Nue+B8Fzzo+BMQSzDNCA==",
       "requires": {
-        "@apidevtools/json-schema-ref-parser": "^9.0.6",
-        "@types/json-schema": "^7.0.9",
+        "@readme/json-schema-ref-parser": "^1.1.0",
+        "@types/json-schema": "^7.0.11",
         "cardinal": "^2.1.1",
         "chalk": "^4.1.2",
         "glob": "^7.1.2",
@@ -23587,23 +23568,12 @@
         "jsonpointer": "^5.0.0",
         "memoizee": "^0.4.14",
         "minimist": "^1.2.0",
-        "oas-normalize": "^5.1.0",
+        "oas-normalize": "^5.2.0",
         "openapi-types": "^10.0.0",
         "path-to-regexp": "^6.2.0",
-        "swagger-inline": "^5.0.2"
+        "swagger-inline": "^5.2.0"
       },
       "dependencies": {
-        "@apidevtools/json-schema-ref-parser": {
-          "version": "9.0.9",
-          "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.9.tgz",
-          "integrity": "sha512-GBD2Le9w2+lVFoc4vswGI/TjkNIZSVp7+9xPf+X3uidBfWnAeUWmquteSyt0+VCrhNMWj/FTABISQrD3Z/YA+w==",
-          "requires": {
-            "@jsdevtools/ono": "^7.1.3",
-            "@types/json-schema": "^7.0.6",
-            "call-me-maybe": "^1.0.1",
-            "js-yaml": "^4.1.0"
-          }
-        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -23611,11 +23581,6 @@
           "requires": {
             "color-convert": "^2.0.1"
           }
-        },
-        "argparse": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
         },
         "chalk": {
           "version": "4.1.2",
@@ -23643,14 +23608,6 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-        },
-        "js-yaml": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-          "requires": {
-            "argparse": "^2.0.1"
-          }
         },
         "supports-color": {
           "version": "7.2.0",
@@ -23681,11 +23638,11 @@
       }
     },
     "oas-normalize": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-5.1.0.tgz",
-      "integrity": "sha512-lPVcc+yUzQZOKMKm6SXjmXI69Fgx3rPoPwRo1c/iaGdaVaoOSyB3NlweaW0qqdfuIx+gRz6ssTo9rpHvjsmQmA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-5.2.0.tgz",
+      "integrity": "sha512-xgbNgaFtsK388B9Wh1yE03TaivPXwSl3oMZBHa1ix8g2ZAal7ogl1mj4hRISPGPUgfDt57IQ9JQwdsGJufYRnw==",
       "requires": {
-        "@readme/openapi-parser": "^2.0.0",
+        "@readme/openapi-parser": "^2.1.0",
         "js-yaml": "^4.1.0",
         "node-fetch": "^2.6.1",
         "swagger2openapi": "^7.0.8"
@@ -24091,15 +24048,15 @@
       "dev": true
     },
     "promise.any": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/promise.any/-/promise.any-2.0.2.tgz",
-      "integrity": "sha512-Punsyr4isT+hfleeMH6hqHd6RtsB5ZVuRw+pBIQBBlmQqyacoYyutA0zAAuSdZHSeHi64wIzUK6vvZrI963fFA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/promise.any/-/promise.any-2.0.3.tgz",
+      "integrity": "sha512-BTzZue0G5jWLe5YRxn5yEPm8WI+wI/Kp387Y0P70m4S3VPYRBFuQiQ5GEHgFbpWs0RsTk4pGhQKRaFqVoJfsDw==",
       "requires": {
-        "array.prototype.map": "^1.0.2",
+        "array.prototype.map": "^1.0.4",
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0",
-        "es-aggregate-error": "^1.0.3",
+        "es-abstract": "^1.19.1",
+        "es-aggregate-error": "^1.0.7",
         "get-intrinsic": "^1.1.1",
         "iterate-value": "^1.0.2"
       }
@@ -24298,6 +24255,11 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/remedial/-/remedial-1.0.8.tgz",
       "integrity": "sha512-/62tYiOe6DzS5BqVsNpH/nkGlX45C/Sp6V+NtiN6JQNS1Viay7cWkazmRkrQrdFj2eshDe96SIQNIoMxqhzBOg=="
+    },
+    "remove-undefined-objects": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-undefined-objects/-/remove-undefined-objects-1.1.0.tgz",
+      "integrity": "sha512-lZ8dJTI11nUE3M2l9lXHkXvhAxOquhLn/umJuBqu1Ea+4A10Wh0fymb36ioeze7UgCjYKIlZuSqjVZDtYa+FeQ=="
     },
     "require-directory": {
       "version": "2.1.1",
@@ -24826,9 +24788,9 @@
       }
     },
     "swagger-inline": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/swagger-inline/-/swagger-inline-5.0.2.tgz",
-      "integrity": "sha512-Vdvuv9TzlnnRzue9ydXQBCe0otxh+rXz6vsLnUXwNqFjGWn/2OATYnyVEHojmKXS1fuMkaunVNsv0a9JT08UBw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/swagger-inline/-/swagger-inline-5.2.0.tgz",
+      "integrity": "sha512-QxM1D7QNwlCiT71YPW2Lncro44fgrZE1cPC/Lyjt9+ZplNBASw/4HjaxzNinQuOsCSJZtuE9njMVY09YmQd9Ug==",
       "requires": {
         "commander": "^6.0.0",
         "globby": "^11.0.1",

--- a/packages/api/.gitignore
+++ b/packages/api/.gitignore
@@ -1,2 +1,3 @@
+.api/
 coverage/
 node_modules/

--- a/packages/api/.npmignore
+++ b/packages/api/.npmignore
@@ -1,5 +1,6 @@
 __tests__/
 coverage/
+.api/
 .eslint*
 .gitignore
 .prettier*

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -23,7 +23,7 @@ npm install api --save
 Using `api` is as simple as supplying it an OpenAPI and using the SDK as you would any other!
 
 ```js
-const sdk = require('api')('https://raw.githubusercontent.com/readmeio/oas/master/packages/examples/3.0/json/petstore.json');
+const sdk = require('api')('https://raw.githubusercontent.com/readmeio/oas-examples/main/3.0/json/petstore.json');
 
 sdk.listPets().then(res => {
   console.log(`My pets name is ${res[0].name}!`);
@@ -163,4 +163,18 @@ By default we parse the response based on the `content-type` header for you. You
 
 ```js
 sdk.config({ parseResponse: false });
+```
+
+#### Where is the cache stored?
+
+By default the cache is configured with the [find-cache-dir](https://npm.im/find-cache-dir) library so the cache will be in `node_modules/.cache/api`. If placing this cache within the `node_modules/` directory is a problem for your environment (maybe you use `npm prune`) you can configure this by supplying an additional argument to the SDK instantiator:
+
+```js
+const sdk = require('api')('https://raw.githubusercontent.com/readmeio/oas-examples/main/3.0/json/petstore.json', {
+  cacheDir: './path/to/my/custom/cache/dir',
+});
+
+sdk.listPets().then(res => {
+  console.log(`My pets name is ${res[0].name}!`);
+});
 ```

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -25,7 +25,7 @@ Using `api` is as simple as supplying it an OpenAPI and using the SDK as you wou
 ```js
 const sdk = require('api')('https://raw.githubusercontent.com/readmeio/oas/master/packages/examples/3.0/json/petstore.json');
 
-sdk.listPets().then(res => res.json()).then(res => {
+sdk.listPets().then(res => {
   console.log(`My pets name is ${res[0].name}!`);
 });
 ```
@@ -33,10 +33,11 @@ sdk.listPets().then(res => res.json()).then(res => {
 The OpenAPI definition is automatically downloaded, cached, and transformed into a chainable [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) Promise that you can use to make API requests.
 
 ### Authentication
-`api` supports API authentication through an `.auth()` method that you can chain to your requests, as such:
+`api` supports API authentication through an `.auth()` method:
 
 ```js
-sdk.auth('myApiToken').listPets().then(...);
+sdk.auth('myApiToken');
+sdk.listPets().then(...);
 ```
 
 With the exception of OpenID, it supports all forms of authentication supported by the OpenAPI specification! Just give `.auth()` your credentials and it'll figure out how to use it according to the API you're using.
@@ -46,6 +47,8 @@ For example:
 * HTTP Basic auth: `sdk.auth('username', 'password')`
 * Bearer tokens (HTTP or OAuth 2): `sdk.auth('myBearerToken')`
 * API Keys: `sdk.auth('myApiKey')`
+
+> ℹ️ Note that `sdk.auth()` is not chainable.
 
 ### Parameters and Payloads
 When supplying parameters and/or request body payloads to an API request, you don't need to explicitly define what goes where since the API definition contains all that information. All you need to do is supply either one or two objects:

--- a/packages/api/__tests__/auth.test.js
+++ b/packages/api/__tests__/auth.test.js
@@ -8,19 +8,9 @@ describe('#auth()', () => {
     const apiKey = '123457890';
 
     describe('in: query', () => {
-      it.each([
-        ['should allow you to supply auth', false],
-        ['should allow you to supply auth when unchained from an operation', true],
-      ])('%s', (testCase, chained) => {
+      it('should allow you to supply auth', () => {
         const sdk = api(securityOas);
         const mock = nock('https://httpbin.org').get('/apiKey').query({ apiKey }).reply(200, {});
-
-        if (chained) {
-          return sdk
-            .auth(apiKey)
-            .get('/apiKey')
-            .then(() => mock.done());
-        }
 
         sdk.auth(apiKey);
         return sdk.get('/apiKey').then(() => mock.done());
@@ -29,26 +19,17 @@ describe('#auth()', () => {
       it('should throw if you supply multiple auth keys', () => {
         const sdk = api(securityOas);
 
-        return expect(sdk.auth(apiKey, apiKey).get('/apiKey')).rejects.toThrow(/only a single key is needed/i);
+        sdk.auth(apiKey, apiKey);
+        return expect(sdk.get('/apiKey')).rejects.toThrow(/only a single key is needed/i);
       });
     });
 
     describe('in: header', () => {
-      it.each([
-        ['should allow you to supply auth', false],
-        ['should allow you to supply auth when unchained from an operation', true],
-      ])('%s', (testCase, chained) => {
+      it('should allow you to supply auth', () => {
         const sdk = api(securityOas);
         const mock = nock('https://httpbin.org', { reqheaders: { 'X-API-KEY': apiKey } })
           .put('/apiKey')
           .reply(200, {});
-
-        if (chained) {
-          return sdk
-            .auth(apiKey)
-            .put('/apiKey')
-            .then(() => mock.done());
-        }
 
         sdk.auth(apiKey);
         return sdk.put('/apiKey').then(() => mock.done());
@@ -57,7 +38,8 @@ describe('#auth()', () => {
       it('should throw if you supply multiple auth keys', () => {
         const sdk = api(securityOas);
 
-        return expect(sdk.auth(apiKey, apiKey).put('/apiKey')).rejects.toThrow(/only a single key is needed/i);
+        sdk.auth(apiKey, apiKey);
+        return expect(sdk.put('/apiKey')).rejects.toThrow(/only a single key is needed/i);
       });
     });
   });
@@ -67,27 +49,13 @@ describe('#auth()', () => {
       const user = 'username';
       const pass = 'changeme';
 
-      it.each([
-        ['should allow you to supply auth', false],
-        ['should allow you to supply auth when unchained from an operation', true],
-      ])('%s', (testCase, chained) => {
+      it('should allow you to supply auth', () => {
         const sdk = api(securityOas);
         const mock = nock('https://httpbin.org', {
           reqheaders: { authorization: `Basic ${Buffer.from(`${user}:${pass}`).toString('base64')}` },
         })
           .post('/basic')
           .reply(200, { id: 1 });
-
-        if (chained) {
-          return sdk
-            .auth(user, pass)
-            .post('/basic')
-            .then(res => {
-              // eslint-disable-next-line jest/no-conditional-expect
-              expect(res.id).toBe(1);
-              mock.done();
-            });
-        }
 
         sdk.auth(user, pass);
         return sdk.post('/basic').then(res => {
@@ -104,31 +72,19 @@ describe('#auth()', () => {
           .post('/basic')
           .reply(200, {});
 
-        return sdk
-          .auth(user)
-          .post('/basic')
-          .then(() => mock.done());
+        sdk.auth(user);
+        return sdk.post('/basic').then(() => mock.done());
       });
     });
 
     describe('scheme: bearer', () => {
       const apiKey = '123457890';
 
-      it.each([
-        ['should allow you to supply auth', false],
-        ['should allow you to supply auth when unchained from an operation', true],
-      ])('%s', (testCase, chained) => {
+      it('should allow you to supply auth', () => {
         const sdk = api(securityOas);
         const mock = nock('https://httpbin.org', { reqheaders: { authorization: `Bearer ${apiKey}` } })
           .post('/bearer')
           .reply(200, {});
-
-        if (chained) {
-          return sdk
-            .auth(apiKey)
-            .post('/bearer')
-            .then(() => mock.done());
-        }
 
         sdk.auth(apiKey);
         return sdk.post('/bearer').then(() => mock.done());
@@ -137,7 +93,8 @@ describe('#auth()', () => {
       it('should throw if you pass in multiple bearer tokens', () => {
         const sdk = api(securityOas);
 
-        return expect(sdk.auth(apiKey, apiKey).post('/bearer')).rejects.toThrow(/only a single token is needed/i);
+        sdk.auth(apiKey, apiKey);
+        return expect(sdk.post('/bearer')).rejects.toThrow(/only a single token is needed/i);
       });
     });
   });
@@ -145,21 +102,11 @@ describe('#auth()', () => {
   describe('OAuth 2', () => {
     const apiKey = '123457890';
 
-    it.each([
-      ['should allow you to supply auth', false],
-      ['should allow you to supply auth when unchained from an operation', true],
-    ])('%s', (testCase, chained) => {
+    it('should allow you to supply auth', () => {
       const sdk = api(securityOas);
       const mock = nock('https://httpbin.org', { reqheaders: { authorization: `Bearer ${apiKey}` } })
         .post('/oauth2')
         .reply(200, {});
-
-      if (chained) {
-        return sdk
-          .auth(apiKey)
-          .post('/oauth2')
-          .then(() => mock.done());
-      }
 
       sdk.auth(apiKey);
       return sdk.post('/oauth2').then(() => mock.done());
@@ -168,7 +115,8 @@ describe('#auth()', () => {
     it('should throw if you pass in multiple bearer tokens', () => {
       const sdk = api(securityOas);
 
-      return expect(sdk.auth(apiKey, apiKey).post('/oauth2')).rejects.toThrow(/only a single token is needed/i);
+      sdk.auth(apiKey, apiKey);
+      return expect(sdk.post('/oauth2')).rejects.toThrow(/only a single token is needed/i);
     });
   });
 });

--- a/packages/api/__tests__/cache-custom.test.js
+++ b/packages/api/__tests__/cache-custom.test.js
@@ -39,7 +39,7 @@ describe('custom cache directory', () => {
     const cache = await fs.readFile(path.join(cacheDir, 'cache.json'), 'utf8').then(JSON.parse);
     expect(cache).toStrictEqual({
       bcace67532514a49e663e471602b7be6: {
-        path: `${cacheDir}/specs/f2068ebf6ce28b51a8467bf7ac53bbae.json`,
+        hash: 'f2068ebf6ce28b51a8467bf7ac53bbae',
         original: 'https://example.com/openapi.json',
         title: 'USPTO Data Set API',
         version: '1.0.0',

--- a/packages/api/__tests__/cache-custom.test.js
+++ b/packages/api/__tests__/cache-custom.test.js
@@ -1,0 +1,49 @@
+const path = require('path');
+const fs = require('fs').promises;
+const api = require('../src');
+const nock = require('nock');
+
+const uspto = require('@readme/oas-examples/3.0/json/uspto.json');
+
+describe('custom cache directory', () => {
+  let cacheDir;
+
+  beforeAll(async () => {
+    cacheDir = path.join(__dirname, '..', '.api-test');
+
+    await fs.mkdir(cacheDir, { recursive: true });
+  });
+
+  afterAll(async () => {
+    await fs.rmdir(cacheDir, { recursive: true });
+  });
+
+  it('should support supplying a custom cache directory', async () => {
+    // Our custom caching directory should be empty.
+    await expect(fs.readdir(cacheDir)).resolves.toHaveLength(0);
+
+    const oasMock = nock('https://example.com').get('/openapi.json').reply(200, uspto);
+    const mock = nock('https://developer.uspto.gov/ds-api').get('/').reply(200);
+
+    const sdk = api('https://example.com/openapi.json', { cacheDir });
+
+    await sdk.get('/').then(() => {
+      mock.done();
+      oasMock.done();
+    });
+
+    // Our custom caching directory should have our cached spec in it.
+    const files = [...(await fs.readdir(cacheDir)), ...(await fs.readdir(path.join(cacheDir, 'specs')))];
+    expect(files).toStrictEqual(['cache.json', 'specs', 'f2068ebf6ce28b51a8467bf7ac53bbae.json']);
+
+    const cache = await fs.readFile(path.join(cacheDir, 'cache.json'), 'utf8').then(JSON.parse);
+    expect(cache).toStrictEqual({
+      bcace67532514a49e663e471602b7be6: {
+        path: `${cacheDir}/specs/f2068ebf6ce28b51a8467bf7ac53bbae.json`,
+        original: 'https://example.com/openapi.json',
+        title: 'USPTO Data Set API',
+        version: '1.0.0',
+      },
+    });
+  });
+});

--- a/packages/api/__tests__/cache.test.js
+++ b/packages/api/__tests__/cache.test.js
@@ -141,7 +141,6 @@ describe('#saveUrl()', () => {
 
     const cached = cacheStore.getCache();
     expect(cached).toHaveProperty(hash);
-    expect(cached[hash].path).toMatch(/\.json$/);
   });
 });
 
@@ -182,7 +181,6 @@ describe('#saveFile()', () => {
 
     const cached = cacheStore.getCache();
     expect(cached).toHaveProperty(hash);
-    expect(cached[hash].path).toMatch(/\.json$/);
   });
 });
 
@@ -250,6 +248,26 @@ describe('#get', () => {
 
   it('should load a file out of cache', async () => {
     await cacheStore.saveFile();
+
+    const loaded = cacheStore.get();
+    expect(loaded).toHaveProperty('components');
+    expect(loaded).toHaveProperty('info');
+    expect(loaded).toHaveProperty('paths');
+    expect(loaded).toHaveProperty('servers');
+  });
+
+  it('should support the legacy `path` property in the cache store', async () => {
+    await cacheStore.saveFile();
+
+    const cache = cacheStore.getCache();
+    cache['44ec0da6e10c8806831ba3d4126c1b66'].path = path.join(
+      cacheStore.specsCache,
+      `${cache['44ec0da6e10c8806831ba3d4126c1b66'].hash}.json`
+    );
+
+    delete cache['44ec0da6e10c8806831ba3d4126c1b66'].hash;
+
+    expect(Object.keys(cache)).toHaveLength(1);
 
     const loaded = cacheStore.get();
     expect(loaded).toHaveProperty('components');

--- a/packages/api/__tests__/cache.test.js
+++ b/packages/api/__tests__/cache.test.js
@@ -257,15 +257,15 @@ describe('#get', () => {
   });
 
   it('should support the legacy `path` property in the cache store', async () => {
+    const file = path.join(examplesDir, 'readme.yaml');
+    cacheStore = new Cache(file);
     await cacheStore.saveFile();
 
     const cache = cacheStore.getCache();
-    cache['44ec0da6e10c8806831ba3d4126c1b66'].path = path.join(
-      cacheStore.specsCache,
-      `${cache['44ec0da6e10c8806831ba3d4126c1b66'].hash}.json`
-    );
+    const cacheKey = Object.keys(cache)[0];
+    cache[cacheKey].path = path.join(cacheStore.specsCache, `${cache[cacheKey].hash}.json`);
 
-    delete cache['44ec0da6e10c8806831ba3d4126c1b66'].hash;
+    delete cache[cacheKey].hash;
 
     expect(Object.keys(cache)).toHaveLength(1);
 

--- a/packages/api/__tests__/lib/getSchema.test.js
+++ b/packages/api/__tests__/lib/getSchema.test.js
@@ -1,0 +1,114 @@
+const getSchema = require('../../src/lib/getSchema');
+
+const schema = { type: 'string' };
+
+test('should return the first type if there is content', () => {
+  expect(
+    getSchema({
+      requestBody: {
+        content: {
+          'application/json': {
+            schema,
+          },
+          'text/xml': {
+            schema: { type: 'number' },
+          },
+        },
+      },
+    })
+  ).toStrictEqual({
+    type: 'application/json',
+    schema: { schema },
+  });
+
+  expect(
+    getSchema({
+      requestBody: {
+        content: {
+          'text/xml': {
+            schema,
+          },
+          'application/json': {
+            schema: { type: 'number' },
+          },
+        },
+      },
+    })
+  ).toStrictEqual({
+    type: 'text/xml',
+    schema: { schema },
+  });
+});
+
+test('should return undefined', () => {
+  expect(getSchema({})).toBeUndefined();
+});
+
+test('should return if theres a $ref on the top level', () => {
+  const $ref = '#/definitions/schema';
+  expect(getSchema({ requestBody: { $ref } })).toStrictEqual({
+    type: 'application/json',
+    schema: { $ref },
+  });
+});
+
+// https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#requestBodyObject
+test('should look up the schema if it looks like the first $ref is a request body object', () => {
+  const $ref = '#/components/schemas/schema';
+  expect(
+    getSchema(
+      {
+        requestBody: { $ref: '#/components/requestBodies/schema' },
+      },
+      {
+        components: {
+          requestBodies: { schema: { content: { 'application/json': { schema: { $ref } } } } },
+        },
+      }
+    ).schema.schema.$ref
+  ).toStrictEqual($ref);
+});
+
+test('should return the inline schema from request body object', () => {
+  expect(
+    getSchema(
+      {
+        requestBody: { $ref: '#/components/requestBodies/schema' },
+      },
+      {
+        components: { requestBodies: { schema: { content: { 'application/json': { schema } } } } },
+      }
+    ).schema
+  ).toStrictEqual({ schema });
+});
+
+test('should retain examples if they are present alongside the schema', () => {
+  expect(
+    getSchema({
+      requestBody: {
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: {
+                id: {
+                  type: 'integer',
+                },
+                name: {
+                  type: 'string',
+                },
+              },
+            },
+            examples: {
+              id: 10,
+              name: 'buster',
+            },
+          },
+        },
+      },
+    }).schema.examples
+  ).toStrictEqual({
+    id: 10,
+    name: 'buster',
+  });
+});

--- a/packages/api/example.js
+++ b/packages/api/example.js
@@ -1,13 +1,10 @@
-const sdk = require('./src')('https://raw.githubusercontent.com/readmeio/oas/master/packages/examples/3.0/yaml/readme.yaml');
+// const path = require('path');
+const sdk = require('./src')('https://raw.githubusercontent.com/readmeio/oas-examples/main/3.0/yaml/readme.yaml', {
+  // Uncomment this line to load the SDK with a custom caching directory.
+  // cacheDir: path.join(process.cwd(), '.api'),
+});
 
-sdk
-  .auth('readmeApiToken')
-  .getChangelogs({
-    perPage: 10,
-    page: 1
-  })
-  .then(res => res.json())
-  .then(res => {
-    console.log(`there are ${res.length} changelogs`);
-    console.log(res[0]);
-  });
+sdk.getOpenRoles().then(res => {
+  console.log(`there are ${res.length} open roles`);
+  console.log(res[0]);
+});

--- a/packages/api/package-lock.json
+++ b/packages/api/package-lock.json
@@ -6,11 +6,11 @@
   "packages": {
     "": {
       "name": "api",
-      "version": "4.1.3",
+      "version": "4.2.1",
       "license": "MIT",
       "dependencies": {
-        "@readme/oas-to-har": "^14.0.5",
-        "@readme/openapi-parser": "^2.0.0",
+        "@readme/oas-to-har": "^16.1.0",
+        "@readme/openapi-parser": "^2.1.0",
         "datauri": "^4.1.0",
         "fetch-har": "^5.0.5",
         "find-cache-dir": "^3.3.1",
@@ -20,7 +20,7 @@
         "make-dir": "^3.1.0",
         "mimer": "^2.0.2",
         "node-fetch": "^2.6.0",
-        "oas": "^17.4.1"
+        "oas": "^18.1.0"
       },
       "devDependencies": {
         "@readme/eslint-config": "^8.0.2",
@@ -33,17 +33,6 @@
       },
       "engines": {
         "node": "^12 || ^14 || ^16"
-      }
-    },
-    "node_modules/@apidevtools/json-schema-ref-parser": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.9.tgz",
-      "integrity": "sha512-GBD2Le9w2+lVFoc4vswGI/TjkNIZSVp7+9xPf+X3uidBfWnAeUWmquteSyt0+VCrhNMWj/FTABISQrD3Z/YA+w==",
-      "dependencies": {
-        "@jsdevtools/ono": "^7.1.3",
-        "@types/json-schema": "^7.0.6",
-        "call-me-maybe": "^1.0.1",
-        "js-yaml": "^4.1.0"
       }
     },
     "node_modules/@apidevtools/openapi-schemas": {
@@ -492,9 +481,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.16.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.3.tgz",
-      "integrity": "sha512-WBwekcqacdY2e9AF/Q7WLFUWmdJGJTkbjqTjoMDgXkVZ3ZRUvOPsLb5KdwISoQVsbP+DQzVZW4Zhci0DvpbNTQ==",
+      "version": "7.17.8",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.8.tgz",
+      "integrity": "sha512-dQpEpK0O9o6lj6oPu0gRDbbnk+4LeHlNcBpspf6Olzt3GIX4P1lWF1gS+pHLDFlaJvbR6q7jCfQ08zA4QJBnmA==",
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
       },
@@ -616,9 +605,9 @@
       }
     },
     "node_modules/@humanwhocodes/momoa": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/momoa/-/momoa-2.0.2.tgz",
-      "integrity": "sha512-mkMcsshJ7L17AyntqpyjLiGqhbG62w93B0StW+HSNVJ1WUeVFA2uPssV/GufEfDqN6lRKI1I+uDzBUw83C0VuA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/momoa/-/momoa-2.0.3.tgz",
+      "integrity": "sha512-SytjS6gJk+LXSWFuEm0V9ASdgxlX/BDq6A+6gfh7TaHM90xppBydjcM3SFaziZP4ikKmhUOhPkDi2KktzElnQQ==",
       "engines": {
         "node": ">=10.10.0"
       }
@@ -1784,13 +1773,13 @@
       }
     },
     "node_modules/@readme/better-ajv-errors": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@readme/better-ajv-errors/-/better-ajv-errors-1.4.1.tgz",
-      "integrity": "sha512-MPDca1lZBHuTvx3SntTIW4CPjJy4krgkOpF2TQLgx2pVnk1hqLTM39Kn6z5PWa0mPaLcK4HnPQ9Rdhk0qn1zIA==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@readme/better-ajv-errors/-/better-ajv-errors-1.4.5.tgz",
+      "integrity": "sha512-a3YAAP1bEs9yytoqCy9Kj6VuWJ7WocVxedRcxImdkwTP6NBjtbY/IdBwHakll2DZ1yMOZAAozRebD09Xgfqrsg==",
       "dependencies": {
         "@babel/code-frame": "^7.16.0",
-        "@babel/runtime": "^7.16.0",
-        "@humanwhocodes/momoa": "^2.0.2",
+        "@babel/runtime": "^7.17.8",
+        "@humanwhocodes/momoa": "^2.0.3",
         "chalk": "^4.1.2",
         "json-to-ast": "^2.0.3",
         "jsonpointer": "^5.0.0",
@@ -1901,9 +1890,9 @@
       }
     },
     "node_modules/@readme/json-schema-ref-parser": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@readme/json-schema-ref-parser/-/json-schema-ref-parser-1.0.0.tgz",
-      "integrity": "sha512-M3b8E4l6+MGFyhznQoQ1yoVFkre8vQEkk9doGGp4okHAwYLikwZRKeC/UWp88cGbr8+ZB1a7pMmHu2iteDWmPg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@readme/json-schema-ref-parser/-/json-schema-ref-parser-1.1.0.tgz",
+      "integrity": "sha512-T0DxTMSEfOQHAlpI68LqYCwSFfP3u0w7E6zXWf16YphmAgWSOhLKuvnMSLXAlh27uxwclRekIvQf8AAUoQSDiw==",
       "dependencies": {
         "@jsdevtools/ono": "^7.1.3",
         "@types/json-schema": "^7.0.6",
@@ -1918,40 +1907,41 @@
       "dev": true
     },
     "node_modules/@readme/oas-extensions": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/@readme/oas-extensions/-/oas-extensions-14.0.4.tgz",
-      "integrity": "sha512-mmybpXe+OwHh7+gdY+slFK0R8bD5rWZTlUAM4sXYz5wRG63hWtL46nMSXRmw5BOdyLw23G+1G7tGn4Zl7B+lgg==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/@readme/oas-extensions/-/oas-extensions-14.2.0.tgz",
+      "integrity": "sha512-gE+bQ1zrkNFhtlctKA7gCPnOB3dQ2iUO0BgAeVFMpxyFyotVU1ku4GQH6pnxTUsVq0PZDz1WojsT2VAPe+TkCg==",
       "engines": {
         "node": "^12 || ^14 || ^16"
       },
       "peerDependencies": {
-        "oas": "^17.1.0"
+        "oas": "^17.1.0 || ^18.0.0"
       }
     },
     "node_modules/@readme/oas-to-har": {
-      "version": "14.0.5",
-      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-14.0.5.tgz",
-      "integrity": "sha512-vASZe7v5x5wq9UFlgFpBfjJLK83VjEs2naGKWt7IOIK/F/22Li3Vz+NQh4eCGFjqqo0uAhEm3w0dp6O6d3pGlw==",
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-16.1.0.tgz",
+      "integrity": "sha512-gwyu5w41sigPhijmOxeQFgjfe7ItCLo6wwWuw/MzKfW5ma2GWANauT2c+tSlsZN7zNuPdjAK0wEfOxKSXxQE0g==",
       "dependencies": {
-        "@readme/oas-extensions": "^14.0.4",
-        "oas": "^17.4.1",
-        "parse-data-url": "^4.0.1"
+        "@readme/oas-extensions": "^14.2.0",
+        "oas": "^18.0.6",
+        "parse-data-url": "^4.0.1",
+        "remove-undefined-objects": "^1.1.0"
       },
       "engines": {
         "node": "^12 || ^14 || ^16"
       }
     },
     "node_modules/@readme/openapi-parser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@readme/openapi-parser/-/openapi-parser-2.0.0.tgz",
-      "integrity": "sha512-QzDeBmARj2+PVnJswWQmiEkTjJljNKwP8EBCOjp0+3GmJp6BDEzy6VUEppGYdUJRaVfrLgqdYoiY1aFWlCBMVQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@readme/openapi-parser/-/openapi-parser-2.1.0.tgz",
+      "integrity": "sha512-93HDSz0bzBWvG1RyWC0gfupTlqWJB+k5OvD05LB+37cGi7VSiSDH4mGPLiLP410+kXQLN3X1FwWVIhnW2f4DhQ==",
       "dependencies": {
         "@apidevtools/openapi-schemas": "^2.1.0",
         "@apidevtools/swagger-methods": "^3.0.2",
         "@jsdevtools/ono": "^7.1.3",
-        "@readme/better-ajv-errors": "^1.4.0",
-        "@readme/json-schema-ref-parser": "^1.0.0",
-        "ajv": "^8.6.3",
+        "@readme/better-ajv-errors": "^1.4.5",
+        "@readme/json-schema-ref-parser": "^1.1.0",
+        "ajv": "^8.11.0",
         "ajv-draft-04": "^1.0.0",
         "call-me-maybe": "^1.0.1"
       },
@@ -1963,9 +1953,9 @@
       }
     },
     "node_modules/@readme/openapi-parser/node_modules/ajv": {
-      "version": "8.8.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.2.tgz",
-      "integrity": "sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -2192,9 +2182,9 @@
       }
     },
     "node_modules/@types/json-schema": {
-      "version": "7.0.9",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
-      "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ=="
+      "version": "7.0.11",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
+      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -3253,9 +3243,9 @@
       }
     },
     "node_modules/comment-patterns": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/comment-patterns/-/comment-patterns-0.12.0.tgz",
-      "integrity": "sha512-LhP+aYhloN+w6fh+U/Vwb+zjRvz7igV6V9YDPtSkdIctaUWb2NDasssTu1ujU8Z6/X5oKE3vWjRCKjCPii2FCg==",
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/comment-patterns/-/comment-patterns-0.12.2.tgz",
+      "integrity": "sha512-yA1FeubMSK0MXzapPm1uNdxyGk0mTAn5qrsVS6uQUSDOpUgWVLCqsgZfA/lhRx6TCLr1MvxeRqXOb1peWXWg3Q==",
       "dependencies": {
         "lodash": "^4.17.11"
       }
@@ -3677,19 +3667,18 @@
       }
     },
     "node_modules/es5-ext": {
-      "version": "0.10.53",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
-      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+      "version": "0.10.59",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.59.tgz",
+      "integrity": "sha512-cOgyhW0tIJyQY1Kfw6Kr0viu9ZlUctVchRMZ7R0HiH3dxTSp5zJDLecwxUqPUrGKMsgBI1wd1FL+d9Jxfi4cLw==",
+      "hasInstallScript": true,
       "dependencies": {
-        "es6-iterator": "~2.0.3",
-        "es6-symbol": "~3.1.3",
-        "next-tick": "~1.0.0"
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.3",
+        "next-tick": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
       }
-    },
-    "node_modules/es5-ext/node_modules/next-tick": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
     },
     "node_modules/es6-iterator": {
       "version": "2.0.3",
@@ -4900,9 +4889,9 @@
       }
     },
     "node_modules/ext/node_modules/type": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/type/-/type-2.5.0.tgz",
-      "integrity": "sha512-180WMDQaIMm3+7hGXWf12GtdniDEy7nYcyFMKJn/eZz/6tSLXrUN9V0wKSbMjej0I1WHWbpREDEKHtqPQa9NNw=="
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/type/-/type-2.6.0.tgz",
+      "integrity": "sha512-eiDBDOmkih5pMbo9OqsqPRGMljLodLcwd5XD5JbtNB0o89xZAwynY9EdCDsJU7LtcVCClu9DvM7/0Ep1hYX3EQ=="
     },
     "node_modules/external-editor": {
       "version": "3.1.0",
@@ -5520,9 +5509,9 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/inquirer": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.0.tgz",
-      "integrity": "sha512-0crLweprevJ02tTuA6ThpoAERAGyVILC4sS74uib58Xf/zSr1/ZWtmm7D5CI+bSQEaA04f0K7idaHpQbSWgiVQ==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.2.tgz",
+      "integrity": "sha512-pG7I/si6K/0X7p1qU+rfWnpTE1UIkTONN1wxtzh0d+dHXtT/JG6qBgLxoyHVsQa8cFABxAPh0pD6uUUHiAoaow==",
       "dependencies": {
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.1.1",
@@ -5534,13 +5523,13 @@
         "mute-stream": "0.0.8",
         "ora": "^5.4.1",
         "run-async": "^2.4.0",
-        "rxjs": "^7.2.0",
+        "rxjs": "^7.5.5",
         "string-width": "^4.1.0",
         "strip-ansi": "^6.0.0",
         "through": "^2.3.6"
       },
       "engines": {
-        "node": ">=8.0.0"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/inquirer/node_modules/ansi-styles": {
@@ -9728,12 +9717,12 @@
       "dev": true
     },
     "node_modules/oas": {
-      "version": "17.4.1",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-17.4.1.tgz",
-      "integrity": "sha512-7fUoZ3CVhgHBLYEfaanNB3SY2PDxzYz2VqIGcUeQOpQ3T2j96R1FzWOlLsmP1BIIz0eTij0hzXJ6eT2A3vMdtQ==",
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-18.1.0.tgz",
+      "integrity": "sha512-p1R6NnOFCnorHm6b6Sz+DuxpmYHLUBfsFQ9k9IkJkQagYpWmRNmsHHExNolqTFans1Nue+B8Fzzo+BMQSzDNCA==",
       "dependencies": {
-        "@apidevtools/json-schema-ref-parser": "^9.0.6",
-        "@types/json-schema": "^7.0.9",
+        "@readme/json-schema-ref-parser": "^1.1.0",
+        "@types/json-schema": "^7.0.11",
         "cardinal": "^2.1.1",
         "chalk": "^4.1.2",
         "glob": "^7.1.2",
@@ -9743,10 +9732,10 @@
         "jsonpointer": "^5.0.0",
         "memoizee": "^0.4.14",
         "minimist": "^1.2.0",
-        "oas-normalize": "^5.1.0",
+        "oas-normalize": "^5.2.0",
         "openapi-types": "^10.0.0",
         "path-to-regexp": "^6.2.0",
-        "swagger-inline": "^5.0.2"
+        "swagger-inline": "^5.2.0"
       },
       "bin": {
         "oas": "bin/oas"
@@ -9777,11 +9766,11 @@
       }
     },
     "node_modules/oas-normalize": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-5.1.0.tgz",
-      "integrity": "sha512-lPVcc+yUzQZOKMKm6SXjmXI69Fgx3rPoPwRo1c/iaGdaVaoOSyB3NlweaW0qqdfuIx+gRz6ssTo9rpHvjsmQmA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-5.2.0.tgz",
+      "integrity": "sha512-xgbNgaFtsK388B9Wh1yE03TaivPXwSl3oMZBHa1ix8g2ZAal7ogl1mj4hRISPGPUgfDt57IQ9JQwdsGJufYRnw==",
       "dependencies": {
-        "@readme/openapi-parser": "^2.0.0",
+        "@readme/openapi-parser": "^2.1.0",
         "js-yaml": "^4.1.0",
         "node-fetch": "^2.6.1",
         "swagger2openapi": "^7.0.8"
@@ -9809,9 +9798,9 @@
       }
     },
     "node_modules/oas-resolver/node_modules/yargs": {
-      "version": "17.3.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.1.tgz",
-      "integrity": "sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==",
+      "version": "17.4.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.4.0.tgz",
+      "integrity": "sha512-WJudfrk81yWFSOkZYpAZx4Nt7V4xp7S/uJkX0CnxovMCt1wCE8LNftPpNuF9X/u9gN5nsD7ycYtRcDf2pL3UiA==",
       "dependencies": {
         "cliui": "^7.0.2",
         "escalade": "^3.1.1",
@@ -9826,9 +9815,9 @@
       }
     },
     "node_modules/oas-resolver/node_modules/yargs-parser": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.0.tgz",
-      "integrity": "sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA==",
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
+      "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
       "engines": {
         "node": ">=12"
       }
@@ -10622,6 +10611,14 @@
         "node": "*"
       }
     },
+    "node_modules/remove-undefined-objects": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-undefined-objects/-/remove-undefined-objects-1.1.0.tgz",
+      "integrity": "sha512-lZ8dJTI11nUE3M2l9lXHkXvhAxOquhLn/umJuBqu1Ea+4A10Wh0fymb36ioeze7UgCjYKIlZuSqjVZDtYa+FeQ==",
+      "engines": {
+        "node": "^12 || ^14 || ^16"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -10737,9 +10734,9 @@
       "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q=="
     },
     "node_modules/rxjs": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.1.tgz",
-      "integrity": "sha512-KExVEeZWxMZnZhUZtsJcFwz8IvPvgu4G2Z2QyqjZQzUGr32KDYuSxrEYO4w3tFFNbfLozcrKUTvTPi+E9ywJkQ==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.5.tgz",
+      "integrity": "sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==",
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -11159,9 +11156,9 @@
       }
     },
     "node_modules/swagger-inline": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/swagger-inline/-/swagger-inline-5.0.3.tgz",
-      "integrity": "sha512-AyRme3SOAk3kdAbzt9SvSKnuvGpX7ATXWMeqbR30az5YUS7bY7AtGWyPOMjJgZvokaKzuP3kk/JxWUi03yoHeQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/swagger-inline/-/swagger-inline-5.2.0.tgz",
+      "integrity": "sha512-QxM1D7QNwlCiT71YPW2Lncro44fgrZE1cPC/Lyjt9+ZplNBASw/4HjaxzNinQuOsCSJZtuE9njMVY09YmQd9Ug==",
       "dependencies": {
         "commander": "^6.0.0",
         "globby": "^11.0.1",
@@ -11203,9 +11200,9 @@
       }
     },
     "node_modules/swagger2openapi/node_modules/yargs": {
-      "version": "17.3.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.1.tgz",
-      "integrity": "sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==",
+      "version": "17.4.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.4.0.tgz",
+      "integrity": "sha512-WJudfrk81yWFSOkZYpAZx4Nt7V4xp7S/uJkX0CnxovMCt1wCE8LNftPpNuF9X/u9gN5nsD7ycYtRcDf2pL3UiA==",
       "dependencies": {
         "cliui": "^7.0.2",
         "escalade": "^3.1.1",
@@ -11220,9 +11217,9 @@
       }
     },
     "node_modules/swagger2openapi/node_modules/yargs-parser": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.0.tgz",
-      "integrity": "sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA==",
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
+      "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
       "engines": {
         "node": ">=12"
       }
@@ -11835,17 +11832,6 @@
     }
   },
   "dependencies": {
-    "@apidevtools/json-schema-ref-parser": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.9.tgz",
-      "integrity": "sha512-GBD2Le9w2+lVFoc4vswGI/TjkNIZSVp7+9xPf+X3uidBfWnAeUWmquteSyt0+VCrhNMWj/FTABISQrD3Z/YA+w==",
-      "requires": {
-        "@jsdevtools/ono": "^7.1.3",
-        "@types/json-schema": "^7.0.6",
-        "call-me-maybe": "^1.0.1",
-        "js-yaml": "^4.1.0"
-      }
-    },
     "@apidevtools/openapi-schemas": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
@@ -12206,9 +12192,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.16.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.3.tgz",
-      "integrity": "sha512-WBwekcqacdY2e9AF/Q7WLFUWmdJGJTkbjqTjoMDgXkVZ3ZRUvOPsLb5KdwISoQVsbP+DQzVZW4Zhci0DvpbNTQ==",
+      "version": "7.17.8",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.8.tgz",
+      "integrity": "sha512-dQpEpK0O9o6lj6oPu0gRDbbnk+4LeHlNcBpspf6Olzt3GIX4P1lWF1gS+pHLDFlaJvbR6q7jCfQ08zA4QJBnmA==",
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -12316,9 +12302,9 @@
       }
     },
     "@humanwhocodes/momoa": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/momoa/-/momoa-2.0.2.tgz",
-      "integrity": "sha512-mkMcsshJ7L17AyntqpyjLiGqhbG62w93B0StW+HSNVJ1WUeVFA2uPssV/GufEfDqN6lRKI1I+uDzBUw83C0VuA=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/momoa/-/momoa-2.0.3.tgz",
+      "integrity": "sha512-SytjS6gJk+LXSWFuEm0V9ASdgxlX/BDq6A+6gfh7TaHM90xppBydjcM3SFaziZP4ikKmhUOhPkDi2KktzElnQQ=="
     },
     "@humanwhocodes/object-schema": {
       "version": "1.2.1",
@@ -13221,13 +13207,13 @@
       }
     },
     "@readme/better-ajv-errors": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@readme/better-ajv-errors/-/better-ajv-errors-1.4.1.tgz",
-      "integrity": "sha512-MPDca1lZBHuTvx3SntTIW4CPjJy4krgkOpF2TQLgx2pVnk1hqLTM39Kn6z5PWa0mPaLcK4HnPQ9Rdhk0qn1zIA==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@readme/better-ajv-errors/-/better-ajv-errors-1.4.5.tgz",
+      "integrity": "sha512-a3YAAP1bEs9yytoqCy9Kj6VuWJ7WocVxedRcxImdkwTP6NBjtbY/IdBwHakll2DZ1yMOZAAozRebD09Xgfqrsg==",
       "requires": {
         "@babel/code-frame": "^7.16.0",
-        "@babel/runtime": "^7.16.0",
-        "@humanwhocodes/momoa": "^2.0.2",
+        "@babel/runtime": "^7.17.8",
+        "@humanwhocodes/momoa": "^2.0.3",
         "chalk": "^4.1.2",
         "json-to-ast": "^2.0.3",
         "jsonpointer": "^5.0.0",
@@ -13306,9 +13292,9 @@
       }
     },
     "@readme/json-schema-ref-parser": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@readme/json-schema-ref-parser/-/json-schema-ref-parser-1.0.0.tgz",
-      "integrity": "sha512-M3b8E4l6+MGFyhznQoQ1yoVFkre8vQEkk9doGGp4okHAwYLikwZRKeC/UWp88cGbr8+ZB1a7pMmHu2iteDWmPg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@readme/json-schema-ref-parser/-/json-schema-ref-parser-1.1.0.tgz",
+      "integrity": "sha512-T0DxTMSEfOQHAlpI68LqYCwSFfP3u0w7E6zXWf16YphmAgWSOhLKuvnMSLXAlh27uxwclRekIvQf8AAUoQSDiw==",
       "requires": {
         "@jsdevtools/ono": "^7.1.3",
         "@types/json-schema": "^7.0.6",
@@ -13323,40 +13309,41 @@
       "dev": true
     },
     "@readme/oas-extensions": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/@readme/oas-extensions/-/oas-extensions-14.0.4.tgz",
-      "integrity": "sha512-mmybpXe+OwHh7+gdY+slFK0R8bD5rWZTlUAM4sXYz5wRG63hWtL46nMSXRmw5BOdyLw23G+1G7tGn4Zl7B+lgg==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/@readme/oas-extensions/-/oas-extensions-14.2.0.tgz",
+      "integrity": "sha512-gE+bQ1zrkNFhtlctKA7gCPnOB3dQ2iUO0BgAeVFMpxyFyotVU1ku4GQH6pnxTUsVq0PZDz1WojsT2VAPe+TkCg==",
       "requires": {}
     },
     "@readme/oas-to-har": {
-      "version": "14.0.5",
-      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-14.0.5.tgz",
-      "integrity": "sha512-vASZe7v5x5wq9UFlgFpBfjJLK83VjEs2naGKWt7IOIK/F/22Li3Vz+NQh4eCGFjqqo0uAhEm3w0dp6O6d3pGlw==",
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-16.1.0.tgz",
+      "integrity": "sha512-gwyu5w41sigPhijmOxeQFgjfe7ItCLo6wwWuw/MzKfW5ma2GWANauT2c+tSlsZN7zNuPdjAK0wEfOxKSXxQE0g==",
       "requires": {
-        "@readme/oas-extensions": "^14.0.4",
-        "oas": "^17.4.1",
-        "parse-data-url": "^4.0.1"
+        "@readme/oas-extensions": "^14.2.0",
+        "oas": "^18.0.6",
+        "parse-data-url": "^4.0.1",
+        "remove-undefined-objects": "^1.1.0"
       }
     },
     "@readme/openapi-parser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@readme/openapi-parser/-/openapi-parser-2.0.0.tgz",
-      "integrity": "sha512-QzDeBmARj2+PVnJswWQmiEkTjJljNKwP8EBCOjp0+3GmJp6BDEzy6VUEppGYdUJRaVfrLgqdYoiY1aFWlCBMVQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@readme/openapi-parser/-/openapi-parser-2.1.0.tgz",
+      "integrity": "sha512-93HDSz0bzBWvG1RyWC0gfupTlqWJB+k5OvD05LB+37cGi7VSiSDH4mGPLiLP410+kXQLN3X1FwWVIhnW2f4DhQ==",
       "requires": {
         "@apidevtools/openapi-schemas": "^2.1.0",
         "@apidevtools/swagger-methods": "^3.0.2",
         "@jsdevtools/ono": "^7.1.3",
-        "@readme/better-ajv-errors": "^1.4.0",
-        "@readme/json-schema-ref-parser": "^1.0.0",
-        "ajv": "^8.6.3",
+        "@readme/better-ajv-errors": "^1.4.5",
+        "@readme/json-schema-ref-parser": "^1.1.0",
+        "ajv": "^8.11.0",
         "ajv-draft-04": "^1.0.0",
         "call-me-maybe": "^1.0.1"
       },
       "dependencies": {
         "ajv": {
-          "version": "8.8.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.2.tgz",
-          "integrity": "sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==",
+          "version": "8.11.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+          "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -13549,9 +13536,9 @@
       }
     },
     "@types/json-schema": {
-      "version": "7.0.9",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
-      "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ=="
+      "version": "7.0.11",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
+      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="
     },
     "@types/json5": {
       "version": "0.0.29",
@@ -14316,9 +14303,9 @@
       "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA=="
     },
     "comment-patterns": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/comment-patterns/-/comment-patterns-0.12.0.tgz",
-      "integrity": "sha512-LhP+aYhloN+w6fh+U/Vwb+zjRvz7igV6V9YDPtSkdIctaUWb2NDasssTu1ujU8Z6/X5oKE3vWjRCKjCPii2FCg==",
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/comment-patterns/-/comment-patterns-0.12.2.tgz",
+      "integrity": "sha512-yA1FeubMSK0MXzapPm1uNdxyGk0mTAn5qrsVS6uQUSDOpUgWVLCqsgZfA/lhRx6TCLr1MvxeRqXOb1peWXWg3Q==",
       "requires": {
         "lodash": "^4.17.11"
       }
@@ -14664,20 +14651,13 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.53",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
-      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+      "version": "0.10.59",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.59.tgz",
+      "integrity": "sha512-cOgyhW0tIJyQY1Kfw6Kr0viu9ZlUctVchRMZ7R0HiH3dxTSp5zJDLecwxUqPUrGKMsgBI1wd1FL+d9Jxfi4cLw==",
       "requires": {
-        "es6-iterator": "~2.0.3",
-        "es6-symbol": "~3.1.3",
-        "next-tick": "~1.0.0"
-      },
-      "dependencies": {
-        "next-tick": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-          "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
-        }
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.3",
+        "next-tick": "^1.1.0"
       }
     },
     "es6-iterator": {
@@ -15566,9 +15546,9 @@
       },
       "dependencies": {
         "type": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/type/-/type-2.5.0.tgz",
-          "integrity": "sha512-180WMDQaIMm3+7hGXWf12GtdniDEy7nYcyFMKJn/eZz/6tSLXrUN9V0wKSbMjej0I1WHWbpREDEKHtqPQa9NNw=="
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/type/-/type-2.6.0.tgz",
+          "integrity": "sha512-eiDBDOmkih5pMbo9OqsqPRGMljLodLcwd5XD5JbtNB0o89xZAwynY9EdCDsJU7LtcVCClu9DvM7/0Ep1hYX3EQ=="
         }
       }
     },
@@ -16019,9 +15999,9 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "inquirer": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.0.tgz",
-      "integrity": "sha512-0crLweprevJ02tTuA6ThpoAERAGyVILC4sS74uib58Xf/zSr1/ZWtmm7D5CI+bSQEaA04f0K7idaHpQbSWgiVQ==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.2.tgz",
+      "integrity": "sha512-pG7I/si6K/0X7p1qU+rfWnpTE1UIkTONN1wxtzh0d+dHXtT/JG6qBgLxoyHVsQa8cFABxAPh0pD6uUUHiAoaow==",
       "requires": {
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.1.1",
@@ -16033,7 +16013,7 @@
         "mute-stream": "0.0.8",
         "ora": "^5.4.1",
         "run-async": "^2.4.0",
-        "rxjs": "^7.2.0",
+        "rxjs": "^7.5.5",
         "string-width": "^4.1.0",
         "strip-ansi": "^6.0.0",
         "through": "^2.3.6"
@@ -19238,12 +19218,12 @@
       "dev": true
     },
     "oas": {
-      "version": "17.4.1",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-17.4.1.tgz",
-      "integrity": "sha512-7fUoZ3CVhgHBLYEfaanNB3SY2PDxzYz2VqIGcUeQOpQ3T2j96R1FzWOlLsmP1BIIz0eTij0hzXJ6eT2A3vMdtQ==",
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-18.1.0.tgz",
+      "integrity": "sha512-p1R6NnOFCnorHm6b6Sz+DuxpmYHLUBfsFQ9k9IkJkQagYpWmRNmsHHExNolqTFans1Nue+B8Fzzo+BMQSzDNCA==",
       "requires": {
-        "@apidevtools/json-schema-ref-parser": "^9.0.6",
-        "@types/json-schema": "^7.0.9",
+        "@readme/json-schema-ref-parser": "^1.1.0",
+        "@types/json-schema": "^7.0.11",
         "cardinal": "^2.1.1",
         "chalk": "^4.1.2",
         "glob": "^7.1.2",
@@ -19253,10 +19233,10 @@
         "jsonpointer": "^5.0.0",
         "memoizee": "^0.4.14",
         "minimist": "^1.2.0",
-        "oas-normalize": "^5.1.0",
+        "oas-normalize": "^5.2.0",
         "openapi-types": "^10.0.0",
         "path-to-regexp": "^6.2.0",
-        "swagger-inline": "^5.0.2"
+        "swagger-inline": "^5.2.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -19323,11 +19303,11 @@
       }
     },
     "oas-normalize": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-5.1.0.tgz",
-      "integrity": "sha512-lPVcc+yUzQZOKMKm6SXjmXI69Fgx3rPoPwRo1c/iaGdaVaoOSyB3NlweaW0qqdfuIx+gRz6ssTo9rpHvjsmQmA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-5.2.0.tgz",
+      "integrity": "sha512-xgbNgaFtsK388B9Wh1yE03TaivPXwSl3oMZBHa1ix8g2ZAal7ogl1mj4hRISPGPUgfDt57IQ9JQwdsGJufYRnw==",
       "requires": {
-        "@readme/openapi-parser": "^2.0.0",
+        "@readme/openapi-parser": "^2.1.0",
         "js-yaml": "^4.1.0",
         "node-fetch": "^2.6.1",
         "swagger2openapi": "^7.0.8"
@@ -19346,9 +19326,9 @@
       },
       "dependencies": {
         "yargs": {
-          "version": "17.3.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.1.tgz",
-          "integrity": "sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==",
+          "version": "17.4.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.4.0.tgz",
+          "integrity": "sha512-WJudfrk81yWFSOkZYpAZx4Nt7V4xp7S/uJkX0CnxovMCt1wCE8LNftPpNuF9X/u9gN5nsD7ycYtRcDf2pL3UiA==",
           "requires": {
             "cliui": "^7.0.2",
             "escalade": "^3.1.1",
@@ -19360,9 +19340,9 @@
           }
         },
         "yargs-parser": {
-          "version": "21.0.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.0.tgz",
-          "integrity": "sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA=="
+          "version": "21.0.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
+          "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg=="
         }
       }
     },
@@ -19903,6 +19883,11 @@
       "resolved": "https://registry.npmjs.org/remedial/-/remedial-1.0.8.tgz",
       "integrity": "sha512-/62tYiOe6DzS5BqVsNpH/nkGlX45C/Sp6V+NtiN6JQNS1Viay7cWkazmRkrQrdFj2eshDe96SIQNIoMxqhzBOg=="
     },
+    "remove-undefined-objects": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-undefined-objects/-/remove-undefined-objects-1.1.0.tgz",
+      "integrity": "sha512-lZ8dJTI11nUE3M2l9lXHkXvhAxOquhLn/umJuBqu1Ea+4A10Wh0fymb36ioeze7UgCjYKIlZuSqjVZDtYa+FeQ=="
+    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -19984,9 +19969,9 @@
       "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q=="
     },
     "rxjs": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.1.tgz",
-      "integrity": "sha512-KExVEeZWxMZnZhUZtsJcFwz8IvPvgu4G2Z2QyqjZQzUGr32KDYuSxrEYO4w3tFFNbfLozcrKUTvTPi+E9ywJkQ==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.5.tgz",
+      "integrity": "sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==",
       "requires": {
         "tslib": "^2.1.0"
       },
@@ -20339,9 +20324,9 @@
       }
     },
     "swagger-inline": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/swagger-inline/-/swagger-inline-5.0.3.tgz",
-      "integrity": "sha512-AyRme3SOAk3kdAbzt9SvSKnuvGpX7ATXWMeqbR30az5YUS7bY7AtGWyPOMjJgZvokaKzuP3kk/JxWUi03yoHeQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/swagger-inline/-/swagger-inline-5.2.0.tgz",
+      "integrity": "sha512-QxM1D7QNwlCiT71YPW2Lncro44fgrZE1cPC/Lyjt9+ZplNBASw/4HjaxzNinQuOsCSJZtuE9njMVY09YmQd9Ug==",
       "requires": {
         "commander": "^6.0.0",
         "globby": "^11.0.1",
@@ -20369,9 +20354,9 @@
       },
       "dependencies": {
         "yargs": {
-          "version": "17.3.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.1.tgz",
-          "integrity": "sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==",
+          "version": "17.4.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.4.0.tgz",
+          "integrity": "sha512-WJudfrk81yWFSOkZYpAZx4Nt7V4xp7S/uJkX0CnxovMCt1wCE8LNftPpNuF9X/u9gN5nsD7ycYtRcDf2pL3UiA==",
           "requires": {
             "cliui": "^7.0.2",
             "escalade": "^3.1.1",
@@ -20383,9 +20368,9 @@
           }
         },
         "yargs-parser": {
-          "version": "21.0.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.0.tgz",
-          "integrity": "sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA=="
+          "version": "21.0.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
+          "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg=="
         }
       }
     },

--- a/packages/api/package-lock.json
+++ b/packages/api/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/packages/api/package-lock.json
+++ b/packages/api/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/packages/api/package-lock.json
+++ b/packages/api/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "4.2.1",
+  "version": "4.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/packages/api/package-lock.json
+++ b/packages/api/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/packages/api/package-lock.json
+++ b/packages/api/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/packages/api/package-lock.json
+++ b/packages/api/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "api",
-      "version": "4.2.1",
+      "version": "4.4.0",
       "license": "MIT",
       "dependencies": {
         "@readme/oas-to-har": "^16.1.0",
@@ -3060,14 +3060,20 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001272",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001272.tgz",
-      "integrity": "sha512-DV1j9Oot5dydyH1v28g25KoVm7l8MTxazwuiH3utWiAS6iL/9Nh//TGwqFEeqqN8nnWYQ8HHhUq+o4QPt9kvYw==",
+      "version": "1.0.30001341",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001341.tgz",
+      "integrity": "sha512-2SodVrFFtvGENGCv0ChVJIDQ0KPaS1cg7/qtfMaICgeMolDdo/Z2OD32F0Aq9yl6F4YFwGPBS5AaPqNYiW4PoA==",
       "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        }
+      ]
     },
     "node_modules/cardinal": {
       "version": "2.1.1",
@@ -14164,9 +14170,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001272",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001272.tgz",
-      "integrity": "sha512-DV1j9Oot5dydyH1v28g25KoVm7l8MTxazwuiH3utWiAS6iL/9Nh//TGwqFEeqqN8nnWYQ8HHhUq+o4QPt9kvYw==",
+      "version": "1.0.30001341",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001341.tgz",
+      "integrity": "sha512-2SodVrFFtvGENGCv0ChVJIDQ0KPaS1cg7/qtfMaICgeMolDdo/Z2OD32F0Aq9yl6F4YFwGPBS5AaPqNYiW4PoA==",
       "dev": true
     },
     "cardinal": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "Generate an SDK from an OpenAPI definition",
   "main": "src/index.js",
   "scripts": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "description": "Generate an SDK from an OpenAPI definition",
   "main": "src/index.js",
   "scripts": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -23,8 +23,8 @@
     "node": "^12 || ^14 || ^16"
   },
   "dependencies": {
-    "@readme/oas-to-har": "^14.0.5",
-    "@readme/openapi-parser": "^2.0.0",
+    "@readme/oas-to-har": "^16.1.0",
+    "@readme/openapi-parser": "^2.1.0",
     "datauri": "^4.1.0",
     "fetch-har": "^5.0.5",
     "find-cache-dir": "^3.3.1",
@@ -34,7 +34,7 @@
     "make-dir": "^3.1.0",
     "mimer": "^2.0.2",
     "node-fetch": "^2.6.0",
-    "oas": "^17.4.1"
+    "oas": "^18.1.0"
   },
   "devDependencies": {
     "@readme/eslint-config": "^8.0.2",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "description": "Generate an SDK from an OpenAPI definition",
   "main": "src/index.js",
   "scripts": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -48,7 +48,8 @@
   "prettier": "@readme/eslint-config/prettier",
   "jest": {
     "testPathIgnorePatterns": [
-      "__tests__/__fixtures__/"
+      "__tests__/__fixtures__/",
+      ".api-test/"
     ]
   }
 }

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "description": "Generate an SDK from an OpenAPI definition",
   "main": "src/index.js",
   "scripts": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "4.2.1",
+  "version": "4.3.0",
   "description": "Generate an SDK from an OpenAPI definition",
   "main": "src/index.js",
   "scripts": {

--- a/packages/api/src/index.js
+++ b/packages/api/src/index.js
@@ -13,9 +13,11 @@ global.Headers = fetch.Headers;
 global.FormData = require('form-data');
 
 class Sdk {
-  constructor(uri) {
+  constructor(uri, opts = {}) {
     this.uri = uri;
     this.userAgent = `${pkg.name} (node)/${pkg.version}`;
+
+    this.cacheDir = opts.cacheDir ? opts.cacheDir : false;
   }
 
   static getOperations(spec) {
@@ -30,7 +32,7 @@ class Sdk {
 
   load() {
     let authKeys = [];
-    const cache = new Cache(this.uri);
+    const cache = new Cache(this.uri, this.cacheDir);
     const self = this;
     let config = { parseResponse: true };
     let server = false;
@@ -170,6 +172,6 @@ class Sdk {
   }
 }
 
-module.exports = uri => {
-  return new Sdk(uri).load();
+module.exports = (uri, opts = {}) => {
+  return new Sdk(uri, opts).load();
 };

--- a/packages/api/src/index.js
+++ b/packages/api/src/index.js
@@ -29,7 +29,7 @@ class Sdk {
   }
 
   load() {
-    const authKeys = [];
+    let authKeys = [];
     const cache = new Cache(this.uri);
     const self = this;
     let config = { parseResponse: true };
@@ -150,8 +150,7 @@ class Sdk {
 
     sdk = {
       auth: (...values) => {
-        authKeys.push(values);
-        return new Proxy(sdk, sdkProxy);
+        authKeys = values;
       },
       config: opts => {
         // Downside to having `opts` be merged into the existing `config` is that there isn't a clean way to reset your

--- a/packages/api/src/lib/getSchema.js
+++ b/packages/api/src/lib/getSchema.js
@@ -1,0 +1,34 @@
+const {
+  utils: { findSchemaDefinition },
+} = require('oas');
+
+// Gets the schema of the first media type defined in the `content` of the path operation
+// or returns the ref if there's no Request Body Object.
+//
+// If the ref looks like a `requestBodies` reference, then do a lookup for the actual schema
+// https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#fixed-fields-8
+module.exports = function getSchema(pathOperation, api) {
+  try {
+    if (pathOperation.requestBody.content) {
+      const type = Object.keys(pathOperation.requestBody.content)[0];
+
+      return {
+        type,
+        schema: pathOperation.requestBody.content[type],
+      };
+    }
+
+    if (pathOperation.requestBody && pathOperation.requestBody.$ref.match(/^#\/components\/requestBodies\/.*$/)) {
+      return getSchema({
+        requestBody: findSchemaDefinition(pathOperation.requestBody.$ref, api),
+      });
+    }
+
+    return {
+      type: 'application/json',
+      schema: pathOperation.requestBody,
+    };
+  } catch (e) {} // eslint-disable-line no-empty
+
+  return undefined;
+};

--- a/packages/api/src/lib/parseResponse.js
+++ b/packages/api/src/lib/parseResponse.js
@@ -6,18 +6,16 @@ const {
 
 module.exports = async function getResponseBody(response) {
   const contentType = response.headers.get('Content-Type');
-  const isJson = contentType && (matchesMimeType.json(contentType) || matchesMimeType.wildcard(contentType));
+  const isJSON = contentType && (matchesMimeType.json(contentType) || matchesMimeType.wildcard(contentType));
 
-  // We have to clone it before reading, just incase
-  // we cannot parse it as JSON later, then we can
-  // re-read again as plain text
-  const clonedResponse = response.clone();
-  let responseBody;
+  const responseBody = await response.text();
 
-  try {
-    responseBody = await response[isJson ? 'json' : 'text']();
-  } catch (e) {
-    responseBody = await clonedResponse.text();
+  if (isJSON) {
+    try {
+      return JSON.parse(responseBody);
+    } catch (e) {
+      // If our JSON parsing failed then we can just return plaintext instead.
+    }
   }
 
   return responseBody;

--- a/packages/api/src/lib/prepareAuth.js
+++ b/packages/api/src/lib/prepareAuth.js
@@ -7,8 +7,8 @@
  * @param {Array} authKeys
  * @param {Operation} operation
  */
-module.exports = (authKeys, operation) => {
-  if (authKeys.length === 0) {
+module.exports = (authKey, operation) => {
+  if (authKey.length === 0) {
     return {};
   }
 
@@ -21,31 +21,20 @@ module.exports = (authKeys, operation) => {
     return {};
   }
 
-  authKeys.forEach((authKey, idx) => {
-    const schemes = security[securitySchemes[idx]];
-    if (schemes.length > 1) {
-      throw new Error(
-        `Sorry, this API currently requires multiple forms of authentication which we don't yet support.`
-      );
-    }
+  const securityType = securitySchemes[0];
+  const schemes = security[securityType];
+  if (schemes.length > 1) {
+    throw new Error("Sorry, this API currently requires multiple forms of authentication which we don't yet support.");
+  }
 
-    const scheme = schemes[0];
-    if (scheme.type === 'http') {
-      if (scheme.scheme === 'basic') {
-        prepared[scheme._key] = {
-          user: authKey[0],
-          pass: authKey.length === 2 ? authKey[1] : '',
-        };
-      } else if (scheme.scheme === 'bearer') {
-        if (authKey.length > 1) {
-          throw new Error(
-            'Multiple auth tokens were supplied for the auth on this endpoint, but only a single token is needed.'
-          );
-        }
-
-        prepared[scheme._key] = authKey[0];
-      }
-    } else if (scheme.type === 'oauth2') {
+  const scheme = schemes[0];
+  if (scheme.type === 'http') {
+    if (scheme.scheme === 'basic') {
+      prepared[scheme._key] = {
+        user: authKey[0],
+        pass: authKey.length === 2 ? authKey[1] : '',
+      };
+    } else if (scheme.scheme === 'bearer') {
       if (authKey.length > 1) {
         throw new Error(
           'Multiple auth tokens were supplied for the auth on this endpoint, but only a single token is needed.'
@@ -53,20 +42,28 @@ module.exports = (authKeys, operation) => {
       }
 
       prepared[scheme._key] = authKey[0];
-    } else if (scheme.type === 'apiKey') {
-      if (authKey.length > 1) {
-        throw new Error(
-          'Multiple auth keys were supplied for the auth on this endpoint, but only a single key is needed.'
-        );
-      }
-
-      if (scheme.in === 'query' || scheme.in === 'header') {
-        prepared[scheme._key] = authKey[0];
-      }
-    } else {
-      throw new Error(`Sorry, this API currently supports a scheme, ${scheme.type}, that we don't yet support.`);
     }
-  });
+  } else if (scheme.type === 'oauth2') {
+    if (authKey.length > 1) {
+      throw new Error(
+        'Multiple auth tokens were supplied for the auth on this endpoint, but only a single token is needed.'
+      );
+    }
+
+    prepared[scheme._key] = authKey[0];
+  } else if (scheme.type === 'apiKey') {
+    if (authKey.length > 1) {
+      throw new Error(
+        'Multiple auth keys were supplied for the auth on this endpoint, but only a single key is needed.'
+      );
+    }
+
+    if (scheme.in === 'query' || scheme.in === 'header') {
+      prepared[scheme._key] = authKey[0];
+    }
+  } else {
+    throw new Error(`Sorry, this API currently supports a scheme, ${scheme.type}, that we don't yet support.`);
+  }
 
   return prepared;
 };

--- a/packages/api/src/lib/prepareParams.js
+++ b/packages/api/src/lib/prepareParams.js
@@ -4,9 +4,7 @@ const stream = require('stream');
 const mimer = require('mimer');
 const getStream = require('get-stream');
 const datauri = require('datauri');
-const {
-  utils: { getSchema },
-} = require('oas');
+const getSchema = require('./getSchema');
 
 function digestParameters(parameters) {
   return parameters.reduce((prev, param) => {

--- a/packages/httpsnippet-client-api/package-lock.json
+++ b/packages/httpsnippet-client-api/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "httpsnippet-client-api",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/packages/httpsnippet-client-api/package-lock.json
+++ b/packages/httpsnippet-client-api/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "httpsnippet-client-api",
-      "version": "4.1.3",
+      "version": "4.2.0",
       "license": "MIT",
       "dependencies": {
         "content-type": "^1.0.4",
@@ -25,37 +25,7 @@
       },
       "peerDependencies": {
         "@readme/httpsnippet": "^3.0.0",
-        "oas": "^17.1.0"
-      }
-    },
-    "node_modules/@apidevtools/json-schema-ref-parser": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.9.tgz",
-      "integrity": "sha512-GBD2Le9w2+lVFoc4vswGI/TjkNIZSVp7+9xPf+X3uidBfWnAeUWmquteSyt0+VCrhNMWj/FTABISQrD3Z/YA+w==",
-      "peer": true,
-      "dependencies": {
-        "@jsdevtools/ono": "^7.1.3",
-        "@types/json-schema": "^7.0.6",
-        "call-me-maybe": "^1.0.1",
-        "js-yaml": "^4.1.0"
-      }
-    },
-    "node_modules/@apidevtools/json-schema-ref-parser/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "peer": true
-    },
-    "node_modules/@apidevtools/json-schema-ref-parser/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "peer": true,
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
+        "oas": "^18.1.0"
       }
     },
     "node_modules/@apidevtools/openapi-schemas": {
@@ -533,9 +503,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.16.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.3.tgz",
-      "integrity": "sha512-WBwekcqacdY2e9AF/Q7WLFUWmdJGJTkbjqTjoMDgXkVZ3ZRUvOPsLb5KdwISoQVsbP+DQzVZW4Zhci0DvpbNTQ==",
+      "version": "7.17.8",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.8.tgz",
+      "integrity": "sha512-dQpEpK0O9o6lj6oPu0gRDbbnk+4LeHlNcBpspf6Olzt3GIX4P1lWF1gS+pHLDFlaJvbR6q7jCfQ08zA4QJBnmA==",
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
       },
@@ -676,9 +646,9 @@
       }
     },
     "node_modules/@humanwhocodes/momoa": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/momoa/-/momoa-2.0.2.tgz",
-      "integrity": "sha512-mkMcsshJ7L17AyntqpyjLiGqhbG62w93B0StW+HSNVJ1WUeVFA2uPssV/GufEfDqN6lRKI1I+uDzBUw83C0VuA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/momoa/-/momoa-2.0.3.tgz",
+      "integrity": "sha512-SytjS6gJk+LXSWFuEm0V9ASdgxlX/BDq6A+6gfh7TaHM90xppBydjcM3SFaziZP4ikKmhUOhPkDi2KktzElnQQ==",
       "peer": true,
       "engines": {
         "node": ">=10.10.0"
@@ -1903,14 +1873,14 @@
       }
     },
     "node_modules/@readme/better-ajv-errors": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@readme/better-ajv-errors/-/better-ajv-errors-1.3.0.tgz",
-      "integrity": "sha512-9yDff0hkbJJ/KaT+pVdHi6+2FeHsaImOz/LGqYp/auMBFSzUcP+y2kcte0pHrnePHgPp+Lt5H91RS5unwM++6Q==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@readme/better-ajv-errors/-/better-ajv-errors-1.4.5.tgz",
+      "integrity": "sha512-a3YAAP1bEs9yytoqCy9Kj6VuWJ7WocVxedRcxImdkwTP6NBjtbY/IdBwHakll2DZ1yMOZAAozRebD09Xgfqrsg==",
       "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.16.0",
-        "@babel/runtime": "^7.16.0",
-        "@humanwhocodes/momoa": "^2.0.2",
+        "@babel/runtime": "^7.17.8",
+        "@humanwhocodes/momoa": "^2.0.3",
         "chalk": "^4.1.2",
         "json-to-ast": "^2.0.3",
         "jsonpointer": "^5.0.0",
@@ -2072,9 +2042,9 @@
       }
     },
     "node_modules/@readme/json-schema-ref-parser": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@readme/json-schema-ref-parser/-/json-schema-ref-parser-1.0.0.tgz",
-      "integrity": "sha512-M3b8E4l6+MGFyhznQoQ1yoVFkre8vQEkk9doGGp4okHAwYLikwZRKeC/UWp88cGbr8+ZB1a7pMmHu2iteDWmPg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@readme/json-schema-ref-parser/-/json-schema-ref-parser-1.1.0.tgz",
+      "integrity": "sha512-T0DxTMSEfOQHAlpI68LqYCwSFfP3u0w7E6zXWf16YphmAgWSOhLKuvnMSLXAlh27uxwclRekIvQf8AAUoQSDiw==",
       "peer": true,
       "dependencies": {
         "@jsdevtools/ono": "^7.1.3",
@@ -2108,28 +2078,31 @@
       "dev": true
     },
     "node_modules/@readme/openapi-parser": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@readme/openapi-parser/-/openapi-parser-1.2.1.tgz",
-      "integrity": "sha512-WNOJypM5UTiTXZmQUU416bX2z5enrA3gLd7ZJC/SszMyvQjW/ygOJjonJ3I+X9uRQhxGIDV/zgcKDtx3m0Zfng==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@readme/openapi-parser/-/openapi-parser-2.1.0.tgz",
+      "integrity": "sha512-93HDSz0bzBWvG1RyWC0gfupTlqWJB+k5OvD05LB+37cGi7VSiSDH4mGPLiLP410+kXQLN3X1FwWVIhnW2f4DhQ==",
       "peer": true,
       "dependencies": {
         "@apidevtools/openapi-schemas": "^2.1.0",
         "@apidevtools/swagger-methods": "^3.0.2",
         "@jsdevtools/ono": "^7.1.3",
-        "@readme/better-ajv-errors": "^1.1.0",
-        "@readme/json-schema-ref-parser": "^1.0.0",
-        "ajv": "^8.6.3",
+        "@readme/better-ajv-errors": "^1.4.5",
+        "@readme/json-schema-ref-parser": "^1.1.0",
+        "ajv": "^8.11.0",
         "ajv-draft-04": "^1.0.0",
         "call-me-maybe": "^1.0.1"
+      },
+      "engines": {
+        "node": "^12 || ^14 || ^16"
       },
       "peerDependencies": {
         "openapi-types": ">=7"
       }
     },
     "node_modules/@readme/openapi-parser/node_modules/ajv": {
-      "version": "8.8.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.2.tgz",
-      "integrity": "sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
       "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -2359,9 +2332,9 @@
       }
     },
     "node_modules/@types/json-schema": {
-      "version": "7.0.9",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
-      "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ=="
+      "version": "7.0.11",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
+      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -3417,9 +3390,9 @@
       }
     },
     "node_modules/comment-patterns": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/comment-patterns/-/comment-patterns-0.12.0.tgz",
-      "integrity": "sha512-LhP+aYhloN+w6fh+U/Vwb+zjRvz7igV6V9YDPtSkdIctaUWb2NDasssTu1ujU8Z6/X5oKE3vWjRCKjCPii2FCg==",
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/comment-patterns/-/comment-patterns-0.12.2.tgz",
+      "integrity": "sha512-yA1FeubMSK0MXzapPm1uNdxyGk0mTAn5qrsVS6uQUSDOpUgWVLCqsgZfA/lhRx6TCLr1MvxeRqXOb1peWXWg3Q==",
       "peer": true,
       "dependencies": {
         "lodash": "^4.17.11"
@@ -9820,15 +9793,23 @@
       "peer": true
     },
     "node_modules/node-fetch": {
-      "version": "2.6.6",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
-      "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
       "peer": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
       "engines": {
         "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/node-fetch-h2": {
@@ -9935,13 +9916,13 @@
       "dev": true
     },
     "node_modules/oas": {
-      "version": "17.3.2",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-17.3.2.tgz",
-      "integrity": "sha512-rmu2uGrVeoODjlp9WDTiaWUFszq6ehGXdkAqDeEd2p54FHHdklfVVti+D9D+OyacvT5OtrqjvLda47Zt6WjA1A==",
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-18.1.0.tgz",
+      "integrity": "sha512-p1R6NnOFCnorHm6b6Sz+DuxpmYHLUBfsFQ9k9IkJkQagYpWmRNmsHHExNolqTFans1Nue+B8Fzzo+BMQSzDNCA==",
       "peer": true,
       "dependencies": {
-        "@apidevtools/json-schema-ref-parser": "^9.0.6",
-        "@types/json-schema": "^7.0.9",
+        "@readme/json-schema-ref-parser": "^1.1.0",
+        "@types/json-schema": "^7.0.11",
         "cardinal": "^2.1.1",
         "chalk": "^4.1.2",
         "glob": "^7.1.2",
@@ -9951,10 +9932,10 @@
         "jsonpointer": "^5.0.0",
         "memoizee": "^0.4.14",
         "minimist": "^1.2.0",
-        "oas-normalize": "^5.0.5",
-        "openapi-types": "^9.3.0",
+        "oas-normalize": "^5.2.0",
+        "openapi-types": "^10.0.0",
         "path-to-regexp": "^6.2.0",
-        "swagger-inline": "^5.0.2"
+        "swagger-inline": "^5.2.0"
       },
       "bin": {
         "oas": "bin/oas"
@@ -9987,12 +9968,12 @@
       }
     },
     "node_modules/oas-normalize": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-5.0.5.tgz",
-      "integrity": "sha512-Ob+yK3Xh3fJn15rg7iu9ib+hHoHMwmIR0WBfhzX17eJU+LWEYMtaiYes3080ic4QE4O36FkIwuUMIyDCNv0OuQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-5.2.0.tgz",
+      "integrity": "sha512-xgbNgaFtsK388B9Wh1yE03TaivPXwSl3oMZBHa1ix8g2ZAal7ogl1mj4hRISPGPUgfDt57IQ9JQwdsGJufYRnw==",
       "peer": true,
       "dependencies": {
-        "@readme/openapi-parser": "^1.2.1",
+        "@readme/openapi-parser": "^2.1.0",
         "js-yaml": "^4.1.0",
         "node-fetch": "^2.6.1",
         "swagger2openapi": "^7.0.8"
@@ -10039,9 +10020,9 @@
       }
     },
     "node_modules/oas-resolver/node_modules/yargs": {
-      "version": "17.3.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.0.tgz",
-      "integrity": "sha512-GQl1pWyDoGptFPJx9b9L6kmR33TGusZvXIZUT+BOz9f7X2L94oeAskFYLEg/FkhV06zZPBYLvLZRWeYId29lew==",
+      "version": "17.4.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.4.0.tgz",
+      "integrity": "sha512-WJudfrk81yWFSOkZYpAZx4Nt7V4xp7S/uJkX0CnxovMCt1wCE8LNftPpNuF9X/u9gN5nsD7ycYtRcDf2pL3UiA==",
       "peer": true,
       "dependencies": {
         "cliui": "^7.0.2",
@@ -10057,9 +10038,9 @@
       }
     },
     "node_modules/oas-resolver/node_modules/yargs-parser": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.0.tgz",
-      "integrity": "sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA==",
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
+      "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
       "peer": true,
       "engines": {
         "node": ">=12"
@@ -10283,9 +10264,9 @@
       }
     },
     "node_modules/openapi-types": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-9.3.1.tgz",
-      "integrity": "sha512-/Yvsd2D7miYB4HLJ3hOOS0+vnowQpaT75FsHzr/y5M9P4q9bwa7RcbW2YdH6KZBn8ceLbKGnHxMZ1CHliGHUFw==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-10.0.0.tgz",
+      "integrity": "sha512-Y8xOCT2eiKGYDzMW9R4x5cmfc3vGaaI4EL2pwhDmodWw1HlK18YcZ4uJxc7Rdp7/gGzAygzH9SXr6GKYIXbRcQ==",
       "peer": true
     },
     "node_modules/optionator": {
@@ -10654,16 +10635,16 @@
       }
     },
     "node_modules/promise.any": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/promise.any/-/promise.any-2.0.2.tgz",
-      "integrity": "sha512-Punsyr4isT+hfleeMH6hqHd6RtsB5ZVuRw+pBIQBBlmQqyacoYyutA0zAAuSdZHSeHi64wIzUK6vvZrI963fFA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/promise.any/-/promise.any-2.0.3.tgz",
+      "integrity": "sha512-BTzZue0G5jWLe5YRxn5yEPm8WI+wI/Kp387Y0P70m4S3VPYRBFuQiQ5GEHgFbpWs0RsTk4pGhQKRaFqVoJfsDw==",
       "peer": true,
       "dependencies": {
-        "array.prototype.map": "^1.0.2",
+        "array.prototype.map": "^1.0.4",
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0",
-        "es-aggregate-error": "^1.0.3",
+        "es-abstract": "^1.19.1",
+        "es-aggregate-error": "^1.0.7",
         "get-intrinsic": "^1.1.1",
         "iterate-value": "^1.0.2"
       },
@@ -11534,9 +11515,9 @@
       }
     },
     "node_modules/swagger-inline": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/swagger-inline/-/swagger-inline-5.0.2.tgz",
-      "integrity": "sha512-Vdvuv9TzlnnRzue9ydXQBCe0otxh+rXz6vsLnUXwNqFjGWn/2OATYnyVEHojmKXS1fuMkaunVNsv0a9JT08UBw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/swagger-inline/-/swagger-inline-5.2.0.tgz",
+      "integrity": "sha512-QxM1D7QNwlCiT71YPW2Lncro44fgrZE1cPC/Lyjt9+ZplNBASw/4HjaxzNinQuOsCSJZtuE9njMVY09YmQd9Ug==",
       "peer": true,
       "dependencies": {
         "commander": "^6.0.0",
@@ -11598,9 +11579,9 @@
       }
     },
     "node_modules/swagger2openapi/node_modules/yargs": {
-      "version": "17.3.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.0.tgz",
-      "integrity": "sha512-GQl1pWyDoGptFPJx9b9L6kmR33TGusZvXIZUT+BOz9f7X2L94oeAskFYLEg/FkhV06zZPBYLvLZRWeYId29lew==",
+      "version": "17.4.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.4.0.tgz",
+      "integrity": "sha512-WJudfrk81yWFSOkZYpAZx4Nt7V4xp7S/uJkX0CnxovMCt1wCE8LNftPpNuF9X/u9gN5nsD7ycYtRcDf2pL3UiA==",
       "peer": true,
       "dependencies": {
         "cliui": "^7.0.2",
@@ -11616,9 +11597,9 @@
       }
     },
     "node_modules/swagger2openapi/node_modules/yargs-parser": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.0.tgz",
-      "integrity": "sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA==",
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
+      "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
       "peer": true,
       "engines": {
         "node": ">=12"
@@ -12236,35 +12217,6 @@
     }
   },
   "dependencies": {
-    "@apidevtools/json-schema-ref-parser": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.9.tgz",
-      "integrity": "sha512-GBD2Le9w2+lVFoc4vswGI/TjkNIZSVp7+9xPf+X3uidBfWnAeUWmquteSyt0+VCrhNMWj/FTABISQrD3Z/YA+w==",
-      "peer": true,
-      "requires": {
-        "@jsdevtools/ono": "^7.1.3",
-        "@types/json-schema": "^7.0.6",
-        "call-me-maybe": "^1.0.1",
-        "js-yaml": "^4.1.0"
-      },
-      "dependencies": {
-        "argparse": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-          "peer": true
-        },
-        "js-yaml": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-          "peer": true,
-          "requires": {
-            "argparse": "^2.0.1"
-          }
-        }
-      }
-    },
     "@apidevtools/openapi-schemas": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
@@ -12647,9 +12599,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.16.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.3.tgz",
-      "integrity": "sha512-WBwekcqacdY2e9AF/Q7WLFUWmdJGJTkbjqTjoMDgXkVZ3ZRUvOPsLb5KdwISoQVsbP+DQzVZW4Zhci0DvpbNTQ==",
+      "version": "7.17.8",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.8.tgz",
+      "integrity": "sha512-dQpEpK0O9o6lj6oPu0gRDbbnk+4LeHlNcBpspf6Olzt3GIX4P1lWF1gS+pHLDFlaJvbR6q7jCfQ08zA4QJBnmA==",
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -12773,9 +12725,9 @@
       }
     },
     "@humanwhocodes/momoa": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/momoa/-/momoa-2.0.2.tgz",
-      "integrity": "sha512-mkMcsshJ7L17AyntqpyjLiGqhbG62w93B0StW+HSNVJ1WUeVFA2uPssV/GufEfDqN6lRKI1I+uDzBUw83C0VuA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/momoa/-/momoa-2.0.3.tgz",
+      "integrity": "sha512-SytjS6gJk+LXSWFuEm0V9ASdgxlX/BDq6A+6gfh7TaHM90xppBydjcM3SFaziZP4ikKmhUOhPkDi2KktzElnQQ==",
       "peer": true
     },
     "@humanwhocodes/object-schema": {
@@ -13716,14 +13668,14 @@
       }
     },
     "@readme/better-ajv-errors": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@readme/better-ajv-errors/-/better-ajv-errors-1.3.0.tgz",
-      "integrity": "sha512-9yDff0hkbJJ/KaT+pVdHi6+2FeHsaImOz/LGqYp/auMBFSzUcP+y2kcte0pHrnePHgPp+Lt5H91RS5unwM++6Q==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@readme/better-ajv-errors/-/better-ajv-errors-1.4.5.tgz",
+      "integrity": "sha512-a3YAAP1bEs9yytoqCy9Kj6VuWJ7WocVxedRcxImdkwTP6NBjtbY/IdBwHakll2DZ1yMOZAAozRebD09Xgfqrsg==",
       "peer": true,
       "requires": {
         "@babel/code-frame": "^7.16.0",
-        "@babel/runtime": "^7.16.0",
-        "@humanwhocodes/momoa": "^2.0.2",
+        "@babel/runtime": "^7.17.8",
+        "@humanwhocodes/momoa": "^2.0.3",
         "chalk": "^4.1.2",
         "json-to-ast": "^2.0.3",
         "jsonpointer": "^5.0.0",
@@ -13843,9 +13795,9 @@
       }
     },
     "@readme/json-schema-ref-parser": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@readme/json-schema-ref-parser/-/json-schema-ref-parser-1.0.0.tgz",
-      "integrity": "sha512-M3b8E4l6+MGFyhznQoQ1yoVFkre8vQEkk9doGGp4okHAwYLikwZRKeC/UWp88cGbr8+ZB1a7pMmHu2iteDWmPg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@readme/json-schema-ref-parser/-/json-schema-ref-parser-1.1.0.tgz",
+      "integrity": "sha512-T0DxTMSEfOQHAlpI68LqYCwSFfP3u0w7E6zXWf16YphmAgWSOhLKuvnMSLXAlh27uxwclRekIvQf8AAUoQSDiw==",
       "peer": true,
       "requires": {
         "@jsdevtools/ono": "^7.1.3",
@@ -13878,25 +13830,25 @@
       "dev": true
     },
     "@readme/openapi-parser": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@readme/openapi-parser/-/openapi-parser-1.2.1.tgz",
-      "integrity": "sha512-WNOJypM5UTiTXZmQUU416bX2z5enrA3gLd7ZJC/SszMyvQjW/ygOJjonJ3I+X9uRQhxGIDV/zgcKDtx3m0Zfng==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@readme/openapi-parser/-/openapi-parser-2.1.0.tgz",
+      "integrity": "sha512-93HDSz0bzBWvG1RyWC0gfupTlqWJB+k5OvD05LB+37cGi7VSiSDH4mGPLiLP410+kXQLN3X1FwWVIhnW2f4DhQ==",
       "peer": true,
       "requires": {
         "@apidevtools/openapi-schemas": "^2.1.0",
         "@apidevtools/swagger-methods": "^3.0.2",
         "@jsdevtools/ono": "^7.1.3",
-        "@readme/better-ajv-errors": "^1.1.0",
-        "@readme/json-schema-ref-parser": "^1.0.0",
-        "ajv": "^8.6.3",
+        "@readme/better-ajv-errors": "^1.4.5",
+        "@readme/json-schema-ref-parser": "^1.1.0",
+        "ajv": "^8.11.0",
         "ajv-draft-04": "^1.0.0",
         "call-me-maybe": "^1.0.1"
       },
       "dependencies": {
         "ajv": {
-          "version": "8.8.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.2.tgz",
-          "integrity": "sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==",
+          "version": "8.11.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+          "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
           "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
@@ -14092,9 +14044,9 @@
       }
     },
     "@types/json-schema": {
-      "version": "7.0.9",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
-      "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ=="
+      "version": "7.0.11",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
+      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="
     },
     "@types/json5": {
       "version": "0.0.29",
@@ -14861,9 +14813,9 @@
       "peer": true
     },
     "comment-patterns": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/comment-patterns/-/comment-patterns-0.12.0.tgz",
-      "integrity": "sha512-LhP+aYhloN+w6fh+U/Vwb+zjRvz7igV6V9YDPtSkdIctaUWb2NDasssTu1ujU8Z6/X5oKE3vWjRCKjCPii2FCg==",
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/comment-patterns/-/comment-patterns-0.12.2.tgz",
+      "integrity": "sha512-yA1FeubMSK0MXzapPm1uNdxyGk0mTAn5qrsVS6uQUSDOpUgWVLCqsgZfA/lhRx6TCLr1MvxeRqXOb1peWXWg3Q==",
       "peer": true,
       "requires": {
         "lodash": "^4.17.11"
@@ -19739,9 +19691,9 @@
       "peer": true
     },
     "node-fetch": {
-      "version": "2.6.6",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
-      "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
       "peer": true,
       "requires": {
         "whatwg-url": "^5.0.0"
@@ -19843,13 +19795,13 @@
       "dev": true
     },
     "oas": {
-      "version": "17.3.2",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-17.3.2.tgz",
-      "integrity": "sha512-rmu2uGrVeoODjlp9WDTiaWUFszq6ehGXdkAqDeEd2p54FHHdklfVVti+D9D+OyacvT5OtrqjvLda47Zt6WjA1A==",
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-18.1.0.tgz",
+      "integrity": "sha512-p1R6NnOFCnorHm6b6Sz+DuxpmYHLUBfsFQ9k9IkJkQagYpWmRNmsHHExNolqTFans1Nue+B8Fzzo+BMQSzDNCA==",
       "peer": true,
       "requires": {
-        "@apidevtools/json-schema-ref-parser": "^9.0.6",
-        "@types/json-schema": "^7.0.9",
+        "@readme/json-schema-ref-parser": "^1.1.0",
+        "@types/json-schema": "^7.0.11",
         "cardinal": "^2.1.1",
         "chalk": "^4.1.2",
         "glob": "^7.1.2",
@@ -19859,10 +19811,10 @@
         "jsonpointer": "^5.0.0",
         "memoizee": "^0.4.14",
         "minimist": "^1.2.0",
-        "oas-normalize": "^5.0.5",
-        "openapi-types": "^9.3.0",
+        "oas-normalize": "^5.2.0",
+        "openapi-types": "^10.0.0",
         "path-to-regexp": "^6.2.0",
-        "swagger-inline": "^5.0.2"
+        "swagger-inline": "^5.2.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -19937,12 +19889,12 @@
       }
     },
     "oas-normalize": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-5.0.5.tgz",
-      "integrity": "sha512-Ob+yK3Xh3fJn15rg7iu9ib+hHoHMwmIR0WBfhzX17eJU+LWEYMtaiYes3080ic4QE4O36FkIwuUMIyDCNv0OuQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-5.2.0.tgz",
+      "integrity": "sha512-xgbNgaFtsK388B9Wh1yE03TaivPXwSl3oMZBHa1ix8g2ZAal7ogl1mj4hRISPGPUgfDt57IQ9JQwdsGJufYRnw==",
       "peer": true,
       "requires": {
-        "@readme/openapi-parser": "^1.2.1",
+        "@readme/openapi-parser": "^2.1.0",
         "js-yaml": "^4.1.0",
         "node-fetch": "^2.6.1",
         "swagger2openapi": "^7.0.8"
@@ -19979,9 +19931,9 @@
       },
       "dependencies": {
         "yargs": {
-          "version": "17.3.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.0.tgz",
-          "integrity": "sha512-GQl1pWyDoGptFPJx9b9L6kmR33TGusZvXIZUT+BOz9f7X2L94oeAskFYLEg/FkhV06zZPBYLvLZRWeYId29lew==",
+          "version": "17.4.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.4.0.tgz",
+          "integrity": "sha512-WJudfrk81yWFSOkZYpAZx4Nt7V4xp7S/uJkX0CnxovMCt1wCE8LNftPpNuF9X/u9gN5nsD7ycYtRcDf2pL3UiA==",
           "peer": true,
           "requires": {
             "cliui": "^7.0.2",
@@ -19994,9 +19946,9 @@
           }
         },
         "yargs-parser": {
-          "version": "21.0.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.0.tgz",
-          "integrity": "sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA==",
+          "version": "21.0.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
+          "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
           "peer": true
         }
       }
@@ -20110,9 +20062,9 @@
       }
     },
     "openapi-types": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-9.3.1.tgz",
-      "integrity": "sha512-/Yvsd2D7miYB4HLJ3hOOS0+vnowQpaT75FsHzr/y5M9P4q9bwa7RcbW2YdH6KZBn8ceLbKGnHxMZ1CHliGHUFw==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-10.0.0.tgz",
+      "integrity": "sha512-Y8xOCT2eiKGYDzMW9R4x5cmfc3vGaaI4EL2pwhDmodWw1HlK18YcZ4uJxc7Rdp7/gGzAygzH9SXr6GKYIXbRcQ==",
       "peer": true
     },
     "optionator": {
@@ -20383,16 +20335,16 @@
       "dev": true
     },
     "promise.any": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/promise.any/-/promise.any-2.0.2.tgz",
-      "integrity": "sha512-Punsyr4isT+hfleeMH6hqHd6RtsB5ZVuRw+pBIQBBlmQqyacoYyutA0zAAuSdZHSeHi64wIzUK6vvZrI963fFA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/promise.any/-/promise.any-2.0.3.tgz",
+      "integrity": "sha512-BTzZue0G5jWLe5YRxn5yEPm8WI+wI/Kp387Y0P70m4S3VPYRBFuQiQ5GEHgFbpWs0RsTk4pGhQKRaFqVoJfsDw==",
       "peer": true,
       "requires": {
-        "array.prototype.map": "^1.0.2",
+        "array.prototype.map": "^1.0.4",
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0",
-        "es-aggregate-error": "^1.0.3",
+        "es-abstract": "^1.19.1",
+        "es-aggregate-error": "^1.0.7",
         "get-intrinsic": "^1.1.1",
         "iterate-value": "^1.0.2"
       }
@@ -21086,9 +21038,9 @@
       }
     },
     "swagger-inline": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/swagger-inline/-/swagger-inline-5.0.2.tgz",
-      "integrity": "sha512-Vdvuv9TzlnnRzue9ydXQBCe0otxh+rXz6vsLnUXwNqFjGWn/2OATYnyVEHojmKXS1fuMkaunVNsv0a9JT08UBw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/swagger-inline/-/swagger-inline-5.2.0.tgz",
+      "integrity": "sha512-QxM1D7QNwlCiT71YPW2Lncro44fgrZE1cPC/Lyjt9+ZplNBASw/4HjaxzNinQuOsCSJZtuE9njMVY09YmQd9Ug==",
       "peer": true,
       "requires": {
         "commander": "^6.0.0",
@@ -21135,9 +21087,9 @@
       },
       "dependencies": {
         "yargs": {
-          "version": "17.3.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.0.tgz",
-          "integrity": "sha512-GQl1pWyDoGptFPJx9b9L6kmR33TGusZvXIZUT+BOz9f7X2L94oeAskFYLEg/FkhV06zZPBYLvLZRWeYId29lew==",
+          "version": "17.4.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.4.0.tgz",
+          "integrity": "sha512-WJudfrk81yWFSOkZYpAZx4Nt7V4xp7S/uJkX0CnxovMCt1wCE8LNftPpNuF9X/u9gN5nsD7ycYtRcDf2pL3UiA==",
           "peer": true,
           "requires": {
             "cliui": "^7.0.2",
@@ -21150,9 +21102,9 @@
           }
         },
         "yargs-parser": {
-          "version": "21.0.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.0.tgz",
-          "integrity": "sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA==",
+          "version": "21.0.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
+          "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
           "peer": true
         }
       }

--- a/packages/httpsnippet-client-api/package.json
+++ b/packages/httpsnippet-client-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "httpsnippet-client-api",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "An HTTP Snippet client for generating snippets for the api module.",
   "main": "src/index.js",
   "scripts": {

--- a/packages/httpsnippet-client-api/package.json
+++ b/packages/httpsnippet-client-api/package.json
@@ -29,7 +29,7 @@
   },
   "peerDependencies": {
     "@readme/httpsnippet": "^3.0.0",
-    "oas": "^17.1.0"
+    "oas": "^18.1.0"
   },
   "devDependencies": {
     "@readme/eslint-config": "^8.0.2",


### PR DESCRIPTION
> Don't merge this in, I will tag a v4.5.1 release directly off this branch.

## 🧰 Changes

With the custom cache directory work I did in https://github.com/readmeio/api/compare/v4.4.0...v4.5.0 I realized that I've been storing absolute paths to where specs are stored so if you run `api` locally and then push that cache up to a different machine/environment `api` will throw errors because the spec can't be found in that path.

So I'm removing `path` from the `cache.json` and adding `hash` which points to the file in the specs cache. If `path` still exists in users `cache.json` files we'll still use that for backward compatibility reasons, but `path` will no longer be added to `cache.json` ever.

## 🧬 QA & Testing

See tests.
