### PR TITLE
fix: generated SDKs now ship an IFEE

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -10,7 +10,7 @@ packages/api/.prettier*
 packages/api/CHANGELOG.md
 packages/api/dist/
 packages/api/example.js
-packages/api/test/
+packages/api/test/__fixtures/sdk/
 
 # httpsnippet-client-api subpackage
 packages/httpsnippet-client-api/.nyc_output/

--- a/.prettierignore
+++ b/.prettierignore
@@ -10,7 +10,7 @@ packages/api/.prettier*
 packages/api/CHANGELOG.md
 packages/api/dist/
 packages/api/example.js
-packages/api/test/__fixtures/sdk/
+packages/api/test/__fixtures__/sdk/
 
 # httpsnippet-client-api subpackage
 packages/httpsnippet-client-api/.nyc_output/

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -23,7 +23,6 @@ Once you have your library generated and installed you can use your SDK like you
 ```js
 const SDK = require('@api/petstore');
 
-const petstore = new SDK();
 petstore.listPets().then(res => {
   console.log(`My pets name is ${res[0].name}!`);
 });

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -31,7 +31,6 @@ $ npx api install https://raw.githubusercontent.com/OAI/OpenAPI-Specification/ma
 ```js
 const SDK = require('@api/petstore');
 
-const petstore = new SDK();
 petstore.listPets().then(res => {
   console.log(`My pets name is ${res[0].name}!`);
 });

--- a/packages/api/src/cli/codegen/languages/typescript.ts
+++ b/packages/api/src/cli/codegen/languages/typescript.ts
@@ -23,6 +23,11 @@ import { compile } from 'json-schema-to-typescript';
 import { format as prettier } from 'json-schema-to-typescript/dist/src/formatter';
 import execa from 'execa';
 
