### PR TITLE
fix: downgrading json-schema-to-typescript to v10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,18 +29,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@apidevtools/json-schema-ref-parser": {
-      "version": "0.0.0-dev",
-      "resolved": "git+ssh://git@github.com/bcherny/json-schema-ref-parser.git#984282d34a2993e5243aa35100fe32a63699164d",
-      "integrity": "sha512-VN1BtD3BKNgtwIFEKXE+vLkPeC3XB8TmjrAIMiJJ0Q1LhfyTNoaQUKsbqSUnozThV+SMM9s/Y+p+alyzSDCFvg==",
-      "license": "MIT",
-      "dependencies": {
-        "@jsdevtools/ono": "^7.1.3",
-        "@types/json-schema": "^7.0.6",
-        "call-me-maybe": "^1.0.1",
-        "js-yaml": "^4.1.0"
-      }
-    },
     "node_modules/@apidevtools/openapi-schemas": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
@@ -4380,24 +4368,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/glob-promise": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/glob-promise/-/glob-promise-4.2.2.tgz",
-      "integrity": "sha512-xcUzJ8NWN5bktoTIX7eOclO1Npxd/dyVqUJxlLIDasT4C7KZyqlPIwkdJ0Ypiy3p2ZKahTjK4M9uC3sNSfNMzw==",
-      "dependencies": {
-        "@types/glob": "^7.1.3"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://github.com/sponsors/ahmadnassri"
-      },
-      "peerDependencies": {
-        "glob": "^7.1.6"
-      }
-    },
     "node_modules/glob-to-regexp": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
@@ -5321,42 +5291,26 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/json-schema-to-typescript": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/json-schema-to-typescript/-/json-schema-to-typescript-11.0.1.tgz",
-      "integrity": "sha512-iQFEErdr9PWQUN3kLvaFFdgWAfwBeqH3PMzxza4NpSU/8uadwHKKi66Hgu5Rb3NeVSk85xkwTYIeuah+R0ASeA==",
+    "node_modules/json-schema-ref-parser": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-9.0.9.tgz",
+      "integrity": "sha512-qcP2lmGy+JUoQJ4DOQeLaZDqH9qSkeGCK3suKWxJXS82dg728Mn3j97azDMaOUmJAN4uCq91LdPx4K7E8F1a7Q==",
       "dependencies": {
-        "@apidevtools/json-schema-ref-parser": "https://github.com/bcherny/json-schema-ref-parser.git#984282d34a2993e5243aa35100fe32a63699164d",
-        "@types/json-schema": "^7.0.11",
-        "@types/lodash": "^4.14.182",
-        "@types/prettier": "^2.6.1",
-        "cli-color": "^2.0.2",
-        "get-stdin": "^8.0.0",
-        "glob": "^7.1.6",
-        "glob-promise": "^4.2.2",
-        "is-glob": "^4.0.3",
-        "lodash": "^4.17.21",
-        "minimist": "^1.2.6",
-        "mkdirp": "^1.0.4",
-        "mz": "^2.7.0",
-        "prettier": "^2.6.2"
-      },
-      "bin": {
-        "json2ts": "dist/src/cli.js"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/json-schema-to-typescript/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
+        "@apidevtools/json-schema-ref-parser": "9.0.9"
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/json-schema-ref-parser/node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.9.tgz",
+      "integrity": "sha512-GBD2Le9w2+lVFoc4vswGI/TjkNIZSVp7+9xPf+X3uidBfWnAeUWmquteSyt0+VCrhNMWj/FTABISQrD3Z/YA+w==",
+      "dependencies": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.6",
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^4.1.0"
       }
     },
     "node_modules/json-schema-traverse": {
@@ -5369,6 +5323,11 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
     },
     "node_modules/json-to-ast": {
       "version": "2.1.0",
@@ -8837,7 +8796,7 @@
       }
     },
     "packages/api": {
-      "version": "4.2.0",
+      "version": "5.0.0-beta.0",
       "license": "MIT",
       "dependencies": {
         "@readme/oas-to-har": "^17.0.8",
@@ -8854,7 +8813,7 @@
         "get-stream": "^6.0.1",
         "isomorphic-fetch": "^3.0.0",
         "js-yaml": "^4.1.0",
-        "json-schema-to-typescript": "^11.0.1",
+        "json-schema-to-typescript": "^10.1.5",
         "json-schema-traverse": "^1.0.0",
         "lodash.merge": "^4.6.2",
         "make-dir": "^3.1.0",
@@ -8906,13 +8865,66 @@
         "node": "^12.20.0 || >=14"
       }
     },
