### PR TITLE
feat: adding support for case-insensitive header parameters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1314,6 +1314,12 @@
         "@types/responselike": "*"
       }
     },
+    "node_modules/@types/caseless": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
+      "integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w==",
+      "dev": true
+    },
     "node_modules/@types/chai": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.1.tgz",
@@ -2686,6 +2692,11 @@
       "bin": {
         "cdl": "bin/cdl.js"
       }
+    },
+    "node_modules/caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
     },
     "node_modules/ccount": {
       "version": "2.0.1",
@@ -13058,6 +13069,7 @@
       "dependencies": {
         "@readme/oas-to-har": "^17.0.8",
         "@readme/openapi-parser": "^2.2.0",
+        "caseless": "^0.12.0",
         "chalk": "^4.1.2",
         "commander": "^9.2.0",
         "datauri": "^4.1.0",
@@ -13087,6 +13099,7 @@
       },
       "devDependencies": {
         "@readme/oas-examples": "^5.4.1",
+        "@types/caseless": "^0.12.2",
         "@types/chai": "^4.3.1",
         "@types/find-cache-dir": "^3.2.1",
         "@types/js-yaml": "^4.0.5",
@@ -14238,6 +14251,12 @@
         "@types/responselike": "*"
       }
     },
+    "@types/caseless": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
+      "integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w==",
+      "dev": true
+    },
     "@types/chai": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.1.tgz",
@@ -14872,6 +14891,7 @@
         "@readme/oas-examples": "^5.4.1",
         "@readme/oas-to-har": "^17.0.8",
         "@readme/openapi-parser": "^2.2.0",
+        "@types/caseless": "^0.12.2",
         "@types/chai": "^4.3.1",
         "@types/find-cache-dir": "^3.2.1",
         "@types/js-yaml": "^4.0.5",
@@ -14882,6 +14902,7 @@
         "@types/sinon-chai": "^3.2.8",
         "@types/ssri": "^7.1.1",
         "@types/validate-npm-package-name": "^4.0.0",
+        "caseless": "^0.12.0",
         "chai": "^4.3.6",
         "chalk": "^4.1.2",
         "commander": "^9.2.0",
@@ -15344,6 +15365,11 @@
         "ansicolors": "~0.3.2",
         "redeyed": "~2.1.0"
       }
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
     },
     "ccount": {
       "version": "2.0.1",

--- a/packages/api/package-lock.json
+++ b/packages/api/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@readme/oas-to-har": "^17.0.8",
         "@readme/openapi-parser": "^2.2.0",
+        "caseless": "^0.12.0",
         "chalk": "^4.1.2",
         "commander": "^9.2.0",
         "datauri": "^4.1.0",
@@ -40,6 +41,7 @@
       },
       "devDependencies": {
         "@readme/oas-examples": "^5.4.1",
+        "@types/caseless": "^0.12.2",
         "@types/chai": "^4.3.1",
         "@types/find-cache-dir": "^3.2.1",
         "@types/js-yaml": "^4.0.5",
@@ -855,6 +857,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/@types/caseless": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
+      "integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w==",
+      "dev": true
+    },
     "node_modules/@types/chai": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.1.tgz",
@@ -1356,6 +1364,11 @@
       "bin": {
         "cdl": "bin/cdl.js"
       }
+    },
+    "node_modules/caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
     },
     "node_modules/chai": {
       "version": "4.3.6",
@@ -5973,6 +5986,12 @@
         }
       }
     },
+    "@types/caseless": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
+      "integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w==",
+      "dev": true
+    },
     "@types/chai": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.1.tgz",
