### PR TITLE
feat: updating httpsnippet-client-api to be compatible with httpsnippet v4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1020,19 +1020,20 @@
       }
     },
     "node_modules/@readme/httpsnippet": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@readme/httpsnippet/-/httpsnippet-3.0.3.tgz",
-      "integrity": "sha512-ZShZE3rswlBkdJssa26lDQX1vcogJJ/ToglP/Bs7zb1j5dJWImv7poYCA+HEx3zIAZk5UEeDzHegZ4cCVf5uzg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@readme/httpsnippet/-/httpsnippet-4.0.3.tgz",
+      "integrity": "sha512-1QExCC4DPJxsUeyvBlsicaRIHpVfIKiKo+ukkxpeazoQl0S/idrdNh/S/A4IHkNO3dIPoj2NGT+0onq2Tk5+7w==",
       "peer": true,
       "dependencies": {
+        "ajv": "^6.12.6",
         "event-stream": "4.0.1",
         "form-data": "^4.0.0",
-        "har-validator": "^5.0.0",
+        "har-schema": "^2.0.0",
         "qs": "^6.10.1",
         "stringify-object": "^3.3.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14"
       }
     },
     "node_modules/@readme/httpsnippet/node_modules/form-data": {
@@ -5414,24 +5415,10 @@
     "node_modules/har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
       "peer": true,
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/har-validator": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-      "deprecated": "this library is no longer supported",
-      "peer": true,
-      "dependencies": {
-        "ajv": "^6.12.3",
-        "har-schema": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/hard-rejection": {
@@ -13201,7 +13188,7 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "@readme/httpsnippet": "^3.0.0",
+        "@readme/httpsnippet": "^4.0.3",
         "oas": "^18.0.1"
       }
     }
@@ -13985,14 +13972,15 @@
       }
     },
     "@readme/httpsnippet": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@readme/httpsnippet/-/httpsnippet-3.0.3.tgz",
-      "integrity": "sha512-ZShZE3rswlBkdJssa26lDQX1vcogJJ/ToglP/Bs7zb1j5dJWImv7poYCA+HEx3zIAZk5UEeDzHegZ4cCVf5uzg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@readme/httpsnippet/-/httpsnippet-4.0.3.tgz",
+      "integrity": "sha512-1QExCC4DPJxsUeyvBlsicaRIHpVfIKiKo+ukkxpeazoQl0S/idrdNh/S/A4IHkNO3dIPoj2NGT+0onq2Tk5+7w==",
       "peer": true,
       "requires": {
+        "ajv": "^6.12.6",
         "event-stream": "4.0.1",
         "form-data": "^4.0.0",
-        "har-validator": "^5.0.0",
+        "har-schema": "^2.0.0",
         "qs": "^6.10.1",
         "stringify-object": "^3.3.0"
       },
@@ -17393,18 +17381,8 @@
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
       "peer": true
-    },
-    "har-validator": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-      "peer": true,
-      "requires": {
-        "ajv": "^6.12.3",
-        "har-schema": "^2.0.0"
-      }
     },
     "hard-rejection": {
       "version": "2.1.0",

--- a/packages/httpsnippet-client-api/package-lock.json
+++ b/packages/httpsnippet-client-api/package-lock.json
@@ -28,7 +28,7 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "@readme/httpsnippet": "^3.0.0",
+        "@readme/httpsnippet": "^4.0.3",
         "oas": "^18.0.1"
       }
     },
@@ -67,7 +67,6 @@
         "api": "bin/api"
       },
       "devDependencies": {
-        "@readme/eslint-config": "^8.8.1",
         "@readme/oas-examples": "^5.4.1",
         "@types/chai": "^4.3.1",
         "@types/find-cache-dir": "^3.2.1",
@@ -737,19 +736,20 @@
       }
     },
     "node_modules/@readme/httpsnippet": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@readme/httpsnippet/-/httpsnippet-3.0.0.tgz",