+    "packages/api/node_modules/glob-promise": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/glob-promise/-/glob-promise-3.4.0.tgz",
+      "integrity": "sha512-q08RJ6O+eJn+dVanerAndJwIcumgbDdYiUT7zFQl3Wm1xD6fBKtah7H8ZJChj4wP+8C+QfeVy8xautR7rdmKEw==",
+      "dependencies": {
+        "@types/glob": "*"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "glob": "*"
+      }
+    },
+    "packages/api/node_modules/json-schema-to-typescript": {
+      "version": "10.1.5",
+      "resolved": "https://registry.npmjs.org/json-schema-to-typescript/-/json-schema-to-typescript-10.1.5.tgz",
+      "integrity": "sha512-X8bNNksfCQo6LhEuqNxmZr4eZpPjXZajmimciuk8eWXzZlif9Brq7WuMGD/SOhBKcRKP2SGVDNZbC28WQqx9Rg==",
+      "dependencies": {
+        "@types/json-schema": "^7.0.6",
+        "@types/lodash": "^4.14.168",
+        "@types/prettier": "^2.1.5",
+        "cli-color": "^2.0.0",
+        "get-stdin": "^8.0.0",
+        "glob": "^7.1.6",
+        "glob-promise": "^3.4.0",
+        "is-glob": "^4.0.1",
+        "json-schema-ref-parser": "^9.0.6",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.20",
+        "minimist": "^1.2.5",
+        "mkdirp": "^1.0.4",
+        "mz": "^2.7.0",
+        "prettier": "^2.2.0"
+      },
+      "bin": {
+        "json2ts": "dist/src/cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "packages/api/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
+    "packages/api/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "packages/httpsnippet-client-api": {
-      "version": "4.2.0",
+      "version": "5.0.0-beta.0",
       "license": "MIT",
       "dependencies": {
         "content-type": "^1.0.4",
@@ -8950,17 +8962,6 @@
       "dev": true,
       "requires": {
         "@jridgewell/trace-mapping": "^0.3.0"
-      }
-    },
-    "@apidevtools/json-schema-ref-parser": {
-      "version": "git+ssh://git@github.com/bcherny/json-schema-ref-parser.git#984282d34a2993e5243aa35100fe32a63699164d",
-      "integrity": "sha512-VN1BtD3BKNgtwIFEKXE+vLkPeC3XB8TmjrAIMiJJ0Q1LhfyTNoaQUKsbqSUnozThV+SMM9s/Y+p+alyzSDCFvg==",
-      "from": "@apidevtools/json-schema-ref-parser@https://github.com/bcherny/json-schema-ref-parser.git#984282d34a2993e5243aa35100fe32a63699164d",
-      "requires": {
-        "@jsdevtools/ono": "^7.1.3",
-        "@types/json-schema": "^7.0.6",
-        "call-me-maybe": "^1.0.1",
-        "js-yaml": "^4.1.0"
       }
     },
     "@apidevtools/openapi-schemas": {
@@ -10324,7 +10325,7 @@
         "get-stream": "^6.0.1",
         "isomorphic-fetch": "^3.0.0",
         "js-yaml": "^4.1.0",
-        "json-schema-to-typescript": "^11.0.1",
+        "json-schema-to-typescript": "^10.1.5",
         "json-schema-traverse": "^1.0.0",
         "lodash.merge": "^4.6.2",
         "make-dir": "^3.1.0",
@@ -10350,10 +10351,45 @@
           "resolved": "https://registry.npmjs.org/commander/-/commander-9.3.0.tgz",
           "integrity": "sha512-hv95iU5uXPbK83mjrJKuZyFM/LBAoCV/XhVGkS5Je6tl7sxr6A0ITMw5WoRV46/UaJ46Nllm3Xt7IaJhXTIkzw=="
         },
+        "glob-promise": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/glob-promise/-/glob-promise-3.4.0.tgz",
+          "integrity": "sha512-q08RJ6O+eJn+dVanerAndJwIcumgbDdYiUT7zFQl3Wm1xD6fBKtah7H8ZJChj4wP+8C+QfeVy8xautR7rdmKEw==",
+          "requires": {
+            "@types/glob": "*"
+          }
+        },
+        "json-schema-to-typescript": {
+          "version": "10.1.5",
+          "resolved": "https://registry.npmjs.org/json-schema-to-typescript/-/json-schema-to-typescript-10.1.5.tgz",
+          "integrity": "sha512-X8bNNksfCQo6LhEuqNxmZr4eZpPjXZajmimciuk8eWXzZlif9Brq7WuMGD/SOhBKcRKP2SGVDNZbC28WQqx9Rg==",
+          "requires": {
+            "@types/json-schema": "^7.0.6",
+            "@types/lodash": "^4.14.168",
+            "@types/prettier": "^2.1.5",
+            "cli-color": "^2.0.0",
+            "get-stdin": "^8.0.0",
+            "glob": "^7.1.6",
+            "glob-promise": "^3.4.0",
+            "is-glob": "^4.0.1",
+            "json-schema-ref-parser": "^9.0.6",
+            "json-stringify-safe": "^5.0.1",
+            "lodash": "^4.17.20",
+            "minimist": "^1.2.5",
+            "mkdirp": "^1.0.4",
+            "mz": "^2.7.0",
+            "prettier": "^2.2.0"
+          }
+        },
         "json-schema-traverse": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
           "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+        },
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
         }
       }
     },