+export type TSGeneratorOptions = {
+  outputJS?: boolean;
+  compilerTarget?: 'cjs' | 'esm';
+};
+
 type OperationTypeHousing = {
   types: {
     params?: false | Record<'body' | 'formData' | 'metadata', string>;
@@ -60,15 +65,7 @@ export default class TSGenerator extends CodeGeneratorLanguage {
     }
   >;
 
-  constructor(
-    spec: Oas,
-    specPath: string,
-    identifier: string,
-    opts: {
-      outputJS?: boolean;
-      compilerTarget?: 'cjs' | 'esm';
-    } = {}
-  ) {
+  constructor(spec: Oas, specPath: string, identifier: string, opts: TSGeneratorOptions = {}) {
     const options: { outputJS: boolean; compilerTarget: 'cjs' | 'esm' } = {
       outputJS: false,
       compilerTarget: 'cjs',

--- a/packages/api/test/__fixtures__/sdk/operationid-quirks/index.d.ts
+++ b/packages/api/test/__fixtures__/sdk/operationid-quirks/index.d.ts
@@ -65,7 +65,8 @@ declare class SDK {
    */
   quirkyOperationIdString<T = unknown>(): Promise<T>;
 }
-export default function createSDK(): SDK;
+declare const createSDK: SDK;
+export default createSDK;
 interface ConfigOptions {
   /**
    * By default we parse the response based on the `Content-Type` header of the request. You
@@ -73,4 +74,3 @@ interface ConfigOptions {
    */
   parseResponse: boolean;
 }
-export {};

--- a/packages/api/test/__fixtures__/sdk/operationid-quirks/index.d.ts
+++ b/packages/api/test/__fixtures__/sdk/operationid-quirks/index.d.ts
@@ -1,6 +1,6 @@
 import Oas from 'oas';
 import APICore from 'api/dist/core';
-export default class SDK {
+declare class SDK {
   spec: Oas;
   core: APICore;
   authKeys: (number | string)[][];
@@ -65,6 +65,7 @@ export default class SDK {
    */
   quirkyOperationIdString<T = unknown>(): Promise<T>;
 }
+export default function createSDK(): SDK;
 interface ConfigOptions {
   /**
    * By default we parse the response based on the `Content-Type` header of the request. You

--- a/packages/api/test/__fixtures__/sdk/operationid-quirks/index.ts
+++ b/packages/api/test/__fixtures__/sdk/operationid-quirks/index.ts
@@ -95,9 +95,10 @@ class SDK {
   }
 }
 
-export default function createSDK(): SDK {
+const createSDK = (() => {
   return new SDK();
-}
+})();
+export default createSDK;
 
 interface ConfigOptions {
   /**

--- a/packages/api/test/__fixtures__/sdk/operationid-quirks/index.ts
+++ b/packages/api/test/__fixtures__/sdk/operationid-quirks/index.ts
@@ -1,6 +1,6 @@
 import Oas from 'oas';
 import APICore from 'api/dist/core';
-import definition from './openapi.json';
+import definition from '../../../__fixtures__/definitions/operationid-quirks.json';
 
 export default class SDK {
   spec: Oas;

--- a/packages/api/test/__fixtures__/sdk/operationid-quirks/index.ts
+++ b/packages/api/test/__fixtures__/sdk/operationid-quirks/index.ts
@@ -2,7 +2,7 @@ import Oas from 'oas';
 import APICore from 'api/dist/core';
 import definition from '../../../__fixtures__/definitions/operationid-quirks.json';
 
-export default class SDK {
+class SDK {
   spec: Oas;
   core: APICore;
   authKeys: (number | string)[][] = [];
@@ -93,6 +93,10 @@ export default class SDK {
   quirkyOperationIdString<T = unknown>(): Promise<T> {
     return this.core.fetch('/quirky-operationId', 'get');
   }
+}
+
+export default function createSDK(): SDK {
+  return new SDK();
 }
 
 interface ConfigOptions {

--- a/packages/api/test/__fixtures__/sdk/optional-payload/index.d.ts
+++ b/packages/api/test/__fixtures__/sdk/optional-payload/index.d.ts
@@ -1,6 +1,6 @@
 import Oas from 'oas';
 import APICore from 'api/dist/core';
-export default class SDK {
+declare class SDK {
   spec: Oas;
   core: APICore;
   authKeys: (number | string)[][];
@@ -82,6 +82,7 @@ export default class SDK {
    */
   updatePetWithForm<T = unknown>(metadata: UpdatePetWithFormMetadataParam): Promise<T>;
 }
+export default function createSDK(): SDK;
 interface ConfigOptions {
   /**
    * By default we parse the response based on the `Content-Type` header of the request. You
@@ -89,7 +90,7 @@ interface ConfigOptions {
    */
   parseResponse: boolean;
 }
-export interface UpdatePetWithFormFormDataParam {
+interface UpdatePetWithFormFormDataParam {
   /**
    * Updated name of the pet
    */
@@ -100,7 +101,7 @@ export interface UpdatePetWithFormFormDataParam {
   status?: string;
   [k: string]: unknown;
 }
-export declare type UpdatePetWithFormMetadataParam = {
+declare type UpdatePetWithFormMetadataParam = {
   /**
    * ID of pet that needs to be updated
    */

--- a/packages/api/test/__fixtures__/sdk/optional-payload/index.d.ts
+++ b/packages/api/test/__fixtures__/sdk/optional-payload/index.d.ts
@@ -82,7 +82,8 @@ declare class SDK {
    */
   updatePetWithForm<T = unknown>(metadata: UpdatePetWithFormMetadataParam): Promise<T>;
 }
-export default function createSDK(): SDK;
+declare const createSDK: SDK;
+export default createSDK;
 interface ConfigOptions {
   /**
    * By default we parse the response based on the `Content-Type` header of the request. You
@@ -108,4 +109,3 @@ declare type UpdatePetWithFormMetadataParam = {
   petId: number;
   [k: string]: unknown;
 };
-export {};

--- a/packages/api/test/__fixtures__/sdk/optional-payload/index.ts
+++ b/packages/api/test/__fixtures__/sdk/optional-payload/index.ts
@@ -1,6 +1,6 @@
 import Oas from 'oas';
 import APICore from 'api/dist/core';
-import definition from './openapi.json';
+import definition from '../../../__fixtures__/definitions/optional-payload.json';
 
 export default class SDK {
   spec: Oas;

--- a/packages/api/test/__fixtures__/sdk/optional-payload/index.ts
+++ b/packages/api/test/__fixtures__/sdk/optional-payload/index.ts
@@ -2,7 +2,7 @@ import Oas from 'oas';
 import APICore from 'api/dist/core';
 import definition from '../../../__fixtures__/definitions/optional-payload.json';
 
-export default class SDK {
+class SDK {
   spec: Oas;
   core: APICore;
   authKeys: (number | string)[][] = [];
@@ -121,6 +121,10 @@ export default class SDK {
   }
 }
 
+export default function createSDK(): SDK {
+  return new SDK();
+}
+
 interface ConfigOptions {
   /**
    * By default we parse the response based on the `Content-Type` header of the request. You
@@ -128,7 +132,7 @@ interface ConfigOptions {
    */
   parseResponse: boolean;
 }
-export interface UpdatePetWithFormFormDataParam {
+interface UpdatePetWithFormFormDataParam {
   /**
    * Updated name of the pet
    */
@@ -139,7 +143,7 @@ export interface UpdatePetWithFormFormDataParam {
   status?: string;
   [k: string]: unknown;
 }
-export type UpdatePetWithFormMetadataParam = {
+type UpdatePetWithFormMetadataParam = {
   /**
    * ID of pet that needs to be updated
    */

--- a/packages/api/test/__fixtures__/sdk/optional-payload/index.ts
+++ b/packages/api/test/__fixtures__/sdk/optional-payload/index.ts
@@ -121,9 +121,10 @@ class SDK {
   }
 }
 
-export default function createSDK(): SDK {
+const createSDK = (() => {
   return new SDK();
-}
+})();
+export default createSDK;
 
 interface ConfigOptions {
   /**

--- a/packages/api/test/__fixtures__/sdk/petstore/index.d.ts
+++ b/packages/api/test/__fixtures__/sdk/petstore/index.d.ts
@@ -304,7 +304,8 @@ declare class SDK {
    */
   deleteUser<T = unknown>(metadata: DeleteUserMetadataParam): Promise<T>;
 }
-export default function createSDK(): SDK;
+declare const createSDK: SDK;
+export default createSDK;
 interface ConfigOptions {
   /**
    * By default we parse the response based on the `Content-Type` header of the request. You
@@ -491,4 +492,3 @@ declare type DeleteUserMetadataParam = {
   username: string;
   [k: string]: unknown;
 };
-export {};

--- a/packages/api/test/__fixtures__/sdk/petstore/index.d.ts
+++ b/packages/api/test/__fixtures__/sdk/petstore/index.d.ts
@@ -1,6 +1,6 @@
 import Oas from 'oas';
 import APICore from 'api/dist/core';
-export default class SDK {
+declare class SDK {
   spec: Oas;
   core: APICore;
   authKeys: (number | string)[][];
@@ -304,6 +304,7 @@ export default class SDK {
    */
   deleteUser<T = unknown>(metadata: DeleteUserMetadataParam): Promise<T>;
 }
+export default function createSDK(): SDK;
 interface ConfigOptions {
   /**
    * By default we parse the response based on the `Content-Type` header of the request. You
@@ -311,7 +312,7 @@ interface ConfigOptions {
    */
   parseResponse: boolean;
 }
-export interface Pet {
+interface Pet {
   id?: number;
   category?: Category;
   name: string;
@@ -325,40 +326,40 @@ export interface Pet {
   status?: 'available' | 'pending' | 'sold';
   [k: string]: unknown;
 }
-export interface Category {
+interface Category {
   id?: number;
   name?: string;
   [k: string]: unknown;
 }
-export interface Tag {
+interface Tag {
   id?: number;
   name?: string;
   [k: string]: unknown;
 }
-export declare type FindPetsByStatusMetadataParam = {
+declare type FindPetsByStatusMetadataParam = {
   /**
    * Status values that need to be considered for filter
    */
   status: ('available' | 'pending' | 'sold')[];
   [k: string]: unknown;
 };
-export declare type FindPetsByStatus_Response_200 = Pet[];
-export declare type FindPetsByTagsMetadataParam = {
+declare type FindPetsByStatus_Response_200 = Pet[];
+declare type FindPetsByTagsMetadataParam = {
   /**
    * Tags to filter by
    */
   tags: string[];
   [k: string]: unknown;
 };
-export declare type FindPetsByTags_Response_200 = Pet[];
-export declare type GetPetByIdMetadataParam = {
+declare type FindPetsByTags_Response_200 = Pet[];
+declare type GetPetByIdMetadataParam = {
   /**
    * ID of pet to return
    */
   petId: number;
   [k: string]: unknown;
 };
-export interface UpdatePetWithFormFormDataParam {
+interface UpdatePetWithFormFormDataParam {
   /**
    * Updated name of the pet
    */
@@ -369,14 +370,14 @@ export interface UpdatePetWithFormFormDataParam {
   status?: string;
   [k: string]: unknown;
 }
-export declare type UpdatePetWithFormMetadataParam = {
+declare type UpdatePetWithFormMetadataParam = {
   /**
    * ID of pet that needs to be updated
    */
   petId: number;
   [k: string]: unknown;
 };
-export declare type DeletePetMetadataParam = {
+declare type DeletePetMetadataParam = {
   /**
    * Pet id to delete
    */
@@ -386,7 +387,7 @@ export declare type DeletePetMetadataParam = {
   api_key?: string;
   [k: string]: unknown;
 };
-export interface UploadFileBodyParam {
+interface UploadFileBodyParam {
   /**
    * Additional data to pass to server
    */
@@ -397,23 +398,23 @@ export interface UploadFileBodyParam {
   file?: string;
   [k: string]: unknown;
 }
-export declare type UploadFileMetadataParam = {
+declare type UploadFileMetadataParam = {
   /**
    * ID of pet to update
    */
   petId: number;
   [k: string]: unknown;
 };
-export interface ApiResponse {
+interface ApiResponse {
   code?: number;
   type?: string;
   message?: string;
   [k: string]: unknown;
 }
-export interface GetInventory_Response_200 {
+interface GetInventory_Response_200 {
   [k: string]: number;
 }
-export interface Order {
+interface Order {
   id?: number;
   petId?: number;
   quantity?: number;
@@ -427,21 +428,21 @@ export interface Order {
   complete?: boolean;
   [k: string]: unknown;
 }
-export declare type GetOrderByIdMetadataParam = {
+declare type GetOrderByIdMetadataParam = {
   /**
    * ID of pet that needs to be fetched
    */
   orderId: number;
   [k: string]: unknown;
 };
-export declare type DeleteOrderMetadataParam = {
+declare type DeleteOrderMetadataParam = {
   /**
    * ID of the order that needs to be deleted
    */
   orderId: number;
   [k: string]: unknown;
 };
-export interface User {
+interface User {
   id?: number;
   username?: string;
   firstName?: string;
@@ -455,9 +456,9 @@ export interface User {
   userStatus?: number;
   [k: string]: unknown;
 }
-export declare type CreateUsersWithArrayInputBodyParam = User[];
-export declare type CreateUsersWithListInputBodyParam = User[];
-export declare type LoginUserMetadataParam = {
+declare type CreateUsersWithArrayInputBodyParam = User[];
+declare type CreateUsersWithListInputBodyParam = User[];
+declare type LoginUserMetadataParam = {
   /**
    * The user name for login
    */
@@ -468,22 +469,22 @@ export declare type LoginUserMetadataParam = {
   password: string;
   [k: string]: unknown;
 };
-export declare type LoginUser_Response_200 = string;
-export declare type GetUserByNameMetadataParam = {
+declare type LoginUser_Response_200 = string;
+declare type GetUserByNameMetadataParam = {
   /**
    * The name that needs to be fetched. Use user1 for testing.
    */
   username: string;
   [k: string]: unknown;
 };
-export declare type UpdateUserMetadataParam = {
+declare type UpdateUserMetadataParam = {
   /**
    * name that need to be updated
    */
   username: string;
   [k: string]: unknown;
 };
-export declare type DeleteUserMetadataParam = {
+declare type DeleteUserMetadataParam = {
   /**
    * The name that needs to be deleted
    */

--- a/packages/api/test/__fixtures__/sdk/petstore/index.ts
+++ b/packages/api/test/__fixtures__/sdk/petstore/index.ts
@@ -1,6 +1,6 @@
 import Oas from 'oas';
 import APICore from 'api/dist/core';
-import definition from './openapi.json';
+import definition from '@readme/oas-examples/3.0/json/petstore.json';
 
 export default class SDK {
   spec: Oas;

--- a/packages/api/test/__fixtures__/sdk/petstore/index.ts
+++ b/packages/api/test/__fixtures__/sdk/petstore/index.ts
@@ -2,7 +2,7 @@ import Oas from 'oas';
 import APICore from 'api/dist/core';
 import definition from '@readme/oas-examples/3.0/json/petstore.json';
 
-export default class SDK {
+class SDK {
   spec: Oas;
   core: APICore;
   authKeys: (number | string)[][] = [];
@@ -437,6 +437,10 @@ export default class SDK {
   }
 }
 
+export default function createSDK(): SDK {
+  return new SDK();
+}
+
 interface ConfigOptions {
   /**
    * By default we parse the response based on the `Content-Type` header of the request. You
@@ -444,7 +448,7 @@ interface ConfigOptions {
    */
   parseResponse: boolean;
 }
-export interface Pet {
+interface Pet {
   id?: number;
   category?: Category;
   name: string;
@@ -458,40 +462,40 @@ export interface Pet {
   status?: 'available' | 'pending' | 'sold';
   [k: string]: unknown;
 }
-export interface Category {
+interface Category {
   id?: number;
   name?: string;
   [k: string]: unknown;
 }
-export interface Tag {
+interface Tag {
   id?: number;
   name?: string;
   [k: string]: unknown;
 }
-export type FindPetsByStatusMetadataParam = {
+type FindPetsByStatusMetadataParam = {
   /**
    * Status values that need to be considered for filter
    */
   status: ('available' | 'pending' | 'sold')[];
   [k: string]: unknown;
 };
-export type FindPetsByStatus_Response_200 = Pet[];
-export type FindPetsByTagsMetadataParam = {
+type FindPetsByStatus_Response_200 = Pet[];
+type FindPetsByTagsMetadataParam = {
   /**
    * Tags to filter by
    */
   tags: string[];
   [k: string]: unknown;
 };
-export type FindPetsByTags_Response_200 = Pet[];
-export type GetPetByIdMetadataParam = {
+type FindPetsByTags_Response_200 = Pet[];
+type GetPetByIdMetadataParam = {
   /**
    * ID of pet to return
    */
   petId: number;
   [k: string]: unknown;
 };
-export interface UpdatePetWithFormFormDataParam {
+interface UpdatePetWithFormFormDataParam {
   /**
    * Updated name of the pet
    */
@@ -502,14 +506,14 @@ export interface UpdatePetWithFormFormDataParam {
   status?: string;
   [k: string]: unknown;
 }
-export type UpdatePetWithFormMetadataParam = {
+type UpdatePetWithFormMetadataParam = {
   /**
    * ID of pet that needs to be updated
    */
   petId: number;
   [k: string]: unknown;
 };
-export type DeletePetMetadataParam = {
+type DeletePetMetadataParam = {
   /**
    * Pet id to delete
    */
@@ -519,7 +523,7 @@ export type DeletePetMetadataParam = {
   api_key?: string;
   [k: string]: unknown;
 };
-export interface UploadFileBodyParam {
+interface UploadFileBodyParam {
   /**
    * Additional data to pass to server
    */
@@ -530,23 +534,23 @@ export interface UploadFileBodyParam {
   file?: string;
   [k: string]: unknown;
 }
-export type UploadFileMetadataParam = {
+type UploadFileMetadataParam = {
   /**
    * ID of pet to update
    */
   petId: number;
   [k: string]: unknown;
 };
-export interface ApiResponse {
+interface ApiResponse {
   code?: number;
   type?: string;
   message?: string;
   [k: string]: unknown;
 }
-export interface GetInventory_Response_200 {
+interface GetInventory_Response_200 {
   [k: string]: number;
 }
-export interface Order {
+interface Order {
   id?: number;
   petId?: number;
   quantity?: number;
@@ -560,21 +564,21 @@ export interface Order {
   complete?: boolean;
   [k: string]: unknown;
 }
-export type GetOrderByIdMetadataParam = {
+type GetOrderByIdMetadataParam = {
   /**
    * ID of pet that needs to be fetched
    */
   orderId: number;
   [k: string]: unknown;
 };
-export type DeleteOrderMetadataParam = {
+type DeleteOrderMetadataParam = {
   /**
    * ID of the order that needs to be deleted
    */
   orderId: number;
   [k: string]: unknown;
 };
-export interface User {
+interface User {
   id?: number;
   username?: string;
   firstName?: string;
@@ -588,9 +592,9 @@ export interface User {
   userStatus?: number;
   [k: string]: unknown;
 }
-export type CreateUsersWithArrayInputBodyParam = User[];
-export type CreateUsersWithListInputBodyParam = User[];
-export type LoginUserMetadataParam = {
+type CreateUsersWithArrayInputBodyParam = User[];
+type CreateUsersWithListInputBodyParam = User[];
+type LoginUserMetadataParam = {
   /**
    * The user name for login
    */
@@ -601,22 +605,22 @@ export type LoginUserMetadataParam = {
   password: string;
   [k: string]: unknown;
 };
-export type LoginUser_Response_200 = string;
-export type GetUserByNameMetadataParam = {
+type LoginUser_Response_200 = string;
+type GetUserByNameMetadataParam = {
   /**
    * The name that needs to be fetched. Use user1 for testing.
    */
   username: string;
   [k: string]: unknown;
 };
-export type UpdateUserMetadataParam = {
+type UpdateUserMetadataParam = {
   /**
    * name that need to be updated
    */
   username: string;
   [k: string]: unknown;
 };
-export type DeleteUserMetadataParam = {
+type DeleteUserMetadataParam = {
   /**
    * The name that needs to be deleted
    */

--- a/packages/api/test/__fixtures__/sdk/petstore/index.ts
+++ b/packages/api/test/__fixtures__/sdk/petstore/index.ts
@@ -437,9 +437,10 @@ class SDK {
   }
 }
 
-export default function createSDK(): SDK {
+const createSDK = (() => {
   return new SDK();
-}
+})();
+export default createSDK;
 
 interface ConfigOptions {
   /**

--- a/packages/api/test/__fixtures__/sdk/readme/index.d.ts
+++ b/packages/api/test/__fixtures__/sdk/readme/index.d.ts
@@ -645,7 +645,8 @@ declare class SDK {
     Error_VERSION_CANT_REMOVE_STABLE | DeleteVersion_Response_401 | DeleteVersion_Response_403 | Error_VERSION_NOTFOUND
   >;
 }
-export default function createSDK(): SDK;
+declare const createSDK: SDK;
+export default createSDK;
 interface ConfigOptions {
   /**
    * By default we parse the response based on the `Content-Type` header of the request. You
@@ -1912,4 +1913,3 @@ interface Error_VERSION_CANT_REMOVE_STABLE {
 }
 declare type DeleteVersion_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
 declare type DeleteVersion_Response_403 = Error_APIKEY_MISMATCH;
-export {};

--- a/packages/api/test/__fixtures__/sdk/readme/index.d.ts
+++ b/packages/api/test/__fixtures__/sdk/readme/index.d.ts
@@ -1,6 +1,6 @@
 import Oas from 'oas';
 import APICore from 'api/dist/core';
-export default class SDK {
+declare class SDK {
   spec: Oas;
   core: APICore;
   authKeys: (number | string)[][];
@@ -645,6 +645,7 @@ export default class SDK {
     Error_VERSION_CANT_REMOVE_STABLE | DeleteVersion_Response_401 | DeleteVersion_Response_403 | Error_VERSION_NOTFOUND
   >;
 }
+export default function createSDK(): SDK;
 interface ConfigOptions {
   /**
    * By default we parse the response based on the `Content-Type` header of the request. You
@@ -652,17 +653,17 @@ interface ConfigOptions {
    */
   parseResponse: boolean;
 }
-export declare type GetAPIRegistryMetadataParam = {
+declare type GetAPIRegistryMetadataParam = {
   /**
    * An API Registry UUID. This can be found by navigating to your API Reference page and viewing code snippets for Node with the `api` library.
    */
   uuid: string;
   [k: string]: unknown;
 };
-export interface GetAPIRegistry_Response_200 {
+interface GetAPIRegistry_Response_200 {
   [k: string]: unknown;
 }
-export interface Error_REGISTRY_NOTFOUND {
+interface Error_REGISTRY_NOTFOUND {
   /**
    * An error code unique to the error received.
    */
@@ -689,7 +690,7 @@ export interface Error_REGISTRY_NOTFOUND {
   poem?: string[];
   [k: string]: unknown;
 }
-export declare type GetAPISpecificationMetadataParam = {
+declare type GetAPISpecificationMetadataParam = {
   /**
    * Number of items to include in pagination (up to 100, defaults to 10)
    */
@@ -706,7 +707,7 @@ export declare type GetAPISpecificationMetadataParam = {
   'x-readme-version'?: string;
   [k: string]: unknown;
 };
-export interface GetAPISpecification_Response_200 {
+interface GetAPISpecification_Response_200 {
   /**
    * Pagination information. See https://docs.readme.com/reference/pagination for more information.
    */
@@ -717,7 +718,7 @@ export interface GetAPISpecification_Response_200 {
   'x-total-count'?: string;
   [k: string]: unknown;
 }
-export interface Error_VERSION_EMPTY {
+interface Error_VERSION_EMPTY {
   /**
    * An error code unique to the error received.
    */
@@ -744,8 +745,8 @@ export interface Error_VERSION_EMPTY {
   poem?: string[];
   [k: string]: unknown;
 }
-export declare type GetAPISpecification_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
-export interface Error_APIKEY_EMPTY {
+declare type GetAPISpecification_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
+interface Error_APIKEY_EMPTY {
   /**
    * An error code unique to the error received.
    */
@@ -772,7 +773,7 @@ export interface Error_APIKEY_EMPTY {
   poem?: string[];
   [k: string]: unknown;
 }
-export interface Error_APIKEY_NOTFOUND {
+interface Error_APIKEY_NOTFOUND {
   /**
    * An error code unique to the error received.
    */
@@ -799,8 +800,8 @@ export interface Error_APIKEY_NOTFOUND {
   poem?: string[];
   [k: string]: unknown;
 }
-export declare type GetAPISpecification_Response_403 = Error_APIKEY_MISMATCH;
-export interface Error_APIKEY_MISMATCH {
+declare type GetAPISpecification_Response_403 = Error_APIKEY_MISMATCH;
+interface Error_APIKEY_MISMATCH {
   /**
    * An error code unique to the error received.
    */
@@ -827,7 +828,7 @@ export interface Error_APIKEY_MISMATCH {
   poem?: string[];
   [k: string]: unknown;
 }
-export interface Error_VERSION_NOTFOUND {
+interface Error_VERSION_NOTFOUND {
   /**
    * An error code unique to the error received.
    */
@@ -854,26 +855,26 @@ export interface Error_VERSION_NOTFOUND {
   poem?: string[];
   [k: string]: unknown;
 }
-export interface UploadAPISpecificationBodyParam {
+interface UploadAPISpecificationBodyParam {
   /**
    * OpenAPI/Swagger file
    */
   spec?: string;
   [k: string]: unknown;
 }
-export declare type UploadAPISpecificationMetadataParam = {
+declare type UploadAPISpecificationMetadataParam = {
   /**
    * Version number of your docs project, for example, v3.0. By default the main project version is used. To see all valid versions for your docs project call https://docs.readme.com/reference/version#getversions.
    */
   'x-readme-version'?: string;
   [k: string]: unknown;
 };
-export declare type UploadAPISpecification_Response_400 =
+declare type UploadAPISpecification_Response_400 =
   | Error_SPEC_FILE_EMPTY
   | Error_SPEC_INVALID
   | Error_SPEC_INVALID_SCHEMA
   | Error_SPEC_VERSION_NOTFOUND;
-export interface Error_SPEC_FILE_EMPTY {
+interface Error_SPEC_FILE_EMPTY {
   /**
    * An error code unique to the error received.
    */
@@ -900,7 +901,7 @@ export interface Error_SPEC_FILE_EMPTY {
   poem?: string[];
   [k: string]: unknown;
 }
-export interface Error_SPEC_INVALID {
+interface Error_SPEC_INVALID {
   /**
    * An error code unique to the error received.
    */
@@ -927,7 +928,7 @@ export interface Error_SPEC_INVALID {
   poem?: string[];
   [k: string]: unknown;
 }
-export interface Error_SPEC_INVALID_SCHEMA {
+interface Error_SPEC_INVALID_SCHEMA {
   /**
    * An error code unique to the error received.
    */
@@ -954,7 +955,7 @@ export interface Error_SPEC_INVALID_SCHEMA {
   poem?: string[];
   [k: string]: unknown;
 }
-export interface Error_SPEC_VERSION_NOTFOUND {
+interface Error_SPEC_VERSION_NOTFOUND {
   /**
    * An error code unique to the error received.
    */
@@ -981,9 +982,9 @@ export interface Error_SPEC_VERSION_NOTFOUND {
   poem?: string[];
   [k: string]: unknown;
 }
-export declare type UploadAPISpecification_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
-export declare type UploadAPISpecification_Response_403 = Error_APIKEY_MISMATCH;
-export interface Error_SPEC_TIMEOUT {
+declare type UploadAPISpecification_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
+declare type UploadAPISpecification_Response_403 = Error_APIKEY_MISMATCH;
+interface Error_SPEC_TIMEOUT {
   /**
    * An error code unique to the error received.
    */
@@ -1010,28 +1011,28 @@ export interface Error_SPEC_TIMEOUT {
   poem?: string[];
   [k: string]: unknown;
 }
-export interface UpdateAPISpecificationBodyParam {
+interface UpdateAPISpecificationBodyParam {
   /**
    * OpenAPI/Swagger file
    */
   spec?: string;
   [k: string]: unknown;
 }
-export declare type UpdateAPISpecificationMetadataParam = {
+declare type UpdateAPISpecificationMetadataParam = {
   /**
    * ID of the API specification. The unique ID for each API can be found by navigating to your **API Definitions** page.
    */
   id: string;
   [k: string]: unknown;
 };
-export declare type UpdateAPISpecification_Response_400 =
+declare type UpdateAPISpecification_Response_400 =
   | Error_SPEC_FILE_EMPTY
   | Error_SPEC_ID_DUPLICATE
   | Error_SPEC_ID_INVALID
   | Error_SPEC_INVALID
   | Error_SPEC_INVALID_SCHEMA
   | Error_SPEC_VERSION_NOTFOUND;
-export interface Error_SPEC_ID_DUPLICATE {
+interface Error_SPEC_ID_DUPLICATE {
   /**
    * An error code unique to the error received.
    */
@@ -1058,7 +1059,7 @@ export interface Error_SPEC_ID_DUPLICATE {
   poem?: string[];
   [k: string]: unknown;
 }
-export interface Error_SPEC_ID_INVALID {
+interface Error_SPEC_ID_INVALID {
   /**
    * An error code unique to the error received.
    */
@@ -1085,18 +1086,18 @@ export interface Error_SPEC_ID_INVALID {
   poem?: string[];
   [k: string]: unknown;
 }
-export declare type UpdateAPISpecification_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
-export declare type UpdateAPISpecification_Response_403 = Error_APIKEY_MISMATCH;
-export declare type DeleteAPISpecificationMetadataParam = {
+declare type UpdateAPISpecification_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
+declare type UpdateAPISpecification_Response_403 = Error_APIKEY_MISMATCH;
+declare type DeleteAPISpecificationMetadataParam = {
   /**
    * ID of the API specification. The unique ID for each API can be found by navigating to your **API Definitions** page.
    */
   id: string;
   [k: string]: unknown;
 };
-export declare type DeleteAPISpecification_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
-export declare type DeleteAPISpecification_Response_403 = Error_APIKEY_MISMATCH;
-export interface Error_SPEC_NOTFOUND {
+declare type DeleteAPISpecification_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
+declare type DeleteAPISpecification_Response_403 = Error_APIKEY_MISMATCH;
+interface Error_SPEC_NOTFOUND {
   /**
    * An error code unique to the error received.
    */
@@ -1123,8 +1124,8 @@ export interface Error_SPEC_NOTFOUND {
   poem?: string[];
   [k: string]: unknown;
 }
-export declare type GetOpenRoles_Response_200 = JobOpening[];
-export interface JobOpening {
+declare type GetOpenRoles_Response_200 = JobOpening[];
+interface JobOpening {
   /**
    * A slugified version of the job opening title.
    */
@@ -1155,7 +1156,7 @@ export interface JobOpening {
   url?: string;
   [k: string]: unknown;
 }
-export interface Apply {
+interface Apply {
   /**
    * Your full name
    */
@@ -1199,7 +1200,7 @@ export interface Apply {
   dontReallyApply?: boolean;
   [k: string]: unknown;
 }
-export declare type GetCategoriesMetadataParam = {
+declare type GetCategoriesMetadataParam = {
   /**
    * Number of items to include in pagination (up to 100, defaults to 10)
    */
@@ -1216,7 +1217,7 @@ export declare type GetCategoriesMetadataParam = {
   'x-readme-version'?: string;
   [k: string]: unknown;
 };
-export interface GetCategories_Response_200 {
+interface GetCategories_Response_200 {
   /**
    * Pagination information. See https://docs.readme.com/reference/pagination for more information.
    */
@@ -1227,7 +1228,7 @@ export interface GetCategories_Response_200 {
   'x-total-count'?: string;
   [k: string]: unknown;
 }
-export interface Category {
+interface Category {
   /**
    * A short title for the category. This is what will show in the sidebar.
    */
@@ -1238,14 +1239,14 @@ export interface Category {
   type?: 'reference' | 'guide';
   [k: string]: unknown;
 }
-export declare type CreateCategoryMetadataParam = {
+declare type CreateCategoryMetadataParam = {
   /**
    * Version number of your docs project, for example, v3.0. By default the main project version is used. To see all valid versions for your docs project call https://docs.readme.com/reference/version#getversions.
    */
   'x-readme-version'?: string;
   [k: string]: unknown;
 };
-export interface Error_CATEGORY_INVALID {
+interface Error_CATEGORY_INVALID {
   /**
    * An error code unique to the error received.
    */
@@ -1272,7 +1273,7 @@ export interface Error_CATEGORY_INVALID {
   poem?: string[];
   [k: string]: unknown;
 }
-export declare type GetCategoryMetadataParam = {
+declare type GetCategoryMetadataParam = {
   /**
    * A URL-safe representation of the category title. Slugs must be all lowercase, and replace spaces with hyphens. For example, for the the category "Getting Started", enter the slug "getting-started"
    */
@@ -1285,7 +1286,7 @@ export declare type GetCategoryMetadataParam = {
   'x-readme-version'?: string;
   [k: string]: unknown;
 };
-export interface Error_CATEGORY_NOTFOUND {
+interface Error_CATEGORY_NOTFOUND {
   /**
    * An error code unique to the error received.
    */
@@ -1312,7 +1313,7 @@ export interface Error_CATEGORY_NOTFOUND {
   poem?: string[];
   [k: string]: unknown;
 }
-export declare type UpdateCategoryMetadataParam = {
+declare type UpdateCategoryMetadataParam = {
   /**
    * A URL-safe representation of the category title. Slugs must be all lowercase, and replace spaces with hyphens. For example, for the the category "Getting Started", enter the slug "getting-started"
    */
@@ -1325,7 +1326,7 @@ export declare type UpdateCategoryMetadataParam = {
   'x-readme-version'?: string;
   [k: string]: unknown;
 };
-export declare type DeleteCategoryMetadataParam = {
+declare type DeleteCategoryMetadataParam = {
   /**
    * A URL-safe representation of the category title. Slugs must be all lowercase, and replace spaces with hyphens. For example, for the the category "Getting Started", enter the slug "getting-started"
    */
@@ -1338,7 +1339,7 @@ export declare type DeleteCategoryMetadataParam = {
   'x-readme-version'?: string;
   [k: string]: unknown;
 };
-export declare type GetCategoryDocsMetadataParam = {
+declare type GetCategoryDocsMetadataParam = {
   /**
    * A URL-safe representation of the category title. Slugs must be all lowercase, and replace spaces with hyphens. For example, for the the category "Getting Started", enter the slug "getting-started"
    */
@@ -1351,7 +1352,7 @@ export declare type GetCategoryDocsMetadataParam = {
   'x-readme-version'?: string;
   [k: string]: unknown;
 };
-export declare type GetChangelogsMetadataParam = {
+declare type GetChangelogsMetadataParam = {
   /**
    * Number of items to include in pagination (up to 100, defaults to 10)
    */
@@ -1362,7 +1363,7 @@ export declare type GetChangelogsMetadataParam = {
   page?: number;
   [k: string]: unknown;
 };
-export interface GetChangelogs_Response_200 {
+interface GetChangelogs_Response_200 {
   /**
    * Pagination information. See https://docs.readme.com/reference/pagination for more information.
    */
@@ -1373,7 +1374,7 @@ export interface GetChangelogs_Response_200 {
   'x-total-count'?: string;
   [k: string]: unknown;
 }
-export interface Changelog {
+interface Changelog {
   /**
    * Title of the changelog
    */
@@ -1389,28 +1390,28 @@ export interface Changelog {
   hidden?: boolean;
   [k: string]: unknown;
 }
-export declare type GetChangelogMetadataParam = {
+declare type GetChangelogMetadataParam = {
   /**
    * A URL-safe representation of the changelog title. Slugs must be all lowercase, and replace spaces with hyphens. For example, for the the changelog "Owlet Weekly Update", enter the slug "owlet-weekly-update"
    */
   slug: string;
   [k: string]: unknown;
 };
-export declare type UpdateChangelogMetadataParam = {
+declare type UpdateChangelogMetadataParam = {
   /**
    * A URL-safe representation of the changelog title. Slugs must be all lowercase, and replace spaces with hyphens. For example, for the the changelog "Owlet Weekly Update", enter the slug "owlet-weekly-update"
    */
   slug: string;
   [k: string]: unknown;
 };
-export declare type DeleteChangelogMetadataParam = {
+declare type DeleteChangelogMetadataParam = {
   /**
    * A URL-safe representation of the changelog title. Slugs must be all lowercase, and replace spaces with hyphens. For example, for the the changelog "Owlet Weekly Update", enter the slug "owlet-weekly-update"
    */
   slug: string;
   [k: string]: unknown;
 };
-export declare type GetCustomPagesMetadataParam = {
+declare type GetCustomPagesMetadataParam = {
   /**
    * Number of items to include in pagination (up to 100, defaults to 10)
    */
@@ -1421,7 +1422,7 @@ export declare type GetCustomPagesMetadataParam = {
   page?: number;
   [k: string]: unknown;
 };
-export interface GetCustomPages_Response_200 {
+interface GetCustomPages_Response_200 {
   /**
    * Pagination information. See https://docs.readme.com/reference/pagination for more information.
    */
@@ -1432,9 +1433,9 @@ export interface GetCustomPages_Response_200 {
   'x-total-count'?: string;
   [k: string]: unknown;
 }
-export declare type GetCustomPages_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
-export declare type GetCustomPages_Response_403 = Error_APIKEY_MISMATCH;
-export interface CustomPage {
+declare type GetCustomPages_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
+declare type GetCustomPages_Response_403 = Error_APIKEY_MISMATCH;
+interface CustomPage {
   /**
    * Title of the custom page
    */
@@ -1457,7 +1458,7 @@ export interface CustomPage {
   hidden?: boolean;
   [k: string]: unknown;
 }
-export interface Error_CUSTOMPAGE_INVALID {
+interface Error_CUSTOMPAGE_INVALID {
   /**
    * An error code unique to the error received.
    */
@@ -1484,18 +1485,18 @@ export interface Error_CUSTOMPAGE_INVALID {
   poem?: string[];
   [k: string]: unknown;
 }
-export declare type CreateCustomPage_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
-export declare type CreateCustomPage_Response_403 = Error_APIKEY_MISMATCH;
-export declare type GetCustomPageMetadataParam = {
+declare type CreateCustomPage_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
+declare type CreateCustomPage_Response_403 = Error_APIKEY_MISMATCH;
+declare type GetCustomPageMetadataParam = {
   /**
    * A URL-safe representation of the custom page title. Slugs must be all lowercase, and replace spaces with hyphens. For example, for the the custom page "Getting Started", enter the slug "getting-started"
    */
   slug: string;
   [k: string]: unknown;
 };
-export declare type GetCustomPage_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
-export declare type GetCustomPage_Response_403 = Error_APIKEY_MISMATCH;
-export interface Error_CUSTOMPAGE_NOTFOUND {
+declare type GetCustomPage_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
+declare type GetCustomPage_Response_403 = Error_APIKEY_MISMATCH;
+interface Error_CUSTOMPAGE_NOTFOUND {
   /**
    * An error code unique to the error received.
    */
@@ -1522,25 +1523,25 @@ export interface Error_CUSTOMPAGE_NOTFOUND {
   poem?: string[];
   [k: string]: unknown;
 }
-export declare type UpdateCustomPageMetadataParam = {
+declare type UpdateCustomPageMetadataParam = {
   /**
    * A URL-safe representation of the custom page title. Slugs must be all lowercase, and replace spaces with hyphens. For example, for the the custom page "Getting Started", enter the slug "getting-started"
    */
   slug: string;
   [k: string]: unknown;
 };
-export declare type UpdateCustomPage_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
-export declare type UpdateCustomPage_Response_403 = Error_APIKEY_MISMATCH;
-export declare type DeleteCustomPageMetadataParam = {
+declare type UpdateCustomPage_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
+declare type UpdateCustomPage_Response_403 = Error_APIKEY_MISMATCH;
+declare type DeleteCustomPageMetadataParam = {
   /**
    * A URL-safe representation of the custom page title. Slugs must be all lowercase, and replace spaces with hyphens. For example, for the the custom page "Getting Started", enter the slug "getting-started"
    */
   slug: string;
   [k: string]: unknown;
 };
-export declare type DeleteCustomPage_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
-export declare type DeleteCustomPage_Response_403 = Error_APIKEY_MISMATCH;
-export declare type GetDocMetadataParam = {
+declare type DeleteCustomPage_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
+declare type DeleteCustomPage_Response_403 = Error_APIKEY_MISMATCH;
+declare type GetDocMetadataParam = {
   /**
    * A URL-safe representation of the doc title. Slugs must be all lowercase, and replace spaces with hyphens. For example, for the the doc "New Features", enter the slug "new-features"
    */
@@ -1553,9 +1554,9 @@ export declare type GetDocMetadataParam = {
   'x-readme-version'?: string;
   [k: string]: unknown;
 };
-export declare type GetDoc_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
-export declare type GetDoc_Response_403 = Error_APIKEY_MISMATCH;
-export interface Error_DOC_NOTFOUND {
+declare type GetDoc_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
+declare type GetDoc_Response_403 = Error_APIKEY_MISMATCH;
+interface Error_DOC_NOTFOUND {
   /**
    * An error code unique to the error received.
    */
@@ -1582,7 +1583,7 @@ export interface Error_DOC_NOTFOUND {
   poem?: string[];
   [k: string]: unknown;
 }
-export interface Doc {
+interface Doc {
   /**
    * Title of the page
    */
@@ -1620,7 +1621,7 @@ export interface Doc {
   };
   [k: string]: unknown;
 }
-export declare type UpdateDocMetadataParam = {
+declare type UpdateDocMetadataParam = {
   /**
    * A URL-safe representation of the doc title. Slugs must be all lowercase, and replace spaces with hyphens. For example, for the the doc "New Features", enter the slug "new-features"
    */
@@ -1633,7 +1634,7 @@ export declare type UpdateDocMetadataParam = {
   'x-readme-version'?: string;
   [k: string]: unknown;
 };
-export interface Error_DOC_INVALID {
+interface Error_DOC_INVALID {
   /**
    * An error code unique to the error received.
    */
@@ -1660,9 +1661,9 @@ export interface Error_DOC_INVALID {
   poem?: string[];
   [k: string]: unknown;
 }
-export declare type UpdateDoc_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
-export declare type UpdateDoc_Response_403 = Error_APIKEY_MISMATCH;
-export declare type DeleteDocMetadataParam = {
+declare type UpdateDoc_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
+declare type UpdateDoc_Response_403 = Error_APIKEY_MISMATCH;
+declare type DeleteDocMetadataParam = {
   /**
    * A URL-safe representation of the doc title. Slugs must be all lowercase, and replace spaces with hyphens. For example, for the the doc "New Features", enter the slug "new-features"
    */
@@ -1675,18 +1676,18 @@ export declare type DeleteDocMetadataParam = {
   'x-readme-version'?: string;
   [k: string]: unknown;
 };
-export declare type DeleteDoc_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
-export declare type DeleteDoc_Response_403 = Error_APIKEY_MISMATCH;
-export declare type CreateDocMetadataParam = {
+declare type DeleteDoc_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
+declare type DeleteDoc_Response_403 = Error_APIKEY_MISMATCH;
+declare type CreateDocMetadataParam = {
   /**
    * Version number of your docs project, for example, v3.0. By default the main project version is used. To see all valid versions for your docs project call https://docs.readme.com/reference/version#getversions.
    */
   'x-readme-version'?: string;
   [k: string]: unknown;
 };
-export declare type CreateDoc_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
-export declare type CreateDoc_Response_403 = Error_APIKEY_MISMATCH;
-export declare type SearchDocsMetadataParam = {
+declare type CreateDoc_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
+declare type CreateDoc_Response_403 = Error_APIKEY_MISMATCH;
+declare type SearchDocsMetadataParam = {
   /**
    * Search string to look for
    */
@@ -1699,11 +1700,11 @@ export declare type SearchDocsMetadataParam = {
   'x-readme-version'?: string;
   [k: string]: unknown;
 };
-export declare type SearchDocs_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
-export declare type SearchDocs_Response_403 = Error_APIKEY_MISMATCH;
-export declare type GetErrors_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
-export declare type GetErrors_Response_403 = Error_APIKEY_MISMATCH;
-export interface CondensedProjectData {
+declare type SearchDocs_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
+declare type SearchDocs_Response_403 = Error_APIKEY_MISMATCH;
+declare type GetErrors_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
+declare type GetErrors_Response_403 = Error_APIKEY_MISMATCH;
+interface CondensedProjectData {
   name?: string;
   subdomain?: string;
   jwtSecret?: string;
@@ -1714,11 +1715,11 @@ export interface CondensedProjectData {
   plan?: string;
   [k: string]: unknown;
 }
-export declare type GetProject_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
-export declare type GetProject_Response_403 = Error_APIKEY_MISMATCH;
-export declare type GetVersions_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
-export declare type GetVersions_Response_403 = Error_APIKEY_MISMATCH;
-export interface Version {
+declare type GetProject_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
+declare type GetProject_Response_403 = Error_APIKEY_MISMATCH;
+declare type GetVersions_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
+declare type GetVersions_Response_403 = Error_APIKEY_MISMATCH;
+interface Version {
   /**
    * Semantic Version
    */
@@ -1746,11 +1747,8 @@ export interface Version {
   is_deprecated?: boolean;
   [k: string]: unknown;
 }
-export declare type CreateVersion_Response_400 =
-  | Error_VERSION_EMPTY
-  | Error_VERSION_DUPLICATE
-  | Error_VERSION_FORK_EMPTY;
-export interface Error_VERSION_DUPLICATE {
+declare type CreateVersion_Response_400 = Error_VERSION_EMPTY | Error_VERSION_DUPLICATE | Error_VERSION_FORK_EMPTY;
+interface Error_VERSION_DUPLICATE {
   /**
    * An error code unique to the error received.
    */
@@ -1777,7 +1775,7 @@ export interface Error_VERSION_DUPLICATE {
   poem?: string[];
   [k: string]: unknown;
 }
-export interface Error_VERSION_FORK_EMPTY {
+interface Error_VERSION_FORK_EMPTY {
   /**
    * An error code unique to the error received.
    */
@@ -1804,9 +1802,9 @@ export interface Error_VERSION_FORK_EMPTY {
   poem?: string[];
   [k: string]: unknown;
 }
-export declare type CreateVersion_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
-export declare type CreateVersion_Response_403 = Error_APIKEY_MISMATCH;
-export interface Error_VERSION_FORK_NOTFOUND {
+declare type CreateVersion_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
+declare type CreateVersion_Response_403 = Error_APIKEY_MISMATCH;
+interface Error_VERSION_FORK_NOTFOUND {
   /**
    * An error code unique to the error received.
    */
@@ -1833,23 +1831,23 @@ export interface Error_VERSION_FORK_NOTFOUND {
   poem?: string[];
   [k: string]: unknown;
 }
-export declare type GetVersionMetadataParam = {
+declare type GetVersionMetadataParam = {
   /**
    * Semver identifier for the project version. For best results, use the formatted `version_clean` value listed in the response from the [Get Versions endpoint](/reference/getversions).
    */
   versionId: string;
   [k: string]: unknown;
 };
-export declare type GetVersion_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
-export declare type GetVersion_Response_403 = Error_APIKEY_MISMATCH;
-export declare type UpdateVersionMetadataParam = {
+declare type GetVersion_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
+declare type GetVersion_Response_403 = Error_APIKEY_MISMATCH;
+declare type UpdateVersionMetadataParam = {
   /**
    * Semver identifier for the project version. For best results, use the formatted `version_clean` value listed in the response from the [Get Versions endpoint](/reference/getversions).
    */
   versionId: string;
   [k: string]: unknown;
 };
-export interface Error_VERSION_CANT_DEMOTE_STABLE {
+interface Error_VERSION_CANT_DEMOTE_STABLE {
   /**
    * An error code unique to the error received.
    */
@@ -1876,16 +1874,16 @@ export interface Error_VERSION_CANT_DEMOTE_STABLE {
   poem?: string[];
   [k: string]: unknown;
 }
-export declare type UpdateVersion_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
-export declare type UpdateVersion_Response_403 = Error_APIKEY_MISMATCH;
-export declare type DeleteVersionMetadataParam = {
+declare type UpdateVersion_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
+declare type UpdateVersion_Response_403 = Error_APIKEY_MISMATCH;
+declare type DeleteVersionMetadataParam = {
   /**
    * Semver identifier for the project version. For best results, use the formatted `version_clean` value listed in the response from the [Get Versions endpoint](/reference/getversions).
    */
   versionId: string;
   [k: string]: unknown;
 };
-export interface Error_VERSION_CANT_REMOVE_STABLE {
+interface Error_VERSION_CANT_REMOVE_STABLE {
   /**
    * An error code unique to the error received.
    */
@@ -1912,6 +1910,6 @@ export interface Error_VERSION_CANT_REMOVE_STABLE {
   poem?: string[];
   [k: string]: unknown;
 }
-export declare type DeleteVersion_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
-export declare type DeleteVersion_Response_403 = Error_APIKEY_MISMATCH;
+declare type DeleteVersion_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
+declare type DeleteVersion_Response_403 = Error_APIKEY_MISMATCH;
 export {};

--- a/packages/api/test/__fixtures__/sdk/readme/index.ts
+++ b/packages/api/test/__fixtures__/sdk/readme/index.ts
@@ -2,7 +2,7 @@ import Oas from 'oas';
 import APICore from 'api/dist/core';
 import definition from '@readme/oas-examples/3.0/json/readme.json';
 
-export default class SDK {
+class SDK {
   spec: Oas;
   core: APICore;
   authKeys: (number | string)[][] = [];
@@ -812,6 +812,10 @@ export default class SDK {
   }
 }
 
+export default function createSDK(): SDK {
+  return new SDK();
+}
+
 interface ConfigOptions {
   /**
    * By default we parse the response based on the `Content-Type` header of the request. You
@@ -819,17 +823,17 @@ interface ConfigOptions {
    */
   parseResponse: boolean;
 }
-export type GetAPIRegistryMetadataParam = {
+type GetAPIRegistryMetadataParam = {
   /**
    * An API Registry UUID. This can be found by navigating to your API Reference page and viewing code snippets for Node with the `api` library.
    */
   uuid: string;
   [k: string]: unknown;
 };
-export interface GetAPIRegistry_Response_200 {
+interface GetAPIRegistry_Response_200 {
   [k: string]: unknown;
 }
-export interface Error_REGISTRY_NOTFOUND {
+interface Error_REGISTRY_NOTFOUND {
   /**
    * An error code unique to the error received.
    */
@@ -856,7 +860,7 @@ export interface Error_REGISTRY_NOTFOUND {
   poem?: string[];
   [k: string]: unknown;
 }
-export type GetAPISpecificationMetadataParam = {
+type GetAPISpecificationMetadataParam = {
   /**
    * Number of items to include in pagination (up to 100, defaults to 10)
    */
@@ -873,7 +877,7 @@ export type GetAPISpecificationMetadataParam = {
   'x-readme-version'?: string;
   [k: string]: unknown;
 };
-export interface GetAPISpecification_Response_200 {
+interface GetAPISpecification_Response_200 {
   /**
    * Pagination information. See https://docs.readme.com/reference/pagination for more information.
    */
@@ -884,7 +888,7 @@ export interface GetAPISpecification_Response_200 {
   'x-total-count'?: string;
   [k: string]: unknown;
 }
-export interface Error_VERSION_EMPTY {
+interface Error_VERSION_EMPTY {
   /**
    * An error code unique to the error received.
    */
@@ -911,8 +915,8 @@ export interface Error_VERSION_EMPTY {
   poem?: string[];
   [k: string]: unknown;
 }
-export type GetAPISpecification_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
-export interface Error_APIKEY_EMPTY {
+type GetAPISpecification_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
+interface Error_APIKEY_EMPTY {
   /**
    * An error code unique to the error received.
    */
@@ -939,7 +943,7 @@ export interface Error_APIKEY_EMPTY {
   poem?: string[];
   [k: string]: unknown;
 }
-export interface Error_APIKEY_NOTFOUND {
+interface Error_APIKEY_NOTFOUND {
   /**
    * An error code unique to the error received.
    */
@@ -966,8 +970,8 @@ export interface Error_APIKEY_NOTFOUND {
   poem?: string[];
   [k: string]: unknown;
 }
-export type GetAPISpecification_Response_403 = Error_APIKEY_MISMATCH;
-export interface Error_APIKEY_MISMATCH {
+type GetAPISpecification_Response_403 = Error_APIKEY_MISMATCH;
+interface Error_APIKEY_MISMATCH {
   /**
    * An error code unique to the error received.
    */
@@ -994,7 +998,7 @@ export interface Error_APIKEY_MISMATCH {
   poem?: string[];
   [k: string]: unknown;
 }
-export interface Error_VERSION_NOTFOUND {
+interface Error_VERSION_NOTFOUND {
   /**
    * An error code unique to the error received.
    */
@@ -1021,26 +1025,26 @@ export interface Error_VERSION_NOTFOUND {
   poem?: string[];
   [k: string]: unknown;
 }
-export interface UploadAPISpecificationBodyParam {
+interface UploadAPISpecificationBodyParam {
   /**
    * OpenAPI/Swagger file
    */
   spec?: string;
   [k: string]: unknown;
 }
-export type UploadAPISpecificationMetadataParam = {
+type UploadAPISpecificationMetadataParam = {
   /**
    * Version number of your docs project, for example, v3.0. By default the main project version is used. To see all valid versions for your docs project call https://docs.readme.com/reference/version#getversions.
    */
   'x-readme-version'?: string;
   [k: string]: unknown;
 };
-export type UploadAPISpecification_Response_400 =
+type UploadAPISpecification_Response_400 =
   | Error_SPEC_FILE_EMPTY
   | Error_SPEC_INVALID
   | Error_SPEC_INVALID_SCHEMA
   | Error_SPEC_VERSION_NOTFOUND;
-export interface Error_SPEC_FILE_EMPTY {
+interface Error_SPEC_FILE_EMPTY {
   /**
    * An error code unique to the error received.
    */
@@ -1067,7 +1071,7 @@ export interface Error_SPEC_FILE_EMPTY {
   poem?: string[];
   [k: string]: unknown;
 }
-export interface Error_SPEC_INVALID {
+interface Error_SPEC_INVALID {
   /**
    * An error code unique to the error received.
    */
@@ -1094,7 +1098,7 @@ export interface Error_SPEC_INVALID {
   poem?: string[];
   [k: string]: unknown;
 }
-export interface Error_SPEC_INVALID_SCHEMA {
+interface Error_SPEC_INVALID_SCHEMA {
   /**
    * An error code unique to the error received.
    */
@@ -1121,7 +1125,7 @@ export interface Error_SPEC_INVALID_SCHEMA {
   poem?: string[];
   [k: string]: unknown;
 }
-export interface Error_SPEC_VERSION_NOTFOUND {
+interface Error_SPEC_VERSION_NOTFOUND {
   /**
    * An error code unique to the error received.
    */
@@ -1148,9 +1152,9 @@ export interface Error_SPEC_VERSION_NOTFOUND {
   poem?: string[];
   [k: string]: unknown;
 }
-export type UploadAPISpecification_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
-export type UploadAPISpecification_Response_403 = Error_APIKEY_MISMATCH;
-export interface Error_SPEC_TIMEOUT {
+type UploadAPISpecification_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
+type UploadAPISpecification_Response_403 = Error_APIKEY_MISMATCH;
+interface Error_SPEC_TIMEOUT {
   /**
    * An error code unique to the error received.
    */
@@ -1177,28 +1181,28 @@ export interface Error_SPEC_TIMEOUT {
   poem?: string[];
   [k: string]: unknown;
 }
-export interface UpdateAPISpecificationBodyParam {
+interface UpdateAPISpecificationBodyParam {
   /**
    * OpenAPI/Swagger file
    */
   spec?: string;
   [k: string]: unknown;
 }
-export type UpdateAPISpecificationMetadataParam = {
+type UpdateAPISpecificationMetadataParam = {
   /**
    * ID of the API specification. The unique ID for each API can be found by navigating to your **API Definitions** page.
    */
   id: string;
   [k: string]: unknown;
 };
-export type UpdateAPISpecification_Response_400 =
+type UpdateAPISpecification_Response_400 =
   | Error_SPEC_FILE_EMPTY
   | Error_SPEC_ID_DUPLICATE
   | Error_SPEC_ID_INVALID
   | Error_SPEC_INVALID
   | Error_SPEC_INVALID_SCHEMA
   | Error_SPEC_VERSION_NOTFOUND;
-export interface Error_SPEC_ID_DUPLICATE {
+interface Error_SPEC_ID_DUPLICATE {
   /**
    * An error code unique to the error received.
    */
@@ -1225,7 +1229,7 @@ export interface Error_SPEC_ID_DUPLICATE {
   poem?: string[];
   [k: string]: unknown;
 }
-export interface Error_SPEC_ID_INVALID {
+interface Error_SPEC_ID_INVALID {
   /**
    * An error code unique to the error received.
    */
@@ -1252,18 +1256,18 @@ export interface Error_SPEC_ID_INVALID {
   poem?: string[];
   [k: string]: unknown;
 }
-export type UpdateAPISpecification_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
-export type UpdateAPISpecification_Response_403 = Error_APIKEY_MISMATCH;
-export type DeleteAPISpecificationMetadataParam = {
+type UpdateAPISpecification_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
+type UpdateAPISpecification_Response_403 = Error_APIKEY_MISMATCH;
+type DeleteAPISpecificationMetadataParam = {
   /**
    * ID of the API specification. The unique ID for each API can be found by navigating to your **API Definitions** page.
    */
   id: string;
   [k: string]: unknown;
 };
-export type DeleteAPISpecification_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
-export type DeleteAPISpecification_Response_403 = Error_APIKEY_MISMATCH;
-export interface Error_SPEC_NOTFOUND {
+type DeleteAPISpecification_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
+type DeleteAPISpecification_Response_403 = Error_APIKEY_MISMATCH;
+interface Error_SPEC_NOTFOUND {
   /**
    * An error code unique to the error received.
    */
@@ -1290,8 +1294,8 @@ export interface Error_SPEC_NOTFOUND {
   poem?: string[];
   [k: string]: unknown;
 }
-export type GetOpenRoles_Response_200 = JobOpening[];
-export interface JobOpening {
+type GetOpenRoles_Response_200 = JobOpening[];
+interface JobOpening {
   /**
    * A slugified version of the job opening title.
    */
@@ -1322,7 +1326,7 @@ export interface JobOpening {
   url?: string;
   [k: string]: unknown;
 }
-export interface Apply {
+interface Apply {
   /**
    * Your full name
    */
@@ -1366,7 +1370,7 @@ export interface Apply {
   dontReallyApply?: boolean;
   [k: string]: unknown;
 }
-export type GetCategoriesMetadataParam = {
+type GetCategoriesMetadataParam = {
   /**
    * Number of items to include in pagination (up to 100, defaults to 10)
    */
@@ -1383,7 +1387,7 @@ export type GetCategoriesMetadataParam = {
   'x-readme-version'?: string;
   [k: string]: unknown;
 };
-export interface GetCategories_Response_200 {
+interface GetCategories_Response_200 {
   /**
    * Pagination information. See https://docs.readme.com/reference/pagination for more information.
    */
@@ -1394,7 +1398,7 @@ export interface GetCategories_Response_200 {
   'x-total-count'?: string;
   [k: string]: unknown;
 }
-export interface Category {
+interface Category {
   /**
    * A short title for the category. This is what will show in the sidebar.
    */
@@ -1405,14 +1409,14 @@ export interface Category {
   type?: 'reference' | 'guide';
   [k: string]: unknown;
 }
-export type CreateCategoryMetadataParam = {
+type CreateCategoryMetadataParam = {
   /**
    * Version number of your docs project, for example, v3.0. By default the main project version is used. To see all valid versions for your docs project call https://docs.readme.com/reference/version#getversions.
    */
   'x-readme-version'?: string;
   [k: string]: unknown;
 };
-export interface Error_CATEGORY_INVALID {
+interface Error_CATEGORY_INVALID {
   /**
    * An error code unique to the error received.
    */
@@ -1439,7 +1443,7 @@ export interface Error_CATEGORY_INVALID {
   poem?: string[];
   [k: string]: unknown;
 }
-export type GetCategoryMetadataParam = {
+type GetCategoryMetadataParam = {
   /**
    * A URL-safe representation of the category title. Slugs must be all lowercase, and replace spaces with hyphens. For example, for the the category "Getting Started", enter the slug "getting-started"
    */
@@ -1452,7 +1456,7 @@ export type GetCategoryMetadataParam = {
   'x-readme-version'?: string;
   [k: string]: unknown;
 };
-export interface Error_CATEGORY_NOTFOUND {
+interface Error_CATEGORY_NOTFOUND {
   /**
    * An error code unique to the error received.
    */
@@ -1479,7 +1483,7 @@ export interface Error_CATEGORY_NOTFOUND {
   poem?: string[];
   [k: string]: unknown;
 }
-export type UpdateCategoryMetadataParam = {
+type UpdateCategoryMetadataParam = {
   /**
    * A URL-safe representation of the category title. Slugs must be all lowercase, and replace spaces with hyphens. For example, for the the category "Getting Started", enter the slug "getting-started"
    */
@@ -1492,7 +1496,7 @@ export type UpdateCategoryMetadataParam = {
   'x-readme-version'?: string;
   [k: string]: unknown;
 };
-export type DeleteCategoryMetadataParam = {
+type DeleteCategoryMetadataParam = {
   /**
    * A URL-safe representation of the category title. Slugs must be all lowercase, and replace spaces with hyphens. For example, for the the category "Getting Started", enter the slug "getting-started"
    */
@@ -1505,7 +1509,7 @@ export type DeleteCategoryMetadataParam = {
   'x-readme-version'?: string;
   [k: string]: unknown;
 };
-export type GetCategoryDocsMetadataParam = {
+type GetCategoryDocsMetadataParam = {
   /**
    * A URL-safe representation of the category title. Slugs must be all lowercase, and replace spaces with hyphens. For example, for the the category "Getting Started", enter the slug "getting-started"
    */
@@ -1518,7 +1522,7 @@ export type GetCategoryDocsMetadataParam = {
   'x-readme-version'?: string;
   [k: string]: unknown;
 };
-export type GetChangelogsMetadataParam = {
+type GetChangelogsMetadataParam = {
   /**
    * Number of items to include in pagination (up to 100, defaults to 10)
    */
@@ -1529,7 +1533,7 @@ export type GetChangelogsMetadataParam = {
   page?: number;
   [k: string]: unknown;
 };
-export interface GetChangelogs_Response_200 {
+interface GetChangelogs_Response_200 {
   /**
    * Pagination information. See https://docs.readme.com/reference/pagination for more information.
    */
@@ -1540,7 +1544,7 @@ export interface GetChangelogs_Response_200 {
   'x-total-count'?: string;
   [k: string]: unknown;
 }
-export interface Changelog {
+interface Changelog {
   /**
    * Title of the changelog
    */
@@ -1556,28 +1560,28 @@ export interface Changelog {
   hidden?: boolean;
   [k: string]: unknown;
 }
-export type GetChangelogMetadataParam = {
+type GetChangelogMetadataParam = {
   /**
    * A URL-safe representation of the changelog title. Slugs must be all lowercase, and replace spaces with hyphens. For example, for the the changelog "Owlet Weekly Update", enter the slug "owlet-weekly-update"
    */
   slug: string;
   [k: string]: unknown;
 };
-export type UpdateChangelogMetadataParam = {
+type UpdateChangelogMetadataParam = {
   /**
    * A URL-safe representation of the changelog title. Slugs must be all lowercase, and replace spaces with hyphens. For example, for the the changelog "Owlet Weekly Update", enter the slug "owlet-weekly-update"
    */
   slug: string;
   [k: string]: unknown;
 };
-export type DeleteChangelogMetadataParam = {
+type DeleteChangelogMetadataParam = {
   /**
    * A URL-safe representation of the changelog title. Slugs must be all lowercase, and replace spaces with hyphens. For example, for the the changelog "Owlet Weekly Update", enter the slug "owlet-weekly-update"
    */
   slug: string;
   [k: string]: unknown;
 };
-export type GetCustomPagesMetadataParam = {
+type GetCustomPagesMetadataParam = {
   /**
    * Number of items to include in pagination (up to 100, defaults to 10)
    */
@@ -1588,7 +1592,7 @@ export type GetCustomPagesMetadataParam = {
   page?: number;
   [k: string]: unknown;
 };
-export interface GetCustomPages_Response_200 {
+interface GetCustomPages_Response_200 {
   /**
    * Pagination information. See https://docs.readme.com/reference/pagination for more information.
    */
@@ -1599,9 +1603,9 @@ export interface GetCustomPages_Response_200 {
   'x-total-count'?: string;
   [k: string]: unknown;
 }
-export type GetCustomPages_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
-export type GetCustomPages_Response_403 = Error_APIKEY_MISMATCH;
-export interface CustomPage {
+type GetCustomPages_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
+type GetCustomPages_Response_403 = Error_APIKEY_MISMATCH;
+interface CustomPage {
   /**
    * Title of the custom page
    */
@@ -1624,7 +1628,7 @@ export interface CustomPage {
   hidden?: boolean;
   [k: string]: unknown;
 }
-export interface Error_CUSTOMPAGE_INVALID {
+interface Error_CUSTOMPAGE_INVALID {
   /**
    * An error code unique to the error received.
    */
@@ -1651,18 +1655,18 @@ export interface Error_CUSTOMPAGE_INVALID {
   poem?: string[];
   [k: string]: unknown;
 }
-export type CreateCustomPage_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
-export type CreateCustomPage_Response_403 = Error_APIKEY_MISMATCH;
-export type GetCustomPageMetadataParam = {
+type CreateCustomPage_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
+type CreateCustomPage_Response_403 = Error_APIKEY_MISMATCH;
+type GetCustomPageMetadataParam = {
   /**
    * A URL-safe representation of the custom page title. Slugs must be all lowercase, and replace spaces with hyphens. For example, for the the custom page "Getting Started", enter the slug "getting-started"
    */
   slug: string;
   [k: string]: unknown;
 };
-export type GetCustomPage_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
-export type GetCustomPage_Response_403 = Error_APIKEY_MISMATCH;
-export interface Error_CUSTOMPAGE_NOTFOUND {
+type GetCustomPage_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
+type GetCustomPage_Response_403 = Error_APIKEY_MISMATCH;
+interface Error_CUSTOMPAGE_NOTFOUND {
   /**
    * An error code unique to the error received.
    */
@@ -1689,25 +1693,25 @@ export interface Error_CUSTOMPAGE_NOTFOUND {
   poem?: string[];
   [k: string]: unknown;
 }
-export type UpdateCustomPageMetadataParam = {
+type UpdateCustomPageMetadataParam = {
   /**
    * A URL-safe representation of the custom page title. Slugs must be all lowercase, and replace spaces with hyphens. For example, for the the custom page "Getting Started", enter the slug "getting-started"
    */
   slug: string;
   [k: string]: unknown;
 };
-export type UpdateCustomPage_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
-export type UpdateCustomPage_Response_403 = Error_APIKEY_MISMATCH;
-export type DeleteCustomPageMetadataParam = {
+type UpdateCustomPage_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
+type UpdateCustomPage_Response_403 = Error_APIKEY_MISMATCH;
+type DeleteCustomPageMetadataParam = {
   /**
    * A URL-safe representation of the custom page title. Slugs must be all lowercase, and replace spaces with hyphens. For example, for the the custom page "Getting Started", enter the slug "getting-started"
    */
   slug: string;
   [k: string]: unknown;
 };
-export type DeleteCustomPage_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
-export type DeleteCustomPage_Response_403 = Error_APIKEY_MISMATCH;
-export type GetDocMetadataParam = {
+type DeleteCustomPage_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
+type DeleteCustomPage_Response_403 = Error_APIKEY_MISMATCH;
+type GetDocMetadataParam = {
   /**
    * A URL-safe representation of the doc title. Slugs must be all lowercase, and replace spaces with hyphens. For example, for the the doc "New Features", enter the slug "new-features"
    */
@@ -1720,9 +1724,9 @@ export type GetDocMetadataParam = {
   'x-readme-version'?: string;
   [k: string]: unknown;
 };
-export type GetDoc_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
-export type GetDoc_Response_403 = Error_APIKEY_MISMATCH;
-export interface Error_DOC_NOTFOUND {
+type GetDoc_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
+type GetDoc_Response_403 = Error_APIKEY_MISMATCH;
+interface Error_DOC_NOTFOUND {
   /**
    * An error code unique to the error received.
    */
@@ -1749,7 +1753,7 @@ export interface Error_DOC_NOTFOUND {
   poem?: string[];
   [k: string]: unknown;
 }
-export interface Doc {
+interface Doc {
   /**
    * Title of the page
    */
@@ -1787,7 +1791,7 @@ export interface Doc {
   };
   [k: string]: unknown;
 }
-export type UpdateDocMetadataParam = {
+type UpdateDocMetadataParam = {
   /**
    * A URL-safe representation of the doc title. Slugs must be all lowercase, and replace spaces with hyphens. For example, for the the doc "New Features", enter the slug "new-features"
    */
@@ -1800,7 +1804,7 @@ export type UpdateDocMetadataParam = {
   'x-readme-version'?: string;
   [k: string]: unknown;
 };
-export interface Error_DOC_INVALID {
+interface Error_DOC_INVALID {
   /**
    * An error code unique to the error received.
    */
@@ -1827,9 +1831,9 @@ export interface Error_DOC_INVALID {
   poem?: string[];
   [k: string]: unknown;
 }
-export type UpdateDoc_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
-export type UpdateDoc_Response_403 = Error_APIKEY_MISMATCH;
-export type DeleteDocMetadataParam = {
+type UpdateDoc_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
+type UpdateDoc_Response_403 = Error_APIKEY_MISMATCH;
+type DeleteDocMetadataParam = {
   /**
    * A URL-safe representation of the doc title. Slugs must be all lowercase, and replace spaces with hyphens. For example, for the the doc "New Features", enter the slug "new-features"
    */
@@ -1842,18 +1846,18 @@ export type DeleteDocMetadataParam = {
   'x-readme-version'?: string;
   [k: string]: unknown;
 };
-export type DeleteDoc_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
-export type DeleteDoc_Response_403 = Error_APIKEY_MISMATCH;
-export type CreateDocMetadataParam = {
+type DeleteDoc_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
+type DeleteDoc_Response_403 = Error_APIKEY_MISMATCH;
+type CreateDocMetadataParam = {
   /**
    * Version number of your docs project, for example, v3.0. By default the main project version is used. To see all valid versions for your docs project call https://docs.readme.com/reference/version#getversions.
    */
   'x-readme-version'?: string;
   [k: string]: unknown;
 };
-export type CreateDoc_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
-export type CreateDoc_Response_403 = Error_APIKEY_MISMATCH;
-export type SearchDocsMetadataParam = {
+type CreateDoc_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
+type CreateDoc_Response_403 = Error_APIKEY_MISMATCH;
+type SearchDocsMetadataParam = {
   /**
    * Search string to look for
    */
@@ -1866,11 +1870,11 @@ export type SearchDocsMetadataParam = {
   'x-readme-version'?: string;
   [k: string]: unknown;
 };
-export type SearchDocs_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
-export type SearchDocs_Response_403 = Error_APIKEY_MISMATCH;
-export type GetErrors_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
-export type GetErrors_Response_403 = Error_APIKEY_MISMATCH;
-export interface CondensedProjectData {
+type SearchDocs_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
+type SearchDocs_Response_403 = Error_APIKEY_MISMATCH;
+type GetErrors_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
+type GetErrors_Response_403 = Error_APIKEY_MISMATCH;
+interface CondensedProjectData {
   name?: string;
   subdomain?: string;
   jwtSecret?: string;
@@ -1881,11 +1885,11 @@ export interface CondensedProjectData {
   plan?: string;
   [k: string]: unknown;
 }
-export type GetProject_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
-export type GetProject_Response_403 = Error_APIKEY_MISMATCH;
-export type GetVersions_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
-export type GetVersions_Response_403 = Error_APIKEY_MISMATCH;
-export interface Version {
+type GetProject_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
+type GetProject_Response_403 = Error_APIKEY_MISMATCH;
+type GetVersions_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
+type GetVersions_Response_403 = Error_APIKEY_MISMATCH;
+interface Version {
   /**
    * Semantic Version
    */
@@ -1913,8 +1917,8 @@ export interface Version {
   is_deprecated?: boolean;
   [k: string]: unknown;
 }
-export type CreateVersion_Response_400 = Error_VERSION_EMPTY | Error_VERSION_DUPLICATE | Error_VERSION_FORK_EMPTY;
-export interface Error_VERSION_DUPLICATE {
+type CreateVersion_Response_400 = Error_VERSION_EMPTY | Error_VERSION_DUPLICATE | Error_VERSION_FORK_EMPTY;
+interface Error_VERSION_DUPLICATE {
   /**
    * An error code unique to the error received.
    */
@@ -1941,7 +1945,7 @@ export interface Error_VERSION_DUPLICATE {
   poem?: string[];
   [k: string]: unknown;
 }
-export interface Error_VERSION_FORK_EMPTY {
+interface Error_VERSION_FORK_EMPTY {
   /**
    * An error code unique to the error received.
    */
@@ -1968,9 +1972,9 @@ export interface Error_VERSION_FORK_EMPTY {
   poem?: string[];
   [k: string]: unknown;
 }
-export type CreateVersion_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
-export type CreateVersion_Response_403 = Error_APIKEY_MISMATCH;
-export interface Error_VERSION_FORK_NOTFOUND {
+type CreateVersion_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
+type CreateVersion_Response_403 = Error_APIKEY_MISMATCH;
+interface Error_VERSION_FORK_NOTFOUND {
   /**
    * An error code unique to the error received.
    */
@@ -1997,23 +2001,23 @@ export interface Error_VERSION_FORK_NOTFOUND {
   poem?: string[];
   [k: string]: unknown;
 }
-export type GetVersionMetadataParam = {
+type GetVersionMetadataParam = {
   /**
    * Semver identifier for the project version. For best results, use the formatted `version_clean` value listed in the response from the [Get Versions endpoint](/reference/getversions).
    */
   versionId: string;
   [k: string]: unknown;
 };
-export type GetVersion_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
-export type GetVersion_Response_403 = Error_APIKEY_MISMATCH;
-export type UpdateVersionMetadataParam = {
+type GetVersion_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
+type GetVersion_Response_403 = Error_APIKEY_MISMATCH;
+type UpdateVersionMetadataParam = {
   /**
    * Semver identifier for the project version. For best results, use the formatted `version_clean` value listed in the response from the [Get Versions endpoint](/reference/getversions).
    */
   versionId: string;
   [k: string]: unknown;
 };
-export interface Error_VERSION_CANT_DEMOTE_STABLE {
+interface Error_VERSION_CANT_DEMOTE_STABLE {
   /**
    * An error code unique to the error received.
    */
@@ -2040,16 +2044,16 @@ export interface Error_VERSION_CANT_DEMOTE_STABLE {
   poem?: string[];
   [k: string]: unknown;
 }
-export type UpdateVersion_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
-export type UpdateVersion_Response_403 = Error_APIKEY_MISMATCH;
-export type DeleteVersionMetadataParam = {
+type UpdateVersion_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
+type UpdateVersion_Response_403 = Error_APIKEY_MISMATCH;
+type DeleteVersionMetadataParam = {
   /**
    * Semver identifier for the project version. For best results, use the formatted `version_clean` value listed in the response from the [Get Versions endpoint](/reference/getversions).
    */
   versionId: string;
   [k: string]: unknown;
 };
-export interface Error_VERSION_CANT_REMOVE_STABLE {
+interface Error_VERSION_CANT_REMOVE_STABLE {
   /**
    * An error code unique to the error received.
    */
@@ -2076,5 +2080,5 @@ export interface Error_VERSION_CANT_REMOVE_STABLE {
   poem?: string[];
   [k: string]: unknown;
 }
-export type DeleteVersion_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
-export type DeleteVersion_Response_403 = Error_APIKEY_MISMATCH;
+type DeleteVersion_Response_401 = Error_APIKEY_EMPTY | Error_APIKEY_NOTFOUND;
+type DeleteVersion_Response_403 = Error_APIKEY_MISMATCH;

--- a/packages/api/test/__fixtures__/sdk/readme/index.ts
+++ b/packages/api/test/__fixtures__/sdk/readme/index.ts
@@ -1,6 +1,6 @@
 import Oas from 'oas';
 import APICore from 'api/dist/core';
-import definition from './openapi.json';
+import definition from '@readme/oas-examples/3.0/json/readme.json';
 
 export default class SDK {
   spec: Oas;

--- a/packages/api/test/__fixtures__/sdk/readme/index.ts
+++ b/packages/api/test/__fixtures__/sdk/readme/index.ts
@@ -812,9 +812,10 @@ class SDK {
   }
 }
 
-export default function createSDK(): SDK {
+const createSDK = (() => {
   return new SDK();
-}
+})();
+export default createSDK;
 
 interface ConfigOptions {
   /**

--- a/packages/api/test/__fixtures__/sdk/simple-js-cjs/index.d.ts
+++ b/packages/api/test/__fixtures__/sdk/simple-js-cjs/index.d.ts
@@ -67,7 +67,8 @@ declare class SDK {
    */
   findPetsByStatus(metadata: FindPetsByStatusMetadataParam): Promise<FindPetsByStatus_Response_200>;
 }
-export = SDK;
+declare function createSDK(): SDK;
+export = createSDK;
 interface ConfigOptions {
   /**
    * By default we parse the response based on the `Content-Type` header of the request. You
@@ -75,15 +76,15 @@ interface ConfigOptions {
    */
   parseResponse: boolean;
 }
-export declare type FindPetsByStatusMetadataParam = {
+declare type FindPetsByStatusMetadataParam = {
   /**
    * Status values that need to be considered for filter
    */
   status: ('available' | 'pending' | 'sold')[];
   [k: string]: unknown;
 };
-export declare type FindPetsByStatus_Response_200 = Pet[];
-export interface Pet {
+declare type FindPetsByStatus_Response_200 = Pet[];
+interface Pet {
   id?: number;
   category?: Category;
   name: string;
@@ -97,12 +98,12 @@ export interface Pet {
   status?: 'available' | 'pending' | 'sold';
   [k: string]: unknown;
 }
-export interface Category {
+interface Category {
   id?: number;
   name?: string;
   [k: string]: unknown;
 }
-export interface Tag {
+interface Tag {
   id?: number;
   name?: string;
   [k: string]: unknown;

--- a/packages/api/test/__fixtures__/sdk/simple-js-cjs/index.d.ts
+++ b/packages/api/test/__fixtures__/sdk/simple-js-cjs/index.d.ts
@@ -67,7 +67,7 @@ declare class SDK {
    */
   findPetsByStatus(metadata: FindPetsByStatusMetadataParam): Promise<FindPetsByStatus_Response_200>;
 }
-declare function createSDK(): SDK;
+declare const createSDK: SDK;
 export = createSDK;
 interface ConfigOptions {
   /**

--- a/packages/api/test/__fixtures__/sdk/simple-js-cjs/index.js
+++ b/packages/api/test/__fixtures__/sdk/simple-js-cjs/index.js
@@ -6,11 +6,11 @@ var __importDefault =
   };
 var oas_1 = __importDefault(require('oas'));
 var core_1 = __importDefault(require('api/dist/core'));
-var openapi_json_1 = __importDefault(require('./openapi.json'));
+var simple_json_1 = __importDefault(require('../../../__fixtures__/definitions/simple.json'));
 var SDK = /** @class */ (function () {
   function SDK() {
     this.authKeys = [];
-    this.spec = oas_1.default.init(openapi_json_1.default);
+    this.spec = oas_1.default.init(simple_json_1.default);
     this.core = new core_1.default(this.spec, 'simple-js-cjs/1.0.0 (api/5.0-unit-testing)');
   }
   /**

--- a/packages/api/test/__fixtures__/sdk/simple-js-cjs/index.js
+++ b/packages/api/test/__fixtures__/sdk/simple-js-cjs/index.js
@@ -96,4 +96,7 @@ var SDK = /** @class */ (function () {
   };
   return SDK;
 })();
-module.exports = SDK;
+function createSDK() {
+  return new SDK();
+}
+module.exports = createSDK;

--- a/packages/api/test/__fixtures__/sdk/simple-js-cjs/index.js
+++ b/packages/api/test/__fixtures__/sdk/simple-js-cjs/index.js
@@ -96,7 +96,7 @@ var SDK = /** @class */ (function () {
   };
   return SDK;
 })();
-function createSDK() {
+var createSDK = (function () {
   return new SDK();
-}
+})();
 module.exports = createSDK;

--- a/packages/api/test/__fixtures__/sdk/simple-js-esm/index.d.ts
+++ b/packages/api/test/__fixtures__/sdk/simple-js-esm/index.d.ts
@@ -67,7 +67,8 @@ declare class SDK {
    */
   findPetsByStatus(metadata: FindPetsByStatusMetadataParam): Promise<FindPetsByStatus_Response_200>;
 }
-export default function createSDK(): SDK;
+declare const createSDK: SDK;
+export default createSDK;
 interface ConfigOptions {
   /**
    * By default we parse the response based on the `Content-Type` header of the request. You
@@ -107,4 +108,3 @@ interface Tag {
   name?: string;
   [k: string]: unknown;
 }
-export {};

--- a/packages/api/test/__fixtures__/sdk/simple-js-esm/index.d.ts
+++ b/packages/api/test/__fixtures__/sdk/simple-js-esm/index.d.ts
@@ -1,6 +1,6 @@
 import Oas from 'oas';
 import APICore from 'api/dist/core';
-export default class SDK {
+declare class SDK {
   spec: Oas;
   core: APICore;
   authKeys: (number | string)[][];
@@ -67,6 +67,7 @@ export default class SDK {
    */
   findPetsByStatus(metadata: FindPetsByStatusMetadataParam): Promise<FindPetsByStatus_Response_200>;
 }
+export default function createSDK(): SDK;
 interface ConfigOptions {
   /**
    * By default we parse the response based on the `Content-Type` header of the request. You
@@ -74,15 +75,15 @@ interface ConfigOptions {
    */
   parseResponse: boolean;
 }
-export declare type FindPetsByStatusMetadataParam = {
+declare type FindPetsByStatusMetadataParam = {
   /**
    * Status values that need to be considered for filter
    */
   status: ('available' | 'pending' | 'sold')[];
   [k: string]: unknown;
 };
-export declare type FindPetsByStatus_Response_200 = Pet[];
-export interface Pet {
+declare type FindPetsByStatus_Response_200 = Pet[];
+interface Pet {
   id?: number;
   category?: Category;
   name: string;
@@ -96,12 +97,12 @@ export interface Pet {
   status?: 'available' | 'pending' | 'sold';
   [k: string]: unknown;
 }
-export interface Category {
+interface Category {
   id?: number;
   name?: string;
   [k: string]: unknown;
 }
-export interface Tag {
+interface Tag {
   id?: number;
   name?: string;
   [k: string]: unknown;

--- a/packages/api/test/__fixtures__/sdk/simple-js-esm/index.js
+++ b/packages/api/test/__fixtures__/sdk/simple-js-esm/index.js
@@ -81,6 +81,7 @@ class SDK {
     return this.core.fetch('/pet/findByStatus', 'get', metadata);
   }
 }
-export default function createSDK() {
+const createSDK = (() => {
   return new SDK();
-}
+})();
+export default createSDK;

--- a/packages/api/test/__fixtures__/sdk/simple-js-esm/index.js
+++ b/packages/api/test/__fixtures__/sdk/simple-js-esm/index.js
@@ -1,6 +1,6 @@
 import Oas from 'oas';
 import APICore from 'api/dist/core';
-import definition from './openapi.json';
+import definition from '../../../__fixtures__/definitions/simple.json';
 export default class SDK {
   constructor() {
     this.authKeys = [];

--- a/packages/api/test/__fixtures__/sdk/simple-js-esm/index.js
+++ b/packages/api/test/__fixtures__/sdk/simple-js-esm/index.js
@@ -1,7 +1,7 @@
 import Oas from 'oas';
 import APICore from 'api/dist/core';
 import definition from '../../../__fixtures__/definitions/simple.json';
-export default class SDK {
+class SDK {
   constructor() {
     this.authKeys = [];
     this.spec = Oas.init(definition);
@@ -80,4 +80,7 @@ export default class SDK {
   findPetsByStatus(metadata) {
     return this.core.fetch('/pet/findByStatus', 'get', metadata);
   }
+}
+export default function createSDK() {
+  return new SDK();
 }

--- a/packages/api/test/__fixtures__/sdk/simple-ts/index.d.ts
+++ b/packages/api/test/__fixtures__/sdk/simple-ts/index.d.ts
@@ -67,7 +67,8 @@ declare class SDK {
    */
   findPetsByStatus(metadata: FindPetsByStatusMetadataParam): Promise<FindPetsByStatus_Response_200>;
 }
-export default function createSDK(): SDK;
+declare const createSDK: SDK;
+export default createSDK;
 interface ConfigOptions {
   /**
    * By default we parse the response based on the `Content-Type` header of the request. You
@@ -107,4 +108,3 @@ interface Tag {
   name?: string;
   [k: string]: unknown;
 }
-export {};

--- a/packages/api/test/__fixtures__/sdk/simple-ts/index.d.ts
+++ b/packages/api/test/__fixtures__/sdk/simple-ts/index.d.ts
@@ -1,6 +1,6 @@
 import Oas from 'oas';
 import APICore from 'api/dist/core';
-export default class SDK {
+declare class SDK {
   spec: Oas;
   core: APICore;
   authKeys: (number | string)[][];
@@ -67,6 +67,7 @@ export default class SDK {
    */
   findPetsByStatus(metadata: FindPetsByStatusMetadataParam): Promise<FindPetsByStatus_Response_200>;
 }
+export default function createSDK(): SDK;
 interface ConfigOptions {
   /**
    * By default we parse the response based on the `Content-Type` header of the request. You
@@ -74,15 +75,15 @@ interface ConfigOptions {
    */
   parseResponse: boolean;
 }
-export declare type FindPetsByStatusMetadataParam = {
+declare type FindPetsByStatusMetadataParam = {
   /**
    * Status values that need to be considered for filter
    */
   status: ('available' | 'pending' | 'sold')[];
   [k: string]: unknown;
 };
-export declare type FindPetsByStatus_Response_200 = Pet[];
-export interface Pet {
+declare type FindPetsByStatus_Response_200 = Pet[];
+interface Pet {
   id?: number;
   category?: Category;
   name: string;
@@ -96,12 +97,12 @@ export interface Pet {
   status?: 'available' | 'pending' | 'sold';
   [k: string]: unknown;
 }
-export interface Category {
+interface Category {
   id?: number;
   name?: string;
   [k: string]: unknown;
 }
-export interface Tag {
+interface Tag {
   id?: number;
   name?: string;
   [k: string]: unknown;

--- a/packages/api/test/__fixtures__/sdk/simple-ts/index.ts
+++ b/packages/api/test/__fixtures__/sdk/simple-ts/index.ts
@@ -97,9 +97,10 @@ class SDK {
   }
 }
 
-export default function createSDK(): SDK {
+const createSDK = (() => {
   return new SDK();
-}
+})();
+export default createSDK;
 
 interface ConfigOptions {
   /**

--- a/packages/api/test/__fixtures__/sdk/simple-ts/index.ts
+++ b/packages/api/test/__fixtures__/sdk/simple-ts/index.ts
@@ -2,7 +2,7 @@ import Oas from 'oas';
 import APICore from 'api/dist/core';
 import definition from '../../../__fixtures__/definitions/simple.json';
 
-export default class SDK {
+class SDK {
   spec: Oas;
   core: APICore;
   authKeys: (number | string)[][] = [];
@@ -97,6 +97,10 @@ export default class SDK {
   }
 }
 
+export default function createSDK(): SDK {
+  return new SDK();
+}
+
 interface ConfigOptions {
   /**
    * By default we parse the response based on the `Content-Type` header of the request. You
@@ -104,15 +108,15 @@ interface ConfigOptions {
    */
   parseResponse: boolean;
 }
-export type FindPetsByStatusMetadataParam = {
+type FindPetsByStatusMetadataParam = {
   /**
    * Status values that need to be considered for filter
    */
   status: ('available' | 'pending' | 'sold')[];
   [k: string]: unknown;
 };
-export type FindPetsByStatus_Response_200 = Pet[];
-export interface Pet {
+type FindPetsByStatus_Response_200 = Pet[];
+interface Pet {
   id?: number;
   category?: Category;
   name: string;
@@ -126,12 +130,12 @@ export interface Pet {
   status?: 'available' | 'pending' | 'sold';
   [k: string]: unknown;
 }
-export interface Category {
+interface Category {
   id?: number;
   name?: string;
   [k: string]: unknown;
 }
-export interface Tag {
+interface Tag {
   id?: number;
   name?: string;
   [k: string]: unknown;

--- a/packages/api/test/__fixtures__/sdk/simple-ts/index.ts
+++ b/packages/api/test/__fixtures__/sdk/simple-ts/index.ts
@@ -1,6 +1,6 @@
 import Oas from 'oas';
 import APICore from 'api/dist/core';
-import definition from './openapi.json';
+import definition from '../../../__fixtures__/definitions/simple.json';
 
 export default class SDK {
   spec: Oas;

--- a/packages/api/test/cli/codegen/languages/typescript.test.ts
+++ b/packages/api/test/cli/codegen/languages/typescript.test.ts
@@ -2,6 +2,7 @@
 import type { TSGeneratorOptions } from '../../../../src/cli/codegen/languages/typescript';
 
 import chai, { expect } from 'chai';
+import fetchMock from 'fetch-mock';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import chaiPlugins from '../../../helpers/chai-plugins';
@@ -21,6 +22,8 @@ import uniqueTempDir from 'unique-temp-dir';
 import Oas from 'oas';
 import Storage from '../../../../src/cli/storage';
 import TSGenerator from '../../../../src/cli/codegen/languages/typescript';
+
+import { responses as mockResponse } from '../../../helpers/fetch-mock';
 
 chai.use(chaiPlugins);
 chai.use(sinonChai);
@@ -97,6 +100,30 @@ describe('typescript', function () {
           compilerTarget: 'esm',
         })
       );
+    });
+
+    describe('integration', function () {
+      afterEach(function () {
+        fetchMock.restore();
+      });
+
+      it('should be able to make an API request (TS)', async function () {
+        const sdk = await import('../../../__fixtures__/sdk/simple-ts').then(r => r.default);
+        fetchMock.get('http://petstore.swagger.io/v2/pet/findByStatus?status=available', mockResponse.searchParams);
+
+        await sdk.findPetsByStatus({ status: ['available'] }).then(res => {
+          expect(res).to.equal('/v2/pet/findByStatus?status=available');
+        });
+      });
+
+      it('should be able to make an API request (JS)', async function () {
+        const sdk = await import('../../../__fixtures__/sdk/simple-js-cjs').then(r => r.default);
+        fetchMock.get('http://petstore.swagger.io/v2/pet/findByStatus?status=available', mockResponse.searchParams);
+
+        await sdk.findPetsByStatus({ status: ['available'] }).then(res => {
+          expect(res).to.equal('/v2/pet/findByStatus?status=available');
+        });
+      });
     });
   });
 });

--- a/packages/api/test/cli/codegen/languages/typescript.test.ts
+++ b/packages/api/test/cli/codegen/languages/typescript.test.ts
@@ -116,8 +116,17 @@ describe('typescript', function () {
         });
       });
 
-      it('should be able to make an API request (JS)', async function () {
+      it('should be able to make an API request (JS + CommonJS)', async function () {
         const sdk = await import('../../../__fixtures__/sdk/simple-js-cjs').then(r => r.default);
+        fetchMock.get('http://petstore.swagger.io/v2/pet/findByStatus?status=available', mockResponse.searchParams);
+
+        await sdk.findPetsByStatus({ status: ['available'] }).then(res => {
+          expect(res).to.equal('/v2/pet/findByStatus?status=available');
+        });
+      });
+
+      it('should be able to make an API request (JS + ESM)', async function () {
+        const sdk = await import('../../../__fixtures__/sdk/simple-js-esm').then(r => r.default);
         fetchMock.get('http://petstore.swagger.io/v2/pet/findByStatus?status=available', mockResponse.searchParams);
 
         await sdk.findPetsByStatus({ status: ['available'] }).then(res => {


### PR DESCRIPTION
## 🧰 Changes

* [x] Updates our `type` and `interface` compilation to no longer export them due to a series of unreconcilable issues.
* [x] Updates our main default SDK export to now export an IFEE so people no longer need to do `new SDK()`, they just have a ready-to-use instance of the SDK.

### Before

```ts
import SDK from './packages/api/test__fixtures__/sdk/simple-ts';

const simpleSDK = new SDK();
simpleSDK.findPetsByStatus({ status: ['available'] }).then(res => {
  console.log(res)
});
```

### After
```ts
import simpleSDK from './packages/api/test__fixtures__/sdk/simple-ts';

simpleSDK.findPetsByStatus({ status: ['available'] }).then(res => {
  console.log(res)
});
```

## 🐳 Why were types and interfaces a problem?

<img src="https://user-images.githubusercontent.com/33762/180297829-fcdcf26c-3fcf-4e99-bbb2-8d61d54dfd92.gif" align="right" width="400" />

1. [`ts-morph`](https://npm.im/ts-morph) doesn't have great, or any really, support for programmatically creating an IFEE. You can create an IFEE with `addVariableStatement` but when attempting to export it with `setIsDefaultExport` `ts-morph` will crash.
2. After managing to get an IFEE compiled into `export default createSDK` and `module.exports = createSDK`, the `.d.ts` TS declaration files would break with a TS2309 error because it would be exported as `export = _default`, which clashes with our JSON Schema types and interfaces that we're exporting as `export interface` and `export declare type`.
3. The [`json-schema-to-typescript`](https://npm.im/json-schema-to-typescript) library that we're using to convert JSON Schema schemas from an OpenAPI definition into TS code spits out a string dump containing multiple interfaces and types. We're able to handle this now by utilizing the `ts-morph` API to create a temporary source file, import our types + interfaces, and then export them as usable objects, but if we wanted to actually create them the proper way with `ts-morph` we can't because it doesn't have APIs for creating them dynamically. They expect you to know what you're setting into a type or interface, which we don't because it's coming from the API definition.

All of those reasons has led to me dropping support for exporting types and interfaces in our compiled TS declarations. I don't feel great about removing useful functionality here but believe me when I say that there's no other way that we can solve this right now.

We could maybe swap out `json-schema-to-typescript` with a custom JSON Schema compiler that sits directly on top of `ts-morph` but do I have interest in maintaining a JSON Schema compiler? lol. lmao. I'm also not even sure if properly creating, and exporting, these types and interfaces within `ts-morph` would even solve the problem we've got with this IFEE because `ts-morph` doesn't realy seem to like IFEE's very much.

That said, if someone really needs a type or interface exported they can export it themselves with the generated code that we create for them, they'll just need to re-add that if they generate it again. Not ideal, sure, but manageable.

## 🧬 QA & Testing

I've added new integration tests into the TS codegen suite for TS, CJS and ESM compiled SDKs. They all make a simple, mocked, API call. If they work, and TS doesn't complain about their types, then they will work everywhere.
