### PR TITLE
feat: supporting configurable cache dirs in the dynamic SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ npm install api --save
 All you need to use `api` is to supply it an OpenAPI definition and then use the SDK as you would any other!
 
 ```js
-const sdk = require('api')('https://raw.githubusercontent.com/readmeio/oas/master/packages/examples/3.0/json/petstore.json');
+const sdk = require('api')('https://raw.githubusercontent.com/readmeio/oas-examples/main/3.0/json/petstore.json');
 
 sdk.listPets().then(res => {
   console.log(`My pets name is ${res[0].name}!`);
@@ -163,4 +163,17 @@ By default we parse the response based on the `content-type` header for you. You
 
 ```js
 sdk.config({ parseResponse: false });
+```
+
+#### Where is the cache stored?
+
+By default the cache is configured with the [find-cache-dir](https://npm.im/find-cache-dir) library so the cache will be in `node_modules/.cache/api`. If placing this cache within the `node_modules/` directory is a problem for your environment (maybe you use `npm prune`) you can configure this by supplying an additional argument to the SDK instantiator:
+
+```js
+const sdk = require('api')('https://raw.githubusercontent.com/readmeio/oas-examples/main/3.0/json/petstore.json', {
+  cacheDir: './path/to/my/custom/cache/dir',
+});
+sdk.listPets().then(res => {
+  console.log(`My pets name is ${res[0].name}!`);
+});
 ```

--- a/packages/api/.gitignore
+++ b/packages/api/.gitignore
@@ -1,3 +1,4 @@
+.api/
 .nyc_output/
 dist/
 node_modules/

--- a/packages/api/.npmignore
+++ b/packages/api/.npmignore
@@ -1,3 +1,4 @@
+.api/
 .nyc_output/
 test/
 .eslint*

--- a/packages/api/.prettierignore
+++ b/packages/api/.prettierignore
@@ -1,3 +1,4 @@
+.api/
 .nyc_output/
 dist/
 example.js

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -23,7 +23,7 @@ npm install api --save
 All you need to use `api` is to supply it an OpenAPI definition and then use the SDK as you would any other!
 
 ```js