-      "integrity": "sha512-v6/oCr1nkaYGbCl6blMF51WrOwlEJVZ/D050KQi1kxhD3X2d02FYUUUw1ERAzFjXRmrWI2U0H5NE2IWsiqXvSg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@readme/httpsnippet/-/httpsnippet-4.0.3.tgz",
+      "integrity": "sha512-1QExCC4DPJxsUeyvBlsicaRIHpVfIKiKo+ukkxpeazoQl0S/idrdNh/S/A4IHkNO3dIPoj2NGT+0onq2Tk5+7w==",
       "peer": true,
       "dependencies": {
+        "ajv": "^6.12.6",
         "event-stream": "4.0.1",
         "form-data": "^4.0.0",
-        "har-validator": "^5.0.0",
+        "har-schema": "^2.0.0",
         "qs": "^6.10.1",
         "stringify-object": "^3.3.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14"
       }
     },
     "node_modules/@readme/httpsnippet/node_modules/form-data": {
@@ -2354,23 +2354,10 @@
     "node_modules/har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
       "peer": true,
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/har-validator": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
-      "peer": true,
-      "dependencies": {
-        "ajv": "^6.5.5",
-        "har-schema": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/has": {
@@ -6033,14 +6020,15 @@
       }
     },
     "@readme/httpsnippet": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@readme/httpsnippet/-/httpsnippet-3.0.0.tgz",
-      "integrity": "sha512-v6/oCr1nkaYGbCl6blMF51WrOwlEJVZ/D050KQi1kxhD3X2d02FYUUUw1ERAzFjXRmrWI2U0H5NE2IWsiqXvSg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@readme/httpsnippet/-/httpsnippet-4.0.3.tgz",
+      "integrity": "sha512-1QExCC4DPJxsUeyvBlsicaRIHpVfIKiKo+ukkxpeazoQl0S/idrdNh/S/A4IHkNO3dIPoj2NGT+0onq2Tk5+7w==",
       "peer": true,
       "requires": {
+        "ajv": "^6.12.6",
         "event-stream": "4.0.1",
         "form-data": "^4.0.0",
-        "har-validator": "^5.0.0",
+        "har-schema": "^2.0.0",
         "qs": "^6.10.1",
         "stringify-object": "^3.3.0"
       },
@@ -6246,7 +6234,6 @@
     "api": {
       "version": "file:../api",
       "requires": {
-        "@readme/eslint-config": "^8.8.1",
         "@readme/oas-examples": "^5.4.1",
         "@readme/oas-to-har": "^17.0.8",
         "@readme/openapi-parser": "^2.2.0",
@@ -7333,18 +7320,8 @@
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
       "peer": true
-    },
-    "har-validator": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
-      "peer": true,
-      "requires": {
-        "ajv": "^6.5.5",
-        "har-schema": "^2.0.0"
-      }
     },
     "has": {
       "version": "1.0.3",

--- a/packages/httpsnippet-client-api/package.json
+++ b/packages/httpsnippet-client-api/package.json
@@ -25,7 +25,7 @@
     "stringify-object": "^3.3.0"
   },
   "peerDependencies": {
-    "@readme/httpsnippet": "^3.0.0",
+    "@readme/httpsnippet": "^4.0.3",
     "oas": "^18.0.1"
   },
   "devDependencies": {

--- a/packages/httpsnippet-client-api/test/index.test.js
+++ b/packages/httpsnippet-client-api/test/index.test.js
@@ -9,7 +9,7 @@ const sinonChai = require('sinon-chai');
 const vm = require('vm');
 const rimraf = require('rimraf');
 const fs = require('fs/promises');
-const HTTPSnippet = require('@readme/httpsnippet');
+const { HTTPSnippet, addTargetClient } = require('@readme/httpsnippet');
 const path = require('path');
 const fetchMock = require('fetch-mock');
 const openapiParser = require('@readme/openapi-parser');
@@ -68,7 +68,7 @@ describe('httpsnippet-client-api', function () {
     try {
       // Mocha doesn't tear this down so if you run Mocha with `--watch` it'll be set up already
       // throwing the error that we're ignoring below.
-      HTTPSnippet.addTargetClient('node', client);
+      addTargetClient('node', client);
     } catch (err) {
       if (err.message !== 'The supplied custom target client already exists, please use a different key') {
         throw err;


### PR DESCRIPTION
## 🧰 Changes

v4 of HTTPSnippet, and our fork, introduced a full TS rewrite that changed a handful of things around. This update `httpsnippet-client-api` to be compatible with everything that happened.