@@ -12291,14 +12327,6 @@
         "is-glob": "^4.0.3"
       }
     },
-    "glob-promise": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/glob-promise/-/glob-promise-4.2.2.tgz",
-      "integrity": "sha512-xcUzJ8NWN5bktoTIX7eOclO1Npxd/dyVqUJxlLIDasT4C7KZyqlPIwkdJ0Ypiy3p2ZKahTjK4M9uC3sNSfNMzw==",
-      "requires": {
-        "@types/glob": "^7.1.3"
-      }
-    },
     "glob-to-regexp": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
@@ -12957,31 +12985,24 @@
         "lodash": "^4.17.20"
       }
     },
-    "json-schema-to-typescript": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/json-schema-to-typescript/-/json-schema-to-typescript-11.0.1.tgz",
-      "integrity": "sha512-iQFEErdr9PWQUN3kLvaFFdgWAfwBeqH3PMzxza4NpSU/8uadwHKKi66Hgu5Rb3NeVSk85xkwTYIeuah+R0ASeA==",
+    "json-schema-ref-parser": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-9.0.9.tgz",
+      "integrity": "sha512-qcP2lmGy+JUoQJ4DOQeLaZDqH9qSkeGCK3suKWxJXS82dg728Mn3j97azDMaOUmJAN4uCq91LdPx4K7E8F1a7Q==",
       "requires": {
-        "@apidevtools/json-schema-ref-parser": "https://github.com/bcherny/json-schema-ref-parser.git#984282d34a2993e5243aa35100fe32a63699164d",
-        "@types/json-schema": "^7.0.11",
-        "@types/lodash": "^4.14.182",
-        "@types/prettier": "^2.6.1",
-        "cli-color": "^2.0.2",
-        "get-stdin": "^8.0.0",
-        "glob": "^7.1.6",
-        "glob-promise": "^4.2.2",
-        "is-glob": "^4.0.3",
-        "lodash": "^4.17.21",
-        "minimist": "^1.2.6",
-        "mkdirp": "^1.0.4",
-        "mz": "^2.7.0",
-        "prettier": "^2.6.2"
+        "@apidevtools/json-schema-ref-parser": "9.0.9"
       },
       "dependencies": {
-        "mkdirp": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+        "@apidevtools/json-schema-ref-parser": {
+          "version": "9.0.9",
+          "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.9.tgz",
+          "integrity": "sha512-GBD2Le9w2+lVFoc4vswGI/TjkNIZSVp7+9xPf+X3uidBfWnAeUWmquteSyt0+VCrhNMWj/FTABISQrD3Z/YA+w==",
+          "requires": {
+            "@jsdevtools/ono": "^7.1.3",
+            "@types/json-schema": "^7.0.6",
+            "call-me-maybe": "^1.0.1",
+            "js-yaml": "^4.1.0"
+          }
         }
       }
     },
