### PR TITLE
feat: improved typescript method accessor `path` type generation

### DIFF
--- a/packages/api/src/cli/codegen/languages/typescript.ts
+++ b/packages/api/src/cli/codegen/languages/typescript.ts
@@ -373,7 +373,7 @@ sdk.server('https://eu.api.example.com/v14');`)
     const parameters: OptionalKind<ParameterDeclarationStructure>[] = [{ name: 'path', type: 'string' }];
     const docblock: OptionalKind<JSDocStructure> = {
       description: writer => {
-        writer.writeLine(`Access any ${method} endpoint on your API.`);
+        writer.writeLine(`Access any ${method.toUpperCase()} endpoint on your API.`);
         return writer;
       },
       tags: [{ tagName: 'param', text: 'path API path to make a request against.' }],
@@ -589,7 +589,7 @@ sdk.server('https://eu.api.example.com/v14');`)
         this.methodGenerics.get(operation.method).addOverload({
           typeParameters,
           parameters: [
-            { name: 'path', type: 'string' },
+            { name: 'path', type: `'${operation.path}'` },
             { ...parameters.body, hasQuestionToken: false },
             { ...parameters.metadata, hasQuestionToken: false },
           ],
@@ -600,14 +600,14 @@ sdk.server('https://eu.api.example.com/v14');`)
         // Create an overload that just has a single `metadata` parameter.
         this.methodGenerics.get(operation.method).addOverload({
           typeParameters,
-          parameters: [{ name: 'path', type: 'string' }, parameters.metadata],
+          parameters: [{ name: 'path', type: `'${operation.path}'` }, parameters.metadata],
           returnType,
           docs: docblock ? [docblock] : null,
         });
       } else {
         this.methodGenerics.get(operation.method).addOverload({
           typeParameters: responseTypes ? null : ['T = unknown'],
-          parameters: [{ name: 'path', type: 'string' }, ...Object.values(parameters)],
+          parameters: [{ name: 'path', type: `'${operation.path}'` }, ...Object.values(parameters)],
           returnType,
           docs: docblock ? [docblock] : null,
         });

--- a/packages/api/test/__fixtures__/definitions/operationid-quirks.json
+++ b/packages/api/test/__fixtures__/definitions/operationid-quirks.json
@@ -13,7 +13,7 @@
     "/quirky-operationId": {
       "get": {
         "description": "This mess of a string is intentionally nasty so we can be sure that we're not including anything that wouldn't look right as an operationID for a potential method accessor in `api`.",
-        "operationId": "find/?*!@#$%^&*()-=_.,<>+[]{}\\|pets-by_status"
+        "operationId": "quirky/?*!@#$%^&*()-=_.,<>+[]{}\\|operation-id_string"
       }
     },
     "/no-operation-id": {

--- a/packages/api/test/__fixtures__/sdk/operationid-quirks/index.d.ts
+++ b/packages/api/test/__fixtures__/sdk/operationid-quirks/index.d.ts
@@ -58,12 +58,12 @@ export default class SDK {
    * This mess of a string is intentionally nasty so we can be sure that we're not including anything that wouldn't look right as an operationID for a potential method accessor in `api`.
    *
    */
-  get<T = unknown>(path: string): Promise<T>;
+  get<T = unknown>(path: '/quirky-operationId'): Promise<T>;
   /**
    * This mess of a string is intentionally nasty so we can be sure that we're not including anything that wouldn't look right as an operationID for a potential method accessor in `api`.
    *
    */
-  findPetsByStatus<T = unknown>(): Promise<T>;
+  quirkyOperationIdString<T = unknown>(): Promise<T>;
 }
 interface ConfigOptions {
   /**

--- a/packages/api/test/__fixtures__/sdk/operationid-quirks/index.ts
+++ b/packages/api/test/__fixtures__/sdk/operationid-quirks/index.ts
@@ -75,9 +75,9 @@ export default class SDK {
    * This mess of a string is intentionally nasty so we can be sure that we're not including anything that wouldn't look right as an operationID for a potential method accessor in `api`.
    *
    */
-  get<T = unknown>(path: string): Promise<T>;
+  get<T = unknown>(path: '/quirky-operationId'): Promise<T>;
   /**
-   * Access any get endpoint on your API.
+   * Access any GET endpoint on your API.
    *
    * @param path API path to make a request against.
    * @param metadata Object containing all path, query, header, and cookie parameters to supply.
@@ -90,7 +90,7 @@ export default class SDK {
    * This mess of a string is intentionally nasty so we can be sure that we're not including anything that wouldn't look right as an operationID for a potential method accessor in `api`.
    *
    */
-  findPetsByStatus<T = unknown>(): Promise<T> {
+  quirkyOperationIdString<T = unknown>(): Promise<T> {
     return this.core.fetch('/quirky-operationId', 'get');
   }
 }

--- a/packages/api/test/__fixtures__/sdk/optional-payload/index.d.ts
+++ b/packages/api/test/__fixtures__/sdk/optional-payload/index.d.ts
@@ -59,7 +59,7 @@ export default class SDK {
    *
    */
   post<T = unknown>(
-    path: string,
+    path: '/pet/{petId}',
     body: UpdatePetWithFormFormDataParam,
     metadata: UpdatePetWithFormMetadataParam
   ): Promise<T>;
@@ -67,7 +67,7 @@ export default class SDK {
    * Updates a pet in the store with form data
    *
    */
-  post<T = unknown>(path: string, metadata: UpdatePetWithFormMetadataParam): Promise<T>;
+  post<T = unknown>(path: '/pet/{petId}', metadata: UpdatePetWithFormMetadataParam): Promise<T>;
   /**
    * Updates a pet in the store with form data
    *

--- a/packages/api/test/__fixtures__/sdk/optional-payload/index.ts
+++ b/packages/api/test/__fixtures__/sdk/optional-payload/index.ts
@@ -76,7 +76,7 @@ export default class SDK {
    *
    */
   post<T = unknown>(
-    path: string,
+    path: '/pet/{petId}',
     body: UpdatePetWithFormFormDataParam,
     metadata: UpdatePetWithFormMetadataParam
   ): Promise<T>;
@@ -84,9 +84,9 @@ export default class SDK {
    * Updates a pet in the store with form data
    *
    */
-  post<T = unknown>(path: string, metadata: UpdatePetWithFormMetadataParam): Promise<T>;
+  post<T = unknown>(path: '/pet/{petId}', metadata: UpdatePetWithFormMetadataParam): Promise<T>;
   /**
-   * Access any post endpoint on your API.
+   * Access any POST endpoint on your API.
    *
    * @param path API path to make a request against.
    * @param body Request body payload data.

--- a/packages/api/test/__fixtures__/sdk/petstore/index.d.ts
+++ b/packages/api/test/__fixtures__/sdk/petstore/index.d.ts
@@ -58,13 +58,13 @@ export default class SDK {
    * Add a new pet to the store
    *
    */
-  post<T = unknown>(path: string, body: Pet): Promise<T>;
+  post<T = unknown>(path: '/pet', body: Pet): Promise<T>;
   /**
    * Updates a pet in the store with form data
    *
    */
   post<T = unknown>(
-    path: string,
+    path: '/pet/{petId}',
     body: UpdatePetWithFormFormDataParam,
     metadata: UpdatePetWithFormMetadataParam
   ): Promise<T>;
@@ -72,111 +72,115 @@ export default class SDK {
    * Updates a pet in the store with form data
    *
    */
-  post<T = unknown>(path: string, metadata: UpdatePetWithFormMetadataParam): Promise<T>;
+  post<T = unknown>(path: '/pet/{petId}', metadata: UpdatePetWithFormMetadataParam): Promise<T>;
   /**
    * Uploads an image
    *
    */
-  post(path: string, body: UploadFileBodyParam, metadata: UploadFileMetadataParam): Promise<ApiResponse>;
+  post(
+    path: '/pet/{petId}/uploadImage',
+    body: UploadFileBodyParam,
+    metadata: UploadFileMetadataParam
+  ): Promise<ApiResponse>;
   /**
    * Uploads an image
    *
    */
-  post(path: string, metadata: UploadFileMetadataParam): Promise<ApiResponse>;
+  post(path: '/pet/{petId}/uploadImage', metadata: UploadFileMetadataParam): Promise<ApiResponse>;
   /**
    * Place an order for a pet
    *
    */
-  post(path: string, body: Order): Promise<Order>;
+  post(path: '/store/order', body: Order): Promise<Order>;
   /**
    * This can only be done by the logged in user.
    *
    * @summary Create user
    */
-  post<T = unknown>(path: string, body: User): Promise<T>;
+  post<T = unknown>(path: '/user', body: User): Promise<T>;
   /**
    * Creates list of users with given input array
    *
    */
-  post<T = unknown>(path: string, body: CreateUsersWithArrayInputBodyParam): Promise<T>;
+  post<T = unknown>(path: '/user/createWithArray', body: CreateUsersWithArrayInputBodyParam): Promise<T>;
   /**
    * Creates list of users with given input array
    *
    */
-  post<T = unknown>(path: string, body: CreateUsersWithListInputBodyParam): Promise<T>;
+  post<T = unknown>(path: '/user/createWithList', body: CreateUsersWithListInputBodyParam): Promise<T>;
   /**
    * Update an existing pet
    *
    */
-  put<T = unknown>(path: string, body: Pet): Promise<T>;
+  put<T = unknown>(path: '/pet', body: Pet): Promise<T>;
   /**
    * This can only be done by the logged in user.
    *
    * @summary Updated user
    */
-  put<T = unknown>(path: string, body: User, metadata: UpdateUserMetadataParam): Promise<T>;
+  put<T = unknown>(path: '/user/{username}', body: User, metadata: UpdateUserMetadataParam): Promise<T>;
   /**
    * Multiple status values can be provided with comma separated strings
    *
    * @summary Finds Pets by status
    */
-  get(path: string, metadata: FindPetsByStatusMetadataParam): Promise<FindPetsByStatus_Response_200>;
+  get(path: '/pet/findByStatus', metadata: FindPetsByStatusMetadataParam): Promise<FindPetsByStatus_Response_200>;
   /**
    * Muliple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
    *
    * @summary Finds Pets by tags
    */
-  get(path: string, metadata: FindPetsByTagsMetadataParam): Promise<FindPetsByTags_Response_200>;
+  get(path: '/pet/findByTags', metadata: FindPetsByTagsMetadataParam): Promise<FindPetsByTags_Response_200>;
   /**
    * Returns a single pet
    *
    * @summary Find pet by ID
    */
-  get(path: string, metadata: GetPetByIdMetadataParam): Promise<Pet>;
+  get(path: '/pet/{petId}', metadata: GetPetByIdMetadataParam): Promise<Pet>;
   /**
    * Returns a map of status codes to quantities
    *
    * @summary Returns pet inventories by status
    */
-  get(path: string): Promise<GetInventory_Response_200>;
+  get(path: '/store/inventory'): Promise<GetInventory_Response_200>;
   /**
    * For valid response try integer IDs with value >= 1 and <= 10. Other values will generated exceptions
    *
    * @summary Find purchase order by ID
    */
-  get(path: string, metadata: GetOrderByIdMetadataParam): Promise<Order>;
+  get(path: '/store/order/{orderId}', metadata: GetOrderByIdMetadataParam): Promise<Order>;
   /**
    * Logs user into the system
    *
    */
-  get(path: string, metadata: LoginUserMetadataParam): Promise<LoginUser_Response_200>;
+  get(path: '/user/login', metadata: LoginUserMetadataParam): Promise<LoginUser_Response_200>;
   /**
    * Logs out current logged in user session
    *
    */
-  get<T = unknown>(path: string): Promise<T>;
+  get<T = unknown>(path: '/user/logout'): Promise<T>;
   /**
    * Get user by user name
    *
    */
-  get(path: string, metadata: GetUserByNameMetadataParam): Promise<User>;
+  get(path: '/user/{username}', metadata: GetUserByNameMetadataParam): Promise<User>;
   /**
    * Deletes a pet
    *
    */
-  delete<T = unknown>(path: string, metadata: DeletePetMetadataParam): Promise<T>;
+  delete<T = unknown>(path: '/pet/{petId}', metadata: DeletePetMetadataParam): Promise<T>;
   /**
    * For valid response try integer IDs with positive integer value. Negative or non-integer values will generate API errors
    *
    * @summary Delete purchase order by ID
    */
-  delete<T = unknown>(path: string, metadata: DeleteOrderMetadataParam): Promise<T>;
+  delete<T = unknown>(path: '/store/order/{orderId}', metadata: DeleteOrderMetadataParam): Promise<T>;
   /**
    * This can only be done by the logged in user.
    *
    * @summary Delete user
    */
-  delete<T = unknown>(path: string, metadata: DeleteUserMetadataParam): Promise<T>;
+  delete<T = unknown>(path: '/user/{username}', metadata: DeleteUserMetadataParam): Promise<T>;
   /**
    * Add a new pet to the store
    *

--- a/packages/api/test/__fixtures__/sdk/petstore/index.ts
+++ b/packages/api/test/__fixtures__/sdk/petstore/index.ts
@@ -75,13 +75,13 @@ export default class SDK {
    * Add a new pet to the store
    *
    */
-  post<T = unknown>(path: string, body: Pet): Promise<T>;
+  post<T = unknown>(path: '/pet', body: Pet): Promise<T>;
   /**
    * Updates a pet in the store with form data
    *
    */
   post<T = unknown>(
-    path: string,
+    path: '/pet/{petId}',
     body: UpdatePetWithFormFormDataParam,
     metadata: UpdatePetWithFormMetadataParam
   ): Promise<T>;
@@ -89,40 +89,44 @@ export default class SDK {
    * Updates a pet in the store with form data
    *
    */
-  post<T = unknown>(path: string, metadata: UpdatePetWithFormMetadataParam): Promise<T>;
+  post<T = unknown>(path: '/pet/{petId}', metadata: UpdatePetWithFormMetadataParam): Promise<T>;
   /**
    * Uploads an image
    *
    */
-  post(path: string, body: UploadFileBodyParam, metadata: UploadFileMetadataParam): Promise<ApiResponse>;
+  post(
+    path: '/pet/{petId}/uploadImage',
+    body: UploadFileBodyParam,
+    metadata: UploadFileMetadataParam
+  ): Promise<ApiResponse>;
   /**
    * Uploads an image
    *
    */
-  post(path: string, metadata: UploadFileMetadataParam): Promise<ApiResponse>;
+  post(path: '/pet/{petId}/uploadImage', metadata: UploadFileMetadataParam): Promise<ApiResponse>;
   /**
    * Place an order for a pet
    *
    */
-  post(path: string, body: Order): Promise<Order>;
+  post(path: '/store/order', body: Order): Promise<Order>;
   /**
    * This can only be done by the logged in user.
    *
    * @summary Create user
    */
-  post<T = unknown>(path: string, body: User): Promise<T>;
+  post<T = unknown>(path: '/user', body: User): Promise<T>;
   /**
    * Creates list of users with given input array
    *
    */
-  post<T = unknown>(path: string, body: CreateUsersWithArrayInputBodyParam): Promise<T>;
+  post<T = unknown>(path: '/user/createWithArray', body: CreateUsersWithArrayInputBodyParam): Promise<T>;
   /**
    * Creates list of users with given input array
    *
    */
-  post<T = unknown>(path: string, body: CreateUsersWithListInputBodyParam): Promise<T>;
+  post<T = unknown>(path: '/user/createWithList', body: CreateUsersWithListInputBodyParam): Promise<T>;
   /**
-   * Access any post endpoint on your API.
+   * Access any POST endpoint on your API.
    *
    * @param path API path to make a request against.
    * @param body Request body payload data.
@@ -136,15 +140,15 @@ export default class SDK {
    * Update an existing pet
    *
    */
-  put<T = unknown>(path: string, body: Pet): Promise<T>;
+  put<T = unknown>(path: '/pet', body: Pet): Promise<T>;
   /**
    * This can only be done by the logged in user.
    *
    * @summary Updated user
    */
-  put<T = unknown>(path: string, body: User, metadata: UpdateUserMetadataParam): Promise<T>;
+  put<T = unknown>(path: '/user/{username}', body: User, metadata: UpdateUserMetadataParam): Promise<T>;
   /**
-   * Access any put endpoint on your API.
+   * Access any PUT endpoint on your API.
    *
    * @param path API path to make a request against.
    * @param body Request body payload data.
@@ -159,48 +163,48 @@ export default class SDK {
    *
    * @summary Finds Pets by status
    */
-  get(path: string, metadata: FindPetsByStatusMetadataParam): Promise<FindPetsByStatus_Response_200>;
+  get(path: '/pet/findByStatus', metadata: FindPetsByStatusMetadataParam): Promise<FindPetsByStatus_Response_200>;
   /**
    * Muliple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
    *
    * @summary Finds Pets by tags
    */
-  get(path: string, metadata: FindPetsByTagsMetadataParam): Promise<FindPetsByTags_Response_200>;
+  get(path: '/pet/findByTags', metadata: FindPetsByTagsMetadataParam): Promise<FindPetsByTags_Response_200>;
   /**
    * Returns a single pet
    *
    * @summary Find pet by ID
    */
-  get(path: string, metadata: GetPetByIdMetadataParam): Promise<Pet>;
+  get(path: '/pet/{petId}', metadata: GetPetByIdMetadataParam): Promise<Pet>;
   /**
    * Returns a map of status codes to quantities
    *
    * @summary Returns pet inventories by status
    */
-  get(path: string): Promise<GetInventory_Response_200>;
+  get(path: '/store/inventory'): Promise<GetInventory_Response_200>;
   /**
    * For valid response try integer IDs with value >= 1 and <= 10. Other values will generated exceptions
    *
    * @summary Find purchase order by ID
    */
-  get(path: string, metadata: GetOrderByIdMetadataParam): Promise<Order>;
+  get(path: '/store/order/{orderId}', metadata: GetOrderByIdMetadataParam): Promise<Order>;
   /**
    * Logs user into the system
    *
    */
-  get(path: string, metadata: LoginUserMetadataParam): Promise<LoginUser_Response_200>;
+  get(path: '/user/login', metadata: LoginUserMetadataParam): Promise<LoginUser_Response_200>;
   /**
    * Logs out current logged in user session
    *
    */
-  get<T = unknown>(path: string): Promise<T>;
+  get<T = unknown>(path: '/user/logout'): Promise<T>;
   /**
    * Get user by user name
    *
    */
-  get(path: string, metadata: GetUserByNameMetadataParam): Promise<User>;
+  get(path: '/user/{username}', metadata: GetUserByNameMetadataParam): Promise<User>;
   /**
-   * Access any get endpoint on your API.
+   * Access any GET endpoint on your API.
    *
    * @param path API path to make a request against.
    * @param metadata Object containing all path, query, header, and cookie parameters to supply.
@@ -213,21 +217,21 @@ export default class SDK {
    * Deletes a pet
    *
    */
-  delete<T = unknown>(path: string, metadata: DeletePetMetadataParam): Promise<T>;
+  delete<T = unknown>(path: '/pet/{petId}', metadata: DeletePetMetadataParam): Promise<T>;
   /**
    * For valid response try integer IDs with positive integer value. Negative or non-integer values will generate API errors
    *
    * @summary Delete purchase order by ID
    */
-  delete<T = unknown>(path: string, metadata: DeleteOrderMetadataParam): Promise<T>;
+  delete<T = unknown>(path: '/store/order/{orderId}', metadata: DeleteOrderMetadataParam): Promise<T>;
   /**
    * This can only be done by the logged in user.
    *
    * @summary Delete user
    */
-  delete<T = unknown>(path: string, metadata: DeleteUserMetadataParam): Promise<T>;
+  delete<T = unknown>(path: '/user/{username}', metadata: DeleteUserMetadataParam): Promise<T>;
   /**
-   * Access any delete endpoint on your API.
+   * Access any DELETE endpoint on your API.
    *
    * @param path API path to make a request against.
    * @param body Request body payload data.

--- a/packages/api/test/__fixtures__/sdk/readme/index.d.ts
+++ b/packages/api/test/__fixtures__/sdk/readme/index.d.ts
@@ -60,7 +60,7 @@ export default class SDK {
    * @summary Retrieve an entry from the API Registry
    */
   get(
-    path: string,
+    path: '/api-registry/{uuid}',
     metadata: GetAPIRegistryMetadataParam
   ): Promise<GetAPIRegistry_Response_200 | Error_REGISTRY_NOTFOUND>;
   /**
@@ -69,7 +69,7 @@ export default class SDK {
    * @summary Get metadata
    */
   get(
-    path: string,
+    path: '/api-specification',
     metadata?: GetAPISpecificationMetadataParam
   ): Promise<
     | GetAPISpecification_Response_200
@@ -83,44 +83,44 @@ export default class SDK {
    *
    * @summary Get open roles
    */
-  get(path: string): Promise<GetOpenRoles_Response_200>;
+  get(path: '/apply'): Promise<GetOpenRoles_Response_200>;
   /**
    * Returns all the categories for a specified version
    *
    * @summary Get all categories
    */
-  get(path: string, metadata?: GetCategoriesMetadataParam): Promise<GetCategories_Response_200>;
+  get(path: '/categories', metadata?: GetCategoriesMetadataParam): Promise<GetCategories_Response_200>;
   /**
    * Returns the category with this slug
    *
    * @summary Get category
    */
-  get(path: string, metadata: GetCategoryMetadataParam): Promise<Error_CATEGORY_NOTFOUND>;
+  get(path: '/categories/{slug}', metadata: GetCategoryMetadataParam): Promise<Error_CATEGORY_NOTFOUND>;
   /**
    * Returns the docs and children docs within this category
    *
    * @summary Get docs for category
    */
-  get(path: string, metadata: GetCategoryDocsMetadataParam): Promise<Error_CATEGORY_NOTFOUND>;
+  get(path: '/categories/{slug}/docs', metadata: GetCategoryDocsMetadataParam): Promise<Error_CATEGORY_NOTFOUND>;
   /**
    * Returns a list of changelogs associated with the project API key
    *
    * @summary Get changelogs
    */
-  get(path: string, metadata?: GetChangelogsMetadataParam): Promise<GetChangelogs_Response_200>;
+  get(path: '/changelogs', metadata?: GetChangelogsMetadataParam): Promise<GetChangelogs_Response_200>;
   /**
    * Returns the changelog with this slug
    *
    * @summary Get changelog
    */
-  get<T = unknown>(path: string, metadata: GetChangelogMetadataParam): Promise<T>;
+  get<T = unknown>(path: '/changelogs/{slug}', metadata: GetChangelogMetadataParam): Promise<T>;
   /**
    * Returns a list of custom pages associated with the project API key
    *
    * @summary Get custom pages
    */
   get(
-    path: string,
+    path: '/custompages',
     metadata?: GetCustomPagesMetadataParam
   ): Promise<GetCustomPages_Response_200 | GetCustomPages_Response_401 | GetCustomPages_Response_403>;
   /**
@@ -129,7 +129,7 @@ export default class SDK {
    * @summary Get custom page
    */
   get(
-    path: string,
+    path: '/custompages/{slug}',
     metadata: GetCustomPageMetadataParam
   ): Promise<GetCustomPage_Response_401 | GetCustomPage_Response_403 | Error_CUSTOMPAGE_NOTFOUND>;
   /**
@@ -138,7 +138,7 @@ export default class SDK {
    * @summary Get doc
    */
   get(
-    path: string,
+    path: '/docs/{slug}',
     metadata: GetDocMetadataParam
   ): Promise<GetDoc_Response_401 | GetDoc_Response_403 | Error_DOC_NOTFOUND>;
   /**
@@ -146,26 +146,26 @@ export default class SDK {
    *
    * @summary Get errors
    */
-  get(path: string): Promise<GetErrors_Response_401 | GetErrors_Response_403>;
+  get(path: '/errors'): Promise<GetErrors_Response_401 | GetErrors_Response_403>;
   /**
    * Returns project data for API key
    *
    * @summary Get metadata about the current project
    */
-  get(path: string): Promise<CondensedProjectData | GetProject_Response_401 | GetProject_Response_403>;
+  get(path: '/'): Promise<CondensedProjectData | GetProject_Response_401 | GetProject_Response_403>;
   /**
    * Retrieve a list of versions associated with a project API key
    *
    * @summary Get versions
    */
-  get(path: string): Promise<GetVersions_Response_401 | GetVersions_Response_403>;
+  get(path: '/version'): Promise<GetVersions_Response_401 | GetVersions_Response_403>;
   /**
    * Returns the version with this version ID
    *
    * @summary Get version
    */
   get(
-    path: string,
+    path: '/version/{versionId}',
     metadata: GetVersionMetadataParam
   ): Promise<GetVersion_Response_401 | GetVersion_Response_403 | Error_VERSION_NOTFOUND>;
   /**
@@ -174,7 +174,7 @@ export default class SDK {
    * @summary Upload specification
    */
   post(
-    path: string,
+    path: '/api-specification',
     body: UploadAPISpecificationBodyParam,
     metadata?: UploadAPISpecificationMetadataParam
   ): Promise<
@@ -188,26 +188,26 @@ export default class SDK {
    *
    * @summary Submit your application!
    */
-  post<T = unknown>(path: string, body: Apply): Promise<T>;
+  post<T = unknown>(path: '/apply', body: Apply): Promise<T>;
   /**
    * Create a new category inside of this project
    *
    * @summary Create category
    */
-  post(path: string, body: Category, metadata?: CreateCategoryMetadataParam): Promise<Error_CATEGORY_INVALID>;
+  post(path: '/categories', body: Category, metadata?: CreateCategoryMetadataParam): Promise<Error_CATEGORY_INVALID>;
   /**
    * Create a new changelog inside of this project
    *
    * @summary Create changelog
    */
-  post<T = unknown>(path: string, body: Changelog): Promise<T>;
+  post<T = unknown>(path: '/changelogs', body: Changelog): Promise<T>;
   /**
    * Create a new custom page inside of this project
    *
    * @summary Create custom page
    */
   post(
-    path: string,
+    path: '/custompages',
     body: CustomPage
   ): Promise<Error_CUSTOMPAGE_INVALID | CreateCustomPage_Response_401 | CreateCustomPage_Response_403>;
   /**
@@ -216,7 +216,7 @@ export default class SDK {
    * @summary Create doc
    */
   post(
-    path: string,
+    path: '/docs',
     body: Doc,
     metadata?: CreateDocMetadataParam
   ): Promise<Error_DOC_INVALID | CreateDoc_Response_401 | CreateDoc_Response_403>;
@@ -225,14 +225,17 @@ export default class SDK {
    *
    * @summary Search docs
    */
-  post(path: string, metadata: SearchDocsMetadataParam): Promise<SearchDocs_Response_401 | SearchDocs_Response_403>;
+  post(
+    path: '/docs/search',
+    metadata: SearchDocsMetadataParam
+  ): Promise<SearchDocs_Response_401 | SearchDocs_Response_403>;
   /**
    * Create a new version
    *
    * @summary Create version
    */
   post(
-    path: string,
+    path: '/version',
     body: Version
   ): Promise<
     CreateVersion_Response_400 | CreateVersion_Response_401 | CreateVersion_Response_403 | Error_VERSION_FORK_NOTFOUND
@@ -243,7 +246,7 @@ export default class SDK {
    * @summary Update specification
    */
   put(
-    path: string,
+    path: '/api-specification/{id}',
     body: UpdateAPISpecificationBodyParam,
     metadata: UpdateAPISpecificationMetadataParam
   ): Promise<
@@ -258,7 +261,7 @@ export default class SDK {
    * @summary Update category
    */
   put(
-    path: string,
+    path: '/categories/{slug}',
     body: Category,
     metadata: UpdateCategoryMetadataParam
   ): Promise<Error_CATEGORY_INVALID | Error_CATEGORY_NOTFOUND>;
@@ -267,14 +270,14 @@ export default class SDK {
    *
    * @summary Update changelog
    */
-  put<T = unknown>(path: string, body: Changelog, metadata: UpdateChangelogMetadataParam): Promise<T>;
+  put<T = unknown>(path: '/changelogs/{slug}', body: Changelog, metadata: UpdateChangelogMetadataParam): Promise<T>;
   /**
    * Update a custom page with this slug
    *
    * @summary Update custom page
    */
   put(
-    path: string,
+    path: '/custompages/{slug}',
     body: CustomPage,
     metadata: UpdateCustomPageMetadataParam
   ): Promise<
@@ -286,7 +289,7 @@ export default class SDK {
    * @summary Update doc
    */
   put(
-    path: string,
+    path: '/docs/{slug}',
     body: Doc,
     metadata: UpdateDocMetadataParam
   ): Promise<Error_DOC_INVALID | UpdateDoc_Response_401 | UpdateDoc_Response_403 | Error_DOC_NOTFOUND>;
@@ -296,7 +299,7 @@ export default class SDK {
    * @summary Update version
    */
   put(
-    path: string,
+    path: '/version/{versionId}',
     body: Version,
     metadata: UpdateVersionMetadataParam
   ): Promise<
@@ -308,7 +311,7 @@ export default class SDK {
    * @summary Delete specification
    */
   delete(
-    path: string,
+    path: '/api-specification/{id}',
     metadata: DeleteAPISpecificationMetadataParam
   ): Promise<
     | Error_SPEC_ID_INVALID
@@ -323,20 +326,20 @@ export default class SDK {
    *
    * @summary Delete category
    */
-  delete(path: string, metadata: DeleteCategoryMetadataParam): Promise<Error_CATEGORY_NOTFOUND>;
+  delete(path: '/categories/{slug}', metadata: DeleteCategoryMetadataParam): Promise<Error_CATEGORY_NOTFOUND>;
   /**
    * Delete the changelog with this slug
    *
    * @summary Delete changelog
    */
-  delete<T = unknown>(path: string, metadata: DeleteChangelogMetadataParam): Promise<T>;
+  delete<T = unknown>(path: '/changelogs/{slug}', metadata: DeleteChangelogMetadataParam): Promise<T>;
   /**
    * Delete the custom page with this slug
    *
    * @summary Delete custom page
    */
   delete(
-    path: string,
+    path: '/custompages/{slug}',
     metadata: DeleteCustomPageMetadataParam
   ): Promise<DeleteCustomPage_Response_401 | DeleteCustomPage_Response_403 | Error_CUSTOMPAGE_NOTFOUND>;
   /**
@@ -345,7 +348,7 @@ export default class SDK {
    * @summary Delete doc
    */
   delete(
-    path: string,
+    path: '/docs/{slug}',
     metadata: DeleteDocMetadataParam
   ): Promise<DeleteDoc_Response_401 | DeleteDoc_Response_403 | Error_DOC_NOTFOUND>;
   /**
@@ -354,7 +357,7 @@ export default class SDK {
    * @summary Delete version
    */
   delete(
-    path: string,
+    path: '/version/{versionId}',
     metadata: DeleteVersionMetadataParam
   ): Promise<
     Error_VERSION_CANT_REMOVE_STABLE | DeleteVersion_Response_401 | DeleteVersion_Response_403 | Error_VERSION_NOTFOUND

--- a/packages/api/test/__fixtures__/sdk/readme/index.ts
+++ b/packages/api/test/__fixtures__/sdk/readme/index.ts
@@ -77,7 +77,7 @@ export default class SDK {
    * @summary Retrieve an entry from the API Registry
    */
   get(
-    path: string,
+    path: '/api-registry/{uuid}',
     metadata: GetAPIRegistryMetadataParam
   ): Promise<GetAPIRegistry_Response_200 | Error_REGISTRY_NOTFOUND>;
   /**
@@ -86,7 +86,7 @@ export default class SDK {
    * @summary Get metadata
    */
   get(
-    path: string,
+    path: '/api-specification',
     metadata?: GetAPISpecificationMetadataParam
   ): Promise<
     | GetAPISpecification_Response_200
@@ -100,44 +100,44 @@ export default class SDK {
    *
    * @summary Get open roles
    */
-  get(path: string): Promise<GetOpenRoles_Response_200>;
+  get(path: '/apply'): Promise<GetOpenRoles_Response_200>;
   /**
    * Returns all the categories for a specified version
    *
    * @summary Get all categories
    */
-  get(path: string, metadata?: GetCategoriesMetadataParam): Promise<GetCategories_Response_200>;
+  get(path: '/categories', metadata?: GetCategoriesMetadataParam): Promise<GetCategories_Response_200>;
   /**
    * Returns the category with this slug
    *
    * @summary Get category
    */
-  get(path: string, metadata: GetCategoryMetadataParam): Promise<Error_CATEGORY_NOTFOUND>;
+  get(path: '/categories/{slug}', metadata: GetCategoryMetadataParam): Promise<Error_CATEGORY_NOTFOUND>;
   /**
    * Returns the docs and children docs within this category
    *
    * @summary Get docs for category
    */
-  get(path: string, metadata: GetCategoryDocsMetadataParam): Promise<Error_CATEGORY_NOTFOUND>;
+  get(path: '/categories/{slug}/docs', metadata: GetCategoryDocsMetadataParam): Promise<Error_CATEGORY_NOTFOUND>;
   /**
    * Returns a list of changelogs associated with the project API key
    *
    * @summary Get changelogs
    */
-  get(path: string, metadata?: GetChangelogsMetadataParam): Promise<GetChangelogs_Response_200>;
+  get(path: '/changelogs', metadata?: GetChangelogsMetadataParam): Promise<GetChangelogs_Response_200>;
   /**
    * Returns the changelog with this slug
    *
    * @summary Get changelog
    */
-  get<T = unknown>(path: string, metadata: GetChangelogMetadataParam): Promise<T>;
+  get<T = unknown>(path: '/changelogs/{slug}', metadata: GetChangelogMetadataParam): Promise<T>;
   /**
    * Returns a list of custom pages associated with the project API key
    *
    * @summary Get custom pages
    */
   get(
-    path: string,
+    path: '/custompages',
     metadata?: GetCustomPagesMetadataParam
   ): Promise<GetCustomPages_Response_200 | GetCustomPages_Response_401 | GetCustomPages_Response_403>;
   /**
@@ -146,7 +146,7 @@ export default class SDK {
    * @summary Get custom page
    */
   get(
-    path: string,
+    path: '/custompages/{slug}',
     metadata: GetCustomPageMetadataParam
   ): Promise<GetCustomPage_Response_401 | GetCustomPage_Response_403 | Error_CUSTOMPAGE_NOTFOUND>;
   /**
@@ -155,7 +155,7 @@ export default class SDK {
    * @summary Get doc
    */
   get(
-    path: string,
+    path: '/docs/{slug}',
     metadata: GetDocMetadataParam
   ): Promise<GetDoc_Response_401 | GetDoc_Response_403 | Error_DOC_NOTFOUND>;
   /**
@@ -163,30 +163,30 @@ export default class SDK {
    *
    * @summary Get errors
    */
-  get(path: string): Promise<GetErrors_Response_401 | GetErrors_Response_403>;
+  get(path: '/errors'): Promise<GetErrors_Response_401 | GetErrors_Response_403>;
   /**
    * Returns project data for API key
    *
    * @summary Get metadata about the current project
    */
-  get(path: string): Promise<CondensedProjectData | GetProject_Response_401 | GetProject_Response_403>;
+  get(path: '/'): Promise<CondensedProjectData | GetProject_Response_401 | GetProject_Response_403>;
   /**
    * Retrieve a list of versions associated with a project API key
    *
    * @summary Get versions
    */
-  get(path: string): Promise<GetVersions_Response_401 | GetVersions_Response_403>;
+  get(path: '/version'): Promise<GetVersions_Response_401 | GetVersions_Response_403>;
   /**
    * Returns the version with this version ID
    *
    * @summary Get version
    */
   get(
-    path: string,
+    path: '/version/{versionId}',
     metadata: GetVersionMetadataParam
   ): Promise<GetVersion_Response_401 | GetVersion_Response_403 | Error_VERSION_NOTFOUND>;
   /**
-   * Access any get endpoint on your API.
+   * Access any GET endpoint on your API.
    *
    * @param path API path to make a request against.
    * @param metadata Object containing all path, query, header, and cookie parameters to supply.
@@ -201,7 +201,7 @@ export default class SDK {
    * @summary Upload specification
    */
   post(
-    path: string,
+    path: '/api-specification',
     body: UploadAPISpecificationBodyParam,
     metadata?: UploadAPISpecificationMetadataParam
   ): Promise<
@@ -215,26 +215,26 @@ export default class SDK {
    *
    * @summary Submit your application!
    */
-  post<T = unknown>(path: string, body: Apply): Promise<T>;
+  post<T = unknown>(path: '/apply', body: Apply): Promise<T>;
   /**
    * Create a new category inside of this project
    *
    * @summary Create category
    */
-  post(path: string, body: Category, metadata?: CreateCategoryMetadataParam): Promise<Error_CATEGORY_INVALID>;
+  post(path: '/categories', body: Category, metadata?: CreateCategoryMetadataParam): Promise<Error_CATEGORY_INVALID>;
   /**
    * Create a new changelog inside of this project
    *
    * @summary Create changelog
    */
-  post<T = unknown>(path: string, body: Changelog): Promise<T>;
+  post<T = unknown>(path: '/changelogs', body: Changelog): Promise<T>;
   /**
    * Create a new custom page inside of this project
    *
    * @summary Create custom page
    */
   post(
-    path: string,
+    path: '/custompages',
     body: CustomPage
   ): Promise<Error_CUSTOMPAGE_INVALID | CreateCustomPage_Response_401 | CreateCustomPage_Response_403>;
   /**
@@ -243,7 +243,7 @@ export default class SDK {
    * @summary Create doc
    */
   post(
-    path: string,
+    path: '/docs',
     body: Doc,
     metadata?: CreateDocMetadataParam
   ): Promise<Error_DOC_INVALID | CreateDoc_Response_401 | CreateDoc_Response_403>;
@@ -252,20 +252,23 @@ export default class SDK {
    *
    * @summary Search docs
    */
-  post(path: string, metadata: SearchDocsMetadataParam): Promise<SearchDocs_Response_401 | SearchDocs_Response_403>;
+  post(
+    path: '/docs/search',
+    metadata: SearchDocsMetadataParam
+  ): Promise<SearchDocs_Response_401 | SearchDocs_Response_403>;
   /**
    * Create a new version
    *
    * @summary Create version
    */
   post(
-    path: string,
+    path: '/version',
     body: Version
   ): Promise<
     CreateVersion_Response_400 | CreateVersion_Response_401 | CreateVersion_Response_403 | Error_VERSION_FORK_NOTFOUND
   >;
   /**
-   * Access any post endpoint on your API.
+   * Access any POST endpoint on your API.
    *
    * @param path API path to make a request against.
    * @param body Request body payload data.
@@ -281,7 +284,7 @@ export default class SDK {
    * @summary Update specification
    */
   put(
-    path: string,
+    path: '/api-specification/{id}',
     body: UpdateAPISpecificationBodyParam,
     metadata: UpdateAPISpecificationMetadataParam
   ): Promise<
@@ -296,7 +299,7 @@ export default class SDK {
    * @summary Update category
    */
   put(
-    path: string,
+    path: '/categories/{slug}',
     body: Category,
     metadata: UpdateCategoryMetadataParam
   ): Promise<Error_CATEGORY_INVALID | Error_CATEGORY_NOTFOUND>;
@@ -305,14 +308,14 @@ export default class SDK {
    *
    * @summary Update changelog
    */
-  put<T = unknown>(path: string, body: Changelog, metadata: UpdateChangelogMetadataParam): Promise<T>;
+  put<T = unknown>(path: '/changelogs/{slug}', body: Changelog, metadata: UpdateChangelogMetadataParam): Promise<T>;
   /**
    * Update a custom page with this slug
    *
    * @summary Update custom page
    */
   put(
-    path: string,
+    path: '/custompages/{slug}',
     body: CustomPage,
     metadata: UpdateCustomPageMetadataParam
   ): Promise<
@@ -324,7 +327,7 @@ export default class SDK {
    * @summary Update doc
    */
   put(
-    path: string,
+    path: '/docs/{slug}',
     body: Doc,
     metadata: UpdateDocMetadataParam
   ): Promise<Error_DOC_INVALID | UpdateDoc_Response_401 | UpdateDoc_Response_403 | Error_DOC_NOTFOUND>;
@@ -334,14 +337,14 @@ export default class SDK {
    * @summary Update version
    */
   put(
-    path: string,
+    path: '/version/{versionId}',
     body: Version,
     metadata: UpdateVersionMetadataParam
   ): Promise<
     Error_VERSION_CANT_DEMOTE_STABLE | UpdateVersion_Response_401 | UpdateVersion_Response_403 | Error_VERSION_NOTFOUND
   >;
   /**
-   * Access any put endpoint on your API.
+   * Access any PUT endpoint on your API.
    *
    * @param path API path to make a request against.
    * @param body Request body payload data.
@@ -357,7 +360,7 @@ export default class SDK {
    * @summary Delete specification
    */
   delete(
-    path: string,
+    path: '/api-specification/{id}',
     metadata: DeleteAPISpecificationMetadataParam
   ): Promise<
     | Error_SPEC_ID_INVALID
@@ -372,20 +375,20 @@ export default class SDK {
    *
    * @summary Delete category
    */
-  delete(path: string, metadata: DeleteCategoryMetadataParam): Promise<Error_CATEGORY_NOTFOUND>;
+  delete(path: '/categories/{slug}', metadata: DeleteCategoryMetadataParam): Promise<Error_CATEGORY_NOTFOUND>;
   /**
    * Delete the changelog with this slug
    *
    * @summary Delete changelog
    */
-  delete<T = unknown>(path: string, metadata: DeleteChangelogMetadataParam): Promise<T>;
+  delete<T = unknown>(path: '/changelogs/{slug}', metadata: DeleteChangelogMetadataParam): Promise<T>;
   /**
    * Delete the custom page with this slug
    *
    * @summary Delete custom page
    */
   delete(
-    path: string,
+    path: '/custompages/{slug}',
     metadata: DeleteCustomPageMetadataParam
   ): Promise<DeleteCustomPage_Response_401 | DeleteCustomPage_Response_403 | Error_CUSTOMPAGE_NOTFOUND>;
   /**
@@ -394,7 +397,7 @@ export default class SDK {
    * @summary Delete doc
    */
   delete(
-    path: string,
+    path: '/docs/{slug}',
     metadata: DeleteDocMetadataParam
   ): Promise<DeleteDoc_Response_401 | DeleteDoc_Response_403 | Error_DOC_NOTFOUND>;
   /**
@@ -403,13 +406,13 @@ export default class SDK {
    * @summary Delete version
    */
   delete(
-    path: string,
+    path: '/version/{versionId}',
     metadata: DeleteVersionMetadataParam
   ): Promise<
     Error_VERSION_CANT_REMOVE_STABLE | DeleteVersion_Response_401 | DeleteVersion_Response_403 | Error_VERSION_NOTFOUND
   >;
   /**
-   * Access any delete endpoint on your API.
+   * Access any DELETE endpoint on your API.
    *
    * @param path API path to make a request against.
    * @param body Request body payload data.

--- a/packages/api/test/__fixtures__/sdk/simple-js-cjs/index.d.ts
+++ b/packages/api/test/__fixtures__/sdk/simple-js-cjs/index.d.ts
@@ -59,7 +59,7 @@ declare class SDK {
    *
    * @summary Finds Pets by status
    */
-  get(path: string, metadata: FindPetsByStatusMetadataParam): Promise<FindPetsByStatus_Response_200>;
+  get(path: '/pet/findByStatus', metadata: FindPetsByStatusMetadataParam): Promise<FindPetsByStatus_Response_200>;
   /**
    * Multiple status values can be provided with comma separated strings
    *

--- a/packages/api/test/__fixtures__/sdk/simple-js-cjs/index.js
+++ b/packages/api/test/__fixtures__/sdk/simple-js-cjs/index.js
@@ -78,7 +78,7 @@ var SDK = /** @class */ (function () {
     this.core.setServer(url, variables);
   };
   /**
-   * Access any get endpoint on your API.
+   * Access any GET endpoint on your API.
    *
    * @param path API path to make a request against.
    * @param metadata Object containing all path, query, header, and cookie parameters to supply.

--- a/packages/api/test/__fixtures__/sdk/simple-js-esm/index.d.ts
+++ b/packages/api/test/__fixtures__/sdk/simple-js-esm/index.d.ts
@@ -59,7 +59,7 @@ export default class SDK {
    *
    * @summary Finds Pets by status
    */
-  get(path: string, metadata: FindPetsByStatusMetadataParam): Promise<FindPetsByStatus_Response_200>;
+  get(path: '/pet/findByStatus', metadata: FindPetsByStatusMetadataParam): Promise<FindPetsByStatus_Response_200>;
   /**
    * Multiple status values can be provided with comma separated strings
    *

--- a/packages/api/test/__fixtures__/sdk/simple-js-esm/index.js
+++ b/packages/api/test/__fixtures__/sdk/simple-js-esm/index.js
@@ -64,7 +64,7 @@ export default class SDK {
     this.core.setServer(url, variables);
   }
   /**
-   * Access any get endpoint on your API.
+   * Access any GET endpoint on your API.
    *
    * @param path API path to make a request against.
    * @param metadata Object containing all path, query, header, and cookie parameters to supply.

--- a/packages/api/test/__fixtures__/sdk/simple-ts/index.d.ts
+++ b/packages/api/test/__fixtures__/sdk/simple-ts/index.d.ts
@@ -59,7 +59,7 @@ export default class SDK {
    *
    * @summary Finds Pets by status
    */
-  get(path: string, metadata: FindPetsByStatusMetadataParam): Promise<FindPetsByStatus_Response_200>;
+  get(path: '/pet/findByStatus', metadata: FindPetsByStatusMetadataParam): Promise<FindPetsByStatus_Response_200>;
   /**
    * Multiple status values can be provided with comma separated strings
    *

--- a/packages/api/test/__fixtures__/sdk/simple-ts/index.ts
+++ b/packages/api/test/__fixtures__/sdk/simple-ts/index.ts
@@ -76,9 +76,9 @@ export default class SDK {
    *
    * @summary Finds Pets by status
    */
-  get(path: string, metadata: FindPetsByStatusMetadataParam): Promise<FindPetsByStatus_Response_200>;
+  get(path: '/pet/findByStatus', metadata: FindPetsByStatusMetadataParam): Promise<FindPetsByStatus_Response_200>;
   /**
-   * Access any get endpoint on your API.
+   * Access any GET endpoint on your API.
    *
    * @param path API path to make a request against.
    * @param metadata Object containing all path, query, header, and cookie parameters to supply.


### PR DESCRIPTION
## 🧰 Changes

While installing our OpenAPI definition to our homepage repository I noticed that all `get` accessors in the generated library had `path` typed to a simple `string` instead of the actual path in question. This fixes that!

With this work, autocompletion on HTTP method accessors should be a lot smarter and give you better inline docs:

![screen_shot_2022-07-11_at_5 10 56_pm](https://user-images.githubusercontent.com/33762/178384064-c24dc0f8-cdc3-4563-aaa8-132d69dcb52c.png)

## 🧬 QA & Testing

See tests.