-const sdk = require('api')('https://raw.githubusercontent.com/readmeio/oas/master/packages/examples/3.0/json/petstore.json');
+const sdk = require('api')('https://raw.githubusercontent.com/readmeio/oas-examples/main/3.0/json/petstore.json');
 
 sdk.listPets().then(res => {
   console.log(`My pets name is ${res[0].name}!`);
@@ -163,4 +163,17 @@ By default we parse the response based on the `content-type` header for you. You
 
 ```js
 sdk.config({ parseResponse: false });
+```
+
+#### Where is the cache stored?
+
+By default the cache is configured with the [find-cache-dir](https://npm.im/find-cache-dir) library so the cache will be in `node_modules/.cache/api`. If placing this cache within the `node_modules/` directory is a problem for your environment (maybe you use `npm prune`) you can configure this by supplying an additional argument to the SDK instantiator:
+
+```js
+const sdk = require('api')('https://raw.githubusercontent.com/readmeio/oas-examples/main/3.0/json/petstore.json', {
+  cacheDir: './path/to/my/custom/cache/dir',
+});
+sdk.listPets().then(res => {
+  console.log(`My pets name is ${res[0].name}!`);
+});
 ```

--- a/packages/api/example.js
+++ b/packages/api/example.js
@@ -1,13 +1,13 @@
-const sdk = require('.')('https://raw.githubusercontent.com/readmeio/oas-examples/main/3.0/json/readme.json');
+// const path = require('path');
+const sdk = require('./src')('https://raw.githubusercontent.com/readmeio/oas-examples/main/3.0/yaml/readme.yaml', {
+  // Uncomment this line to load the SDK with a custom caching directory.
+  // cacheDir: path.join(process.cwd(), '.api'),
+});
 
 sdk
-  .auth('readmeApiToken')
-  .getChangelogs({
-    perPage: 10,
-    page: 1,
-  })
+  .getOpenRoles()
   .then(res => {
-    console.log(`there are ${res.length} changelogs`);
+    console.log(`there are ${res.length} open roles`);
     console.log(res[0]);
   })
   .catch(console.error);

--- a/packages/api/src/fetcher.ts
+++ b/packages/api/src/fetcher.ts
@@ -31,13 +31,16 @@ export default class Fetcher {
 
     return Promise.resolve(this.uri)
       .then(uri => {
+        let url;
         try {
-          const url = new URL(uri);
-
-          return Fetcher.getURL(url.href);
+          url = new URL(uri);
         } catch (err) {
+          // If that try fails for whatever reason than the URI that we have isn't a real URL and
+          // we can safely attempt to look for it on the filesystem.
           return Fetcher.getFile(uri);
         }
+
+        return Fetcher.getURL(url.href);
       })
       .then(res => Fetcher.validate(res))
       .then(res => res as OASDocument);

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -9,18 +9,26 @@ import Cache from './cache';
 
 import { PACKAGE_NAME, PACKAGE_VERSION } from './packageInfo';
 
+interface SDKOptions {
+  cacheDir?: string;
+}
+
 class Sdk {
   uri: string | OASDocument;
 
   userAgent: string;
 
-  constructor(uri: string | OASDocument) {
+  cacheDir: string | false;
+
+  constructor(uri: string | OASDocument, opts: SDKOptions = {}) {
     this.uri = uri;
     this.userAgent = `${PACKAGE_NAME} (node)/${PACKAGE_VERSION}`;
+
+    this.cacheDir = opts.cacheDir ? opts.cacheDir : false;
   }
 
   load() {
-    const cache = new Cache(this.uri);
+    const cache = new Cache(this.uri, this.cacheDir);
     const userAgent = this.userAgent;
 
     const core = new APICore();
@@ -199,6 +207,6 @@ class Sdk {
 // Why `export` vs `export default`? If we leave this as `export` then TS will transpile it into
 // a `module.exports` export so that when folks load this they don't need to load it as
 // `require('api').default`.
-export = (uri: string | OASDocument) => {
-  return new Sdk(uri).load();
+export = (uri: string | OASDocument, opts: SDKOptions = {}) => {
+  return new Sdk(uri, opts).load();
 };

--- a/packages/api/test/cache-custom.test.ts
+++ b/packages/api/test/cache-custom.test.ts
@@ -1,0 +1,53 @@
+import { expect } from 'chai';
+import path from 'path';
+import fs from 'fs/promises';
+import api from '../src';
+import Cache from '../src/cache';
+import fetchMock from 'fetch-mock';
+
+import uspto from '@readme/oas-examples/3.0/json/uspto.json';
+
+describe('cache (custom directory)', function () {
+  let cacheDir;
+  let originalCacheDir;
+
+  beforeEach(async function () {
+    originalCacheDir = Cache.dir;
+
+    cacheDir = path.join(__dirname, '..', '.api-test');
+
+    await fs.mkdir(cacheDir, { recursive: true });
+  });
+
+  afterEach(async function () {
+    await fs.rmdir(cacheDir, { recursive: true });
+
+    Cache.setCacheDir(originalCacheDir);
+  });
+
+  it('should support supplying a custom cache directory', async function () {
+    // Our custom caching directory should be empty.
+    expect(await fs.readdir(cacheDir)).to.have.length(0);
+
+    fetchMock.get('https://example.com/openapi.json', uspto);
+    fetchMock.get('https://developer.uspto.gov/ds-api/', { status: 200 });
+
+    const sdk = api('https://example.com/openapi.json', { cacheDir });
+
+    await sdk.get('/');
+
+    // Our custom caching directory should have our cached spec in it.
+    const files = [...(await fs.readdir(cacheDir)), ...(await fs.readdir(path.join(cacheDir, 'specs')))];
+    expect(files).to.deep.equal(['cache.json', 'specs', 'f2068ebf6ce28b51a8467bf7ac53bbae.json']);
+
+    const cache = await fs.readFile(path.join(cacheDir, 'cache.json'), 'utf8').then(JSON.parse);
+    expect(cache).to.deep.equal({
+      bcace67532514a49e663e471602b7be6: {
+        hash: 'f2068ebf6ce28b51a8467bf7ac53bbae',
+        original: 'https://example.com/openapi.json',
+        title: 'USPTO Data Set API',
+        version: '1.0.0',
+      },
+    });
+  });
+});

--- a/packages/api/test/cache-tmp.test.ts
+++ b/packages/api/test/cache-tmp.test.ts
@@ -11,7 +11,9 @@ describe('cache (temp dir handling)', function () {
   // Since this test is mocking out the `find-cache-dir` module for a single test, it needs to be run
   // separately from the rest of the cache tests, otherwise all of those tests would use this mocked
   // out version.
-  it('should fallback to an os-level temp directory if a cache directory cannot be determined', function () {
+  it('should fallback to an os-level temp directory if a cache directory cannot be determined', async function () {
+    await Cache.reset();
+
     const dir = os.tmpdir();
     // eslint-disable-next-line no-new
     new Cache('http://example.com/readme.json');


### PR DESCRIPTION
## 🧰 Changes

This backports the work I did in https://github.com/readmeio/api/pull/444 and https://github.com/readmeio/api/pull/445 to add support for a configurable cache directory within the dynamic/Proxy-based SDK.

See those two PR's for more details.