@@ -12995,6 +13016,11 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
     },
     "json-to-ast": {
       "version": "2.1.0",

--- a/packages/api/package-lock.json
+++ b/packages/api/package-lock.json
@@ -23,7 +23,7 @@
         "get-stream": "^6.0.1",
         "isomorphic-fetch": "^3.0.0",
         "js-yaml": "^4.1.0",
-        "json-schema-to-typescript": "^11.0.1",
+        "json-schema-to-typescript": "^10.1.5",
         "json-schema-traverse": "^1.0.0",
         "lodash.merge": "^4.6.2",
         "make-dir": "^3.1.0",
@@ -950,12 +950,12 @@
       }
     },
     "node_modules/@ts-morph/common": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.13.0.tgz",
-      "integrity": "sha512-fEJ6j7Cu8yiWjA4UmybOBH9Efgb/64ZTWuvCF4KysGu4xz8ettfyaqFt8WZ1btCxXsGZJjZ2/3svOF6rL+UFdQ==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.16.0.tgz",
+      "integrity": "sha512-SgJpzkTgZKLKqQniCjLaE3c2L2sdL7UShvmTmPBejAKd2OKV/yfMpQ2IWpAuA+VY5wy7PkSUaEObIqEK6afFuw==",
       "dependencies": {
         "fast-glob": "^3.2.11",
-        "minimatch": "^5.0.1",
+        "minimatch": "^5.1.0",
         "mkdirp": "^1.0.4",
         "path-browserify": "^1.0.1"
       }
@@ -969,9 +969,9 @@
       }
     },
     "node_modules/@ts-morph/common/node_modules/minimatch": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
-      "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+      "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -1130,9 +1130,9 @@
       }
     },
     "node_modules/@types/validate-npm-package-name": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/validate-npm-package-name/-/validate-npm-package-name-3.0.3.tgz",
-      "integrity": "sha512-dLhCHEIjf9++/vHaHCo/ngJzGqGGbPh/f7HKwznEk3WFL64t/VKuRiVpyQH4afX93YkCV94I9M0Cx+DBLk1Dsg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/validate-npm-package-name/-/validate-npm-package-name-4.0.0.tgz",
+      "integrity": "sha512-RpO62vB2lkjEkyLbwTheA2+uwYmtVMWTr/kWRI++UAgVdZqNqdAuIQl/SxBCGeMKfdjWaXPbyhZbiCc4PAj+KA==",
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -7121,11 +7121,11 @@
       }
     },
     "node_modules/ts-morph": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-14.0.0.tgz",
-      "integrity": "sha512-tO8YQ1dP41fw8GVmeQAdNsD8roZi1JMqB7YwZrqU856DvmG5/710e41q2XauzTYrygH9XmMryaFeLo+kdCziyA==",
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-15.1.0.tgz",
+      "integrity": "sha512-RBsGE2sDzUXFTnv8Ba22QfeuKbgvAGJFuTN7HfmIRUkgT/NaVLfDM/8OFm2NlFkGlWEXdpW5OaFIp1jvqdDuOg==",
       "dependencies": {
-        "@ts-morph/common": "~0.13.0",
+        "@ts-morph/common": "~0.16.0",
         "code-block-writer": "^11.0.0"
       }
     },
@@ -8218,12 +8218,12 @@
       }
     },
     "@ts-morph/common": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.13.0.tgz",