@@ -6368,6 +6387,11 @@
         "ansicolors": "~0.3.2",
         "redeyed": "~2.1.0"
       }
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
     },
     "chai": {
       "version": "4.3.6",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "@readme/oas-to-har": "^17.0.8",
     "@readme/openapi-parser": "^2.2.0",
+    "caseless": "^0.12.0",
     "chalk": "^4.1.2",
     "commander": "^9.2.0",
     "datauri": "^4.1.0",
@@ -64,6 +65,7 @@
   },
   "devDependencies": {
     "@readme/oas-examples": "^5.4.1",
+    "@types/caseless": "^0.12.2",
     "@types/chai": "^4.3.1",
     "@types/find-cache-dir": "^3.2.1",
     "@types/js-yaml": "^4.0.5",

--- a/packages/api/src/core/prepareParams.ts
+++ b/packages/api/src/core/prepareParams.ts
@@ -9,6 +9,7 @@ import stream from 'stream';
 import getStream from 'get-stream';
 import datauri from 'datauri/sync';
 import DatauriParser from 'datauri/parser';
+import caseless from 'caseless';
 import getJSONSchemaDefaults from './getJSONSchemaDefaults';
 
 /**
@@ -184,19 +185,19 @@ export default async function prepareParams(operation: Operation, body?: unknown
         // isn't anything we can do about it.
         params.body = merge(params.body, body);
       } else {
-        const headerParams: string[] = [];
+        const headerParams = caseless({});
         Object.entries(digestedParameters).forEach(([paramName, param]) => {
           // Headers are sent case-insensitive so we need to make sure that we're properly
           // matching them when detecting what our incoming payload looks like.
           if (param.in === 'header') {
-            headerParams.push(paramName.toLowerCase());
+            headerParams.set(paramName, '');
           }
         });
 
         const intersection = Object.keys(body).filter(value => {
           if (Object.keys(digestedParameters).includes(value)) {
             return true;
-          } else if (headerParams.includes(value.toLowerCase())) {
+          } else if (headerParams.has(value)) {
             return true;
           }
 

--- a/packages/api/test/core/prepareParams.test.ts
+++ b/packages/api/test/core/prepareParams.test.ts
@@ -358,6 +358,19 @@ describe('#prepareParams', function () {
       });
     });
 
+    it('should support matching on case-insensitive header parameters', async function () {
+      const operation = parameterStyle.operation('/anything/headers', 'get');
+      const metadata = {
+        PrimItive: 'buster',
+      };
+
+      expect(await prepareParams(operation, metadata)).to.deep.equal({
+        header: {
+          primitive: 'buster',
+        },
+      });
+    });
+
     it('should support path parameters', async function () {
       const operation = parameterStyle.operation('/anything/path/{primitive}/{array}/{object}', 'get');
       const metadata = {

--- a/packages/httpsnippet-client-api/package-lock.json
+++ b/packages/httpsnippet-client-api/package-lock.json
@@ -42,6 +42,7 @@
       "dependencies": {
         "@readme/oas-to-har": "^17.0.8",
         "@readme/openapi-parser": "^2.2.0",
+        "caseless": "^0.12.0",
         "chalk": "^4.1.2",
         "commander": "^9.2.0",
         "datauri": "^4.1.0",
@@ -71,6 +72,7 @@
       },
       "devDependencies": {
         "@readme/oas-examples": "^5.4.1",
+        "@types/caseless": "^0.12.2",
         "@types/chai": "^4.3.1",
         "@types/find-cache-dir": "^3.2.1",
         "@types/js-yaml": "^4.0.5",
@@ -6322,6 +6324,7 @@
         "@readme/oas-examples": "^5.4.1",
         "@readme/oas-to-har": "^17.0.8",
         "@readme/openapi-parser": "^2.2.0",
+        "@types/caseless": "^0.12.2",
         "@types/chai": "^4.3.1",
         "@types/find-cache-dir": "^3.2.1",
         "@types/js-yaml": "^4.0.5",
@@ -6332,6 +6335,7 @@
         "@types/sinon-chai": "^3.2.8",
         "@types/ssri": "^7.1.1",
         "@types/validate-npm-package-name": "^4.0.0",
+        "caseless": "^0.12.0",
         "chai": "^4.3.6",
         "chalk": "^4.1.2",
         "commander": "^9.2.0",

--- a/packages/httpsnippet-client-api/test/__datasets__/headers/index.ts
+++ b/packages/httpsnippet-client-api/test/__datasets__/headers/index.ts
@@ -15,6 +15,10 @@ const mock: SnippetMock = {
         name: 'x-foo',
         value: 'Bar',
       },
+      {
+        name: 'X-Bar',
+        value: 'foo',
+      },
     ],
     headersSize: 0,
     httpVersion: 'HTTP/1.1',
@@ -31,6 +35,7 @@ const mock: SnippetMock = {
       url: 'https://httpbin.org/anything',
       method: 'GET',
       headers: {
+        'x-bar': 'foo',
         'x-foo': 'Bar',
       },
     },

--- a/packages/httpsnippet-client-api/test/__datasets__/headers/openapi.json
+++ b/packages/httpsnippet-client-api/test/__datasets__/headers/openapi.json
@@ -19,6 +19,13 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "in": "header",
+            "name": "x-bar",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {

--- a/packages/httpsnippet-client-api/test/__datasets__/headers/output.js
+++ b/packages/httpsnippet-client-api/test/__datasets__/headers/output.js
@@ -1,5 +1,5 @@
 const sdk = require('api')('https://api.example.com/headers.json');
 
-sdk.get('/anything', {'x-foo': 'Bar'})
+sdk.get('/anything', {'x-foo': 'Bar', 'x-bar': 'foo'})
   .then(res => console.log(res))
   .catch(err => console.error(err));

--- a/packages/httpsnippet-client-api/test/__datasets__/petstore/output.js
+++ b/packages/httpsnippet-client-api/test/__datasets__/petstore/output.js
@@ -1,6 +1,6 @@
 const sdk = require('api')('https://api.example.com/petstore.json');
 
 sdk.auth('123');
-sdk.findPetsByStatus({status: 'available', Accept: 'application/xml'})
+sdk.findPetsByStatus({status: 'available', accept: 'application/xml'})
   .then(res => console.log(res))
   .catch(err => console.error(err));


### PR DESCRIPTION
| 🚥 Fix #178 |
| :-- |

## 🧰 Changes

* [x] Updates snippet generation to present headers as lowercase.
* [x] Updates `api` parameter matching to be able to match case-insensitive parameters.