-      "integrity": "sha512-fEJ6j7Cu8yiWjA4UmybOBH9Efgb/64ZTWuvCF4KysGu4xz8ettfyaqFt8WZ1btCxXsGZJjZ2/3svOF6rL+UFdQ==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.16.0.tgz",
+      "integrity": "sha512-SgJpzkTgZKLKqQniCjLaE3c2L2sdL7UShvmTmPBejAKd2OKV/yfMpQ2IWpAuA+VY5wy7PkSUaEObIqEK6afFuw==",
       "requires": {
         "fast-glob": "^3.2.11",
-        "minimatch": "^5.0.1",
+        "minimatch": "^5.1.0",
         "mkdirp": "^1.0.4",
         "path-browserify": "^1.0.1"
       },
@@ -8237,9 +8237,9 @@
           }
         },
         "minimatch": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
-          "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+          "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
           "requires": {
             "brace-expansion": "^2.0.1"
           }
@@ -8391,9 +8391,9 @@
       }
     },
     "@types/validate-npm-package-name": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/validate-npm-package-name/-/validate-npm-package-name-3.0.3.tgz",
-      "integrity": "sha512-dLhCHEIjf9++/vHaHCo/ngJzGqGGbPh/f7HKwznEk3WFL64t/VKuRiVpyQH4afX93YkCV94I9M0Cx+DBLk1Dsg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/validate-npm-package-name/-/validate-npm-package-name-4.0.0.tgz",
+      "integrity": "sha512-RpO62vB2lkjEkyLbwTheA2+uwYmtVMWTr/kWRI++UAgVdZqNqdAuIQl/SxBCGeMKfdjWaXPbyhZbiCc4PAj+KA==",
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
@@ -12830,11 +12830,11 @@
       }
     },
     "ts-morph": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-14.0.0.tgz",
-      "integrity": "sha512-tO8YQ1dP41fw8GVmeQAdNsD8roZi1JMqB7YwZrqU856DvmG5/710e41q2XauzTYrygH9XmMryaFeLo+kdCziyA==",
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-15.1.0.tgz",
+      "integrity": "sha512-RBsGE2sDzUXFTnv8Ba22QfeuKbgvAGJFuTN7HfmIRUkgT/NaVLfDM/8OFm2NlFkGlWEXdpW5OaFIp1jvqdDuOg==",
       "requires": {
-        "@ts-morph/common": "~0.13.0",
+        "@ts-morph/common": "~0.16.0",
         "code-block-writer": "^11.0.0"
       }
     },

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -47,7 +47,7 @@
     "get-stream": "^6.0.1",
     "isomorphic-fetch": "^3.0.0",
     "js-yaml": "^4.1.0",
-    "json-schema-to-typescript": "^11.0.1",
+    "json-schema-to-typescript": "^10.1.5",
     "json-schema-traverse": "^1.0.0",
     "lodash.merge": "^4.6.2",
     "make-dir": "^3.1.0",

--- a/packages/api/test/cli/codegen/languages/typescript.test.ts
+++ b/packages/api/test/cli/codegen/languages/typescript.test.ts
@@ -47,7 +47,7 @@ describe('typescript', function () {
       const ts = new TSGenerator(oas, './petstore.json', 'petstore', { compilerTarget: 'cjs' });
       await ts.installer(storage, { logger, dryRun: true });
 
-      expect(logger).to.be.calledWith(`npm install --save --dry-run api oas`);
+      expect(logger).to.be.calledWith(`npm install --save --dry-run api@beta oas`);
       expect(logger).to.be.calledWith(`npm install --save --dry-run ${Storage.dir}/apis/petstore`);
     });
   });


### PR DESCRIPTION
## 🧰 Changes

The fork of `@apidevtools/json-schema-ref-parser` that `json-schema-to-typescript` switched over to in v11 is causing problems for us in Heroku installs so I'm downgrading it to v10 prior to when the fork was introduced in the hopes that this fixes things.

Thankfully the v11 upgrade didn't offer us much we can't live without for now but I'll keep an eye on that project for when the fork reference is removed from the package.