### PR TITLE
fix: bug where operationIDs with underscores were being modified

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9328,9 +9328,9 @@
       }
     },
     "node_modules/oas": {
-      "version": "18.3.3",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-18.3.3.tgz",
-      "integrity": "sha512-xS/yqmENaDUUPD9p4uL3kaZj9nEx1f+D5EpSe5Oc+WdLpWb7SGbvalp8qPs4S4N0sro7X5lKSqsBXkvohgxo7w==",
+      "version": "18.3.4",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-18.3.4.tgz",
+      "integrity": "sha512-mNaTC91kXLcfJjdLSxd2h06JlOAxFFa9+po+KbF7ifMb5PNYy0t0wvxllo0oS/Erztt8W917/fKX3kHVHWvBKw==",
       "dependencies": {
         "@readme/json-schema-ref-parser": "^1.1.0",
         "@types/json-schema": "^7.0.11",
@@ -9344,7 +9344,7 @@
         "memoizee": "^0.4.14",
         "minimist": "^1.2.0",
         "oas-normalize": "^6.0.0",
-        "openapi-types": "^11.0.0",
+        "openapi-types": "^12.0.0",
         "path-to-regexp": "^6.2.0",
         "swagger-inline": "^6.0.0"
       },
@@ -9604,9 +9604,9 @@
       }
     },
     "node_modules/openapi-types": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-11.1.0.tgz",
-      "integrity": "sha512-ZW+Jf12flFF6DXSij8DGL3svDA4RtSyHXjC/xB/JAh18gg3uVfVIFLvCfScUMowrpvlkxsMMbErakbth2g3/iQ=="
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.0.0.tgz",
+      "integrity": "sha512-6Wd9k8nmGQHgCbehZCP6wwWcfXcvinhybUTBatuhjRsCxUIujuYFZc9QnGeae75CyHASewBtxs0HX/qwREReUw=="
     },
     "node_modules/optionator": {
       "version": "0.9.1",
@@ -13053,7 +13053,7 @@
       }
     },
     "packages/api": {
-      "version": "5.0.0-beta.1",
+      "version": "5.0.0-beta.2",
       "license": "MIT",
       "dependencies": {
         "@readme/oas-to-har": "^17.0.8",
@@ -13074,7 +13074,7 @@
         "json-schema-traverse": "^1.0.0",
         "lodash.merge": "^4.6.2",
         "make-dir": "^3.1.0",
-        "oas": "^18.3.3",
+        "oas": "^18.3.4",
         "object-hash": "^3.0.0",
         "ora": "^5.4.1",
         "prompts": "^2.4.2",
@@ -13178,7 +13178,7 @@
       }
     },
     "packages/httpsnippet-client-api": {
-      "version": "5.0.0-beta.1",
+      "version": "5.0.0-beta.2",
       "license": "MIT",
       "dependencies": {
         "content-type": "^1.0.4",
@@ -13204,7 +13204,7 @@
       },
       "peerDependencies": {
         "@readme/httpsnippet": "^4.0.3",
-        "oas": "^18.0.1"
+        "oas": "^18.3.4"
       }
     }
   },
@@ -14903,7 +14903,7 @@
         "mocha": "^10.0.0",
         "mock-require": "^3.0.3",
         "nyc": "^15.1.0",
-        "oas": "^18.3.3",
+        "oas": "^18.3.4",
         "object-hash": "^3.0.0",
         "ora": "^5.4.1",
         "prompts": "^2.4.2",
@@ -20220,9 +20220,9 @@
       }
     },
     "oas": {
-      "version": "18.3.3",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-18.3.3.tgz",
-      "integrity": "sha512-xS/yqmENaDUUPD9p4uL3kaZj9nEx1f+D5EpSe5Oc+WdLpWb7SGbvalp8qPs4S4N0sro7X5lKSqsBXkvohgxo7w==",
+      "version": "18.3.4",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-18.3.4.tgz",
+      "integrity": "sha512-mNaTC91kXLcfJjdLSxd2h06JlOAxFFa9+po+KbF7ifMb5PNYy0t0wvxllo0oS/Erztt8W917/fKX3kHVHWvBKw==",
       "requires": {
         "@readme/json-schema-ref-parser": "^1.1.0",
         "@types/json-schema": "^7.0.11",
@@ -20236,7 +20236,7 @@
         "memoizee": "^0.4.14",
         "minimist": "^1.2.0",
         "oas-normalize": "^6.0.0",
-        "openapi-types": "^11.0.0",
+        "openapi-types": "^12.0.0",
         "path-to-regexp": "^6.2.0",
         "swagger-inline": "^6.0.0"
       },
@@ -20423,9 +20423,9 @@
       }
     },
     "openapi-types": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-11.1.0.tgz",
-      "integrity": "sha512-ZW+Jf12flFF6DXSij8DGL3svDA4RtSyHXjC/xB/JAh18gg3uVfVIFLvCfScUMowrpvlkxsMMbErakbth2g3/iQ=="
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.0.0.tgz",
+      "integrity": "sha512-6Wd9k8nmGQHgCbehZCP6wwWcfXcvinhybUTBatuhjRsCxUIujuYFZc9QnGeae75CyHASewBtxs0HX/qwREReUw=="
     },
     "optionator": {
       "version": "0.9.1",

--- a/packages/api/package-lock.json
+++ b/packages/api/package-lock.json
@@ -27,7 +27,7 @@
         "json-schema-traverse": "^1.0.0",
         "lodash.merge": "^4.6.2",
         "make-dir": "^3.1.0",
-        "oas": "^18.3.3",
+        "oas": "^18.3.4",
         "object-hash": "^3.0.0",
         "ora": "^5.4.1",
         "prompts": "^2.4.2",
@@ -3884,9 +3884,9 @@
       }
     },
     "node_modules/oas": {
-      "version": "18.3.3",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-18.3.3.tgz",
-      "integrity": "sha512-xS/yqmENaDUUPD9p4uL3kaZj9nEx1f+D5EpSe5Oc+WdLpWb7SGbvalp8qPs4S4N0sro7X5lKSqsBXkvohgxo7w==",
+      "version": "18.3.4",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-18.3.4.tgz",
+      "integrity": "sha512-mNaTC91kXLcfJjdLSxd2h06JlOAxFFa9+po+KbF7ifMb5PNYy0t0wvxllo0oS/Erztt8W917/fKX3kHVHWvBKw==",
       "dependencies": {
         "@readme/json-schema-ref-parser": "^1.1.0",
         "@types/json-schema": "^7.0.11",
@@ -3900,7 +3900,7 @@
         "memoizee": "^0.4.14",
         "minimist": "^1.2.0",
         "oas-normalize": "^6.0.0",
-        "openapi-types": "^11.0.0",
+        "openapi-types": "^12.0.0",
         "path-to-regexp": "^6.2.0",
         "swagger-inline": "^6.0.0"
       },
@@ -4121,9 +4121,9 @@
       }
     },
     "node_modules/openapi-types": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-11.0.0.tgz",
-      "integrity": "sha512-GB+QO6o1hAtKsb8tP3/FTD5jpkdKrf42L4Gel9UySngMurzr+Q9pO+dtnmySQCzoCEfJr39IH6bveEn71xNcVg=="
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.0.0.tgz",
+      "integrity": "sha512-6Wd9k8nmGQHgCbehZCP6wwWcfXcvinhybUTBatuhjRsCxUIujuYFZc9QnGeae75CyHASewBtxs0HX/qwREReUw=="
     },
     "node_modules/ora": {
       "version": "5.4.1",
@@ -8245,9 +8245,9 @@
       }
     },
     "oas": {
-      "version": "18.3.3",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-18.3.3.tgz",
-      "integrity": "sha512-xS/yqmENaDUUPD9p4uL3kaZj9nEx1f+D5EpSe5Oc+WdLpWb7SGbvalp8qPs4S4N0sro7X5lKSqsBXkvohgxo7w==",
+      "version": "18.3.4",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-18.3.4.tgz",
+      "integrity": "sha512-mNaTC91kXLcfJjdLSxd2h06JlOAxFFa9+po+KbF7ifMb5PNYy0t0wvxllo0oS/Erztt8W917/fKX3kHVHWvBKw==",
       "requires": {
         "@readme/json-schema-ref-parser": "^1.1.0",
         "@types/json-schema": "^7.0.11",
@@ -8261,7 +8261,7 @@
         "memoizee": "^0.4.14",
         "minimist": "^1.2.0",
         "oas-normalize": "^6.0.0",
-        "openapi-types": "^11.0.0",
+        "openapi-types": "^12.0.0",
         "path-to-regexp": "^6.2.0",
         "swagger-inline": "^6.0.0"
       },
@@ -8426,9 +8426,9 @@
       }
     },
     "openapi-types": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-11.0.0.tgz",
-      "integrity": "sha512-GB+QO6o1hAtKsb8tP3/FTD5jpkdKrf42L4Gel9UySngMurzr+Q9pO+dtnmySQCzoCEfJr39IH6bveEn71xNcVg=="
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.0.0.tgz",
+      "integrity": "sha512-6Wd9k8nmGQHgCbehZCP6wwWcfXcvinhybUTBatuhjRsCxUIujuYFZc9QnGeae75CyHASewBtxs0HX/qwREReUw=="
     },
     "ora": {
       "version": "5.4.1",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -54,7 +54,7 @@
     "json-schema-traverse": "^1.0.0",
     "lodash.merge": "^4.6.2",
     "make-dir": "^3.1.0",
-    "oas": "^18.3.3",
+    "oas": "^18.3.4",
     "object-hash": "^3.0.0",
     "ora": "^5.4.1",
     "prompts": "^2.4.2",

--- a/packages/api/src/cache.ts
+++ b/packages/api/src/cache.ts
@@ -1,4 +1,4 @@
-import type { OASDocument } from 'oas/@types/rmoas.types';
+import type { OASDocument } from 'oas/dist/rmoas.types';
 
 import 'isomorphic-fetch';
 import OpenAPIParser from '@readme/openapi-parser';

--- a/packages/api/src/cli/codegen/languages/typescript.ts
+++ b/packages/api/src/cli/codegen/languages/typescript.ts
@@ -1,6 +1,6 @@
 import type Oas from 'oas';
 import type { Operation } from 'oas';
-import type { HttpMethods, JSONSchema, SchemaObject } from 'oas/@types/rmoas.types';
+import type { HttpMethods, JSONSchema, SchemaObject } from 'oas/dist/rmoas.types';
 import type {
   ClassDeclaration,
   JSDocStructure,

--- a/packages/api/src/cli/storage.ts
+++ b/packages/api/src/cli/storage.ts
@@ -1,4 +1,4 @@
-import type { OASDocument } from 'oas/@types/rmoas.types';
+import type { OASDocument } from 'oas/dist/rmoas.types';
 
 import ssri from 'ssri';
 import fs from 'fs';

--- a/packages/api/src/core/getJSONSchemaDefaults.ts
+++ b/packages/api/src/core/getJSONSchemaDefaults.ts
@@ -1,5 +1,5 @@
-import type { SchemaObject } from 'oas/@types/rmoas.types';
-import type { SchemaWrapper } from 'oas/@types/operation/get-parameters-as-json-schema';
+import type { SchemaObject } from 'oas/dist/rmoas.types';
+import type { SchemaWrapper } from 'oas/dist/operation/get-parameters-as-json-schema';
 import traverse from 'json-schema-traverse';
 
 /**

--- a/packages/api/src/core/index.ts
+++ b/packages/api/src/core/index.ts
@@ -1,6 +1,6 @@
 import type Oas from 'oas';
 import type { Operation } from 'oas';
-import type { HttpMethods } from 'oas/@types/rmoas.types';
+import type { HttpMethods } from 'oas/dist/rmoas.types';
 
 import 'isomorphic-fetch';
 import fetchHar from 'fetch-har';

--- a/packages/api/src/core/prepareParams.ts
+++ b/packages/api/src/core/prepareParams.ts
@@ -1,5 +1,5 @@
 import type { Operation } from 'oas';
-import type { ParameterObject, SchemaObject } from 'oas/@types/rmoas.types';
+import type { ParameterObject, SchemaObject } from 'oas/dist/rmoas.types';
 import type { ReadStream } from 'fs';
 
 import lodashMerge from 'lodash.merge';

--- a/packages/api/src/fetcher.ts
+++ b/packages/api/src/fetcher.ts
@@ -1,4 +1,4 @@
-import type { OASDocument } from 'oas/@types/rmoas.types';
+import type { OASDocument } from 'oas/dist/rmoas.types';
 
 import 'isomorphic-fetch';
 import OpenAPIParser from '@readme/openapi-parser';

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,5 +1,5 @@
 import type { Operation } from 'oas';
-import type { HttpMethods, OASDocument } from 'oas/@types/rmoas.types';
+import type { HttpMethods, OASDocument } from 'oas/dist/rmoas.types';
 import type { ConfigOptions } from './core';
 
 import Oas from 'oas';

--- a/packages/api/test/__fixtures__/sdk/operationid-quirks/index.d.ts
+++ b/packages/api/test/__fixtures__/sdk/operationid-quirks/index.d.ts
@@ -63,7 +63,7 @@ declare class SDK {
    * This mess of a string is intentionally nasty so we can be sure that we're not including anything that wouldn't look right as an operationID for a potential method accessor in `api`.
    *
    */
-  quirkyOperationIdString<T = unknown>(): Promise<T>;
+  quirky_OperationId_string<T = unknown>(): Promise<T>;
 }
 declare const createSDK: SDK;
 export default createSDK;

--- a/packages/api/test/__fixtures__/sdk/operationid-quirks/index.ts
+++ b/packages/api/test/__fixtures__/sdk/operationid-quirks/index.ts
@@ -90,7 +90,7 @@ class SDK {
    * This mess of a string is intentionally nasty so we can be sure that we're not including anything that wouldn't look right as an operationID for a potential method accessor in `api`.
    *
    */
-  quirkyOperationIdString<T = unknown>(): Promise<T> {
+  quirky_OperationId_string<T = unknown>(): Promise<T> {
     return this.core.fetch('/quirky-operationId', 'get');
   }
 }

--- a/packages/api/test/auth.test.ts
+++ b/packages/api/test/auth.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable mocha/no-setup-in-describe */
-import type { OASDocument } from 'oas/@types/rmoas.types';
+import type { OASDocument } from 'oas/dist/rmoas.types';
 
 import { assert, expect } from 'chai';
 import fetchMock from 'fetch-mock';

--- a/packages/api/test/cache.test.ts
+++ b/packages/api/test/cache.test.ts
@@ -1,4 +1,4 @@
-import type { OASDocument } from 'oas/@types/rmoas.types';
+import type { OASDocument } from 'oas/dist/rmoas.types';
 
 import chai, { assert, expect } from 'chai';
 import path from 'path';

--- a/packages/api/test/cli/storage.test.ts
+++ b/packages/api/test/cli/storage.test.ts
@@ -1,4 +1,4 @@
-import type { OASDocument } from 'oas/@types/rmoas.types';
+import type { OASDocument } from 'oas/dist/rmoas.types';
 
 import 'isomorphic-fetch';
 import chai, { assert, expect } from 'chai';

--- a/packages/api/test/config.test.ts
+++ b/packages/api/test/config.test.ts
@@ -1,4 +1,4 @@
-import type { OASDocument } from 'oas/@types/rmoas.types';
+import type { OASDocument } from 'oas/dist/rmoas.types';
 
 import { expect } from 'chai';
 import fetchMock from 'fetch-mock';

--- a/packages/api/test/core/prepareAuth.test.ts
+++ b/packages/api/test/core/prepareAuth.test.ts
@@ -1,4 +1,4 @@
-import type { OASDocument } from 'oas/@types/rmoas.types';
+import type { OASDocument } from 'oas/dist/rmoas.types';
 
 import { expect } from 'chai';
 import Oas from 'oas';

--- a/packages/api/test/dist.test.ts
+++ b/packages/api/test/dist.test.ts
@@ -1,4 +1,4 @@
-import type { OASDocument } from 'oas/@types/rmoas.types';
+import type { OASDocument } from 'oas/dist/rmoas.types';
 
 import { expect } from 'chai';
 import fetchMock from 'fetch-mock';

--- a/packages/api/test/index.test.ts
+++ b/packages/api/test/index.test.ts
@@ -109,7 +109,7 @@ describe('api', function () {
         // counterpart will.
         await petstoreSDK['find pet by id']()
           .then(() => {
-            throw new Error('This operationID should have thrown an exception');
+            throw new Error('This operationID accessor should have thrown an exception.');
           })
           .catch(err => {
             expect(err.message).to.equal(

--- a/packages/api/test/index.test.ts
+++ b/packages/api/test/index.test.ts
@@ -1,4 +1,4 @@
-import type { OASDocument } from 'oas/@types/rmoas.types';
+import type { OASDocument } from 'oas/dist/rmoas.types';
 
 import { assert, expect } from 'chai';
 import uniqueTempDir from 'unique-temp-dir';
@@ -10,8 +10,8 @@ import pkg from '../package.json';
 
 import { responses as mockResponses } from './helpers/fetch-mock';
 
-let petstoreSdk;
-let readmeSdk;
+let petstoreSDK;
+let readmeSDK;
 const petstoreServerUrl = 'http://petstore.swagger.io/api';
 
 describe('api', function () {
@@ -25,11 +25,11 @@ describe('api', function () {
   beforeEach(async function () {
     const petstore = require.resolve('@readme/oas-examples/3.0/json/petstore-expanded.json');
     await new Cache(petstore).load();
-    petstoreSdk = api(petstore);
+    petstoreSDK = api(petstore);
 
     const readme = require.resolve('@readme/oas-examples/3.0/json/readme.json');
     await new Cache(readme).load();
-    readmeSdk = api(readme);
+    readmeSDK = api(readme);
   });
 
   afterEach(function () {
@@ -90,7 +90,7 @@ describe('api', function () {
   describe('#accessors', function () {
     it('should have a function for each http method', function () {
       ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'].forEach(method => {
-        expect(petstoreSdk[method]).to.be.a('function');
+        expect(petstoreSDK[method]).to.be.a('function');
       });
     });
 
@@ -98,11 +98,26 @@ describe('api', function () {
       it('should work for operationId', async function () {
         fetchMock.get(`${petstoreServerUrl}/pets`, mockResponses.real('it worked!'));
 
-        expect(await petstoreSdk.findPets()).to.equal('it worked!');
+        expect(await petstoreSDK.findPets()).to.equal('it worked!');
       });
 
-      it('should work with operationIds that have contain spaces', function () {
-        expect(petstoreSdk['find pet by id']).to.be.a('function');
+      it('should work with operationIds that have contain spaces', async function () {
+        fetchMock.get(`${petstoreServerUrl}/pets/1234`, mockResponses.real('it worked!'));
+
+        // Because we don't want people using ugly operationIDs like this we transform them into
+        // JS-friendly method accessors so this one won't be available but its `findPetById`
+        // counterpart will.
+        await petstoreSDK['find pet by id']()
+          .then(() => {
+            throw new Error('This operationID should have thrown an exception');
+          })
+          .catch(err => {
+            expect(err.message).to.equal(
+              'Sorry, `find pet by id` does not appear to be a valid operation on this API.'
+            );
+          });
+
+        expect(await petstoreSDK.findPetById({ id: 1234 })).to.equal('it worked!');
       });
 
       it('should support an operationId that was dynamically cleaned up within `Operation.getOperationId', async function () {
@@ -112,19 +127,19 @@ describe('api', function () {
         // `camelCase` option on `Operation.getOperationId()` should transform it into
         // `findPetById`.
         expect(petstore.paths['/pets/{id}'].get.operationId).to.equal('find pet by id');
-        expect(petstoreSdk.findPetById).to.be.a('function');
+        expect(petstoreSDK.findPetById).to.be.a('function');
       });
 
       it('should work for other methods', async function () {
         fetchMock.post(`${petstoreServerUrl}/pets`, mockResponses.real('it worked!'));
 
-        expect(await petstoreSdk.addPet()).to.equal('it worked!');
+        expect(await petstoreSDK.addPet()).to.equal('it worked!');
       });
 
       it.skip('should allow operationId to be the same as a http method');
 
       it('should error if an operationId does not exist', async function () {
-        await petstoreSdk
+        await petstoreSDK
           .findPetz()
           .then(() => assert.fail())
           .catch(err => {
@@ -137,11 +152,11 @@ describe('api', function () {
       it('should work for method and path', async function () {
         fetchMock.get(`${petstoreServerUrl}/pets`, mockResponses.real('it worked!'));
 
-        expect(await petstoreSdk.get('/pets')).to.equal('it worked!');
+        expect(await petstoreSDK.get('/pets')).to.equal('it worked!');
       });
 
       it('should error if method does not exist', async function () {
-        await petstoreSdk
+        await petstoreSDK
           .fetch('/pets')
           .then(() => assert.fail())
           .catch(err => {
@@ -164,7 +179,7 @@ describe('api', function () {
 
       fetchMock.delete(`${petstoreServerUrl}/pets/${petId}`, { body: response, status: 404 });
 
-      await petstoreSdk
+      await petstoreSDK
         .deletePet({ id: petId })
         .then(() => assert.fail())
         .catch(async err => {
@@ -183,7 +198,7 @@ describe('api', function () {
         },
       });
 
-      expect(await petstoreSdk.deletePet({ id: petId })).to.have.deep.property('user-agent', userAgent);
+      expect(await petstoreSDK.deletePet({ id: petId })).to.have.deep.property('user-agent', userAgent);
     });
 
     describe('operationId', function () {
@@ -195,14 +210,14 @@ describe('api', function () {
 
         fetchMock.delete(`${petstoreServerUrl}/pets/${petId}`, response);
 
-        expect(await petstoreSdk.deletePet({ id: petId })).to.deep.equal(response);
+        expect(await petstoreSDK.deletePet({ id: petId })).to.deep.equal(response);
       });
 
       it('should pass through body for operationId', async function () {
         const body = { name: 'Buster' };
         fetchMock.post(`${petstoreServerUrl}/pets`, body, { body });
 
-        expect(await petstoreSdk.addPet(body)).to.deep.equal(body);
+        expect(await petstoreSDK.addPet(body)).to.deep.equal(body);
       });
 
       it('should pass through parameters and body for operationId', async function () {
@@ -214,8 +229,8 @@ describe('api', function () {
 
         fetchMock.put(`https://dash.readme.com/api/v1/changelogs/${slug}`, mockResponses.requestBody, { body });
 
-        readmeSdk.server('https://dash.readme.com/api/v1');
-        expect(await readmeSdk.updateChangelog(body, { slug })).to.deep.equal({
+        readmeSDK.server('https://dash.readme.com/api/v1');
+        expect(await readmeSDK.updateChangelog(body, { slug })).to.deep.equal({
           requestBody: body,
           uri: '/api/v1/changelogs/new-release',
         });
@@ -228,15 +243,15 @@ describe('api', function () {
 
         fetchMock.post(`${petstoreServerUrl}/pets`, body, { body });
 
-        expect(await petstoreSdk.post('/pets', body)).to.deep.equal(body);
+        expect(await petstoreSDK.post('/pets', body)).to.deep.equal(body);
       });
 
       it('should pass through parameters for method + path', async function () {
         const slug = 'new-release';
         fetchMock.put(`https://dash.readme.com/api/v1/changelogs/${slug}`, mockResponses.url('pathname'));
 
-        readmeSdk.server('https://dash.readme.com/api/v1');
-        expect(await readmeSdk.put('/changelogs/{slug}', { slug })).to.equal('/api/v1/changelogs/new-release');
+        readmeSDK.server('https://dash.readme.com/api/v1');
+        expect(await readmeSDK.put('/changelogs/{slug}', { slug })).to.equal('/api/v1/changelogs/new-release');
       });
 
       it('should pass through parameters and body for method + path', async function () {
@@ -248,8 +263,8 @@ describe('api', function () {
 
         fetchMock.put(`https://dash.readme.com/api/v1/changelogs/${slug}`, mockResponses.requestBody, { body });
 
-        readmeSdk.server('https://dash.readme.com/api/v1');
-        expect(await readmeSdk.put('/changelogs/{slug}', body, { slug })).to.deep.equal({
+        readmeSDK.server('https://dash.readme.com/api/v1');
+        expect(await readmeSDK.put('/changelogs/{slug}', body, { slug })).to.deep.equal({
           uri: '/api/v1/changelogs/new-release',
           requestBody: body,
         });

--- a/packages/api/test/integration.test.ts
+++ b/packages/api/test/integration.test.ts
@@ -1,4 +1,4 @@
-import type { OASDocument } from 'oas/@types/rmoas.types';
+import type { OASDocument } from 'oas/dist/rmoas.types';
 
 import chai, { expect } from 'chai';
 import fetchMock from 'fetch-mock';

--- a/packages/httpsnippet-client-api/package-lock.json
+++ b/packages/httpsnippet-client-api/package-lock.json
@@ -32,11 +32,11 @@
       },
       "peerDependencies": {
         "@readme/httpsnippet": "^4.0.3",
-        "oas": "^18.0.1"
+        "oas": "^18.3.4"
       }
     },
     "../api": {
-      "version": "5.0.0-beta.1",
+      "version": "5.0.0-beta.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -58,7 +58,7 @@
         "json-schema-traverse": "^1.0.0",
         "lodash.merge": "^4.6.2",
         "make-dir": "^3.1.0",
-        "oas": "^18.3.3",
+        "oas": "^18.3.4",
         "object-hash": "^3.0.0",
         "ora": "^5.4.1",
         "prompts": "^2.4.2",
@@ -1129,6 +1129,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -1477,7 +1478,8 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "node_modules/content-type": {
       "version": "1.0.4",
@@ -2288,6 +2290,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
       "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -3509,6 +3512,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -4052,16 +4056,16 @@
       }
     },
     "node_modules/oas": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-18.3.1.tgz",
-      "integrity": "sha512-xVGaimVxIrDw5s2/clIEYiU4szW2yG3l2UZbFY/810+JLNdOTPLWgAJ+SJVVdf0jqFVbl6rdLVPg2gNcTn6pdA==",
+      "version": "18.3.4",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-18.3.4.tgz",
+      "integrity": "sha512-mNaTC91kXLcfJjdLSxd2h06JlOAxFFa9+po+KbF7ifMb5PNYy0t0wvxllo0oS/Erztt8W917/fKX3kHVHWvBKw==",
       "peer": true,
       "dependencies": {
         "@readme/json-schema-ref-parser": "^1.1.0",
         "@types/json-schema": "^7.0.11",
         "cardinal": "^2.1.1",
         "chalk": "^4.1.2",
-        "glob": "^7.1.2",
+        "glob": "^8.0.1",
         "inquirer": "^8.1.2",
         "json-schema-merge-allof": "^0.8.1",
         "json2yaml": "^1.1.0",
@@ -4069,7 +4073,7 @@
         "memoizee": "^0.4.14",
         "minimist": "^1.2.0",
         "oas-normalize": "^6.0.0",
-        "openapi-types": "^10.0.0",
+        "openapi-types": "^12.0.0",
         "path-to-regexp": "^6.2.0",
         "swagger-inline": "^6.0.0"
       },
@@ -4207,6 +4211,15 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/oas/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
     "node_modules/oas/node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -4241,6 +4254,25 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "peer": true
     },
+    "node_modules/oas/node_modules/glob": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
+      "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
+      "peer": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/oas/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -4248,6 +4280,18 @@
       "peer": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/oas/node_modules/minimatch": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+      "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/oas/node_modules/supports-color": {
@@ -4316,9 +4360,9 @@
       }
     },
     "node_modules/openapi-types": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-10.0.0.tgz",
-      "integrity": "sha512-Y8xOCT2eiKGYDzMW9R4x5cmfc3vGaaI4EL2pwhDmodWw1HlK18YcZ4uJxc7Rdp7/gGzAygzH9SXr6GKYIXbRcQ==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.0.0.tgz",
+      "integrity": "sha512-6Wd9k8nmGQHgCbehZCP6wwWcfXcvinhybUTBatuhjRsCxUIujuYFZc9QnGeae75CyHASewBtxs0HX/qwREReUw==",
       "peer": true
     },
     "node_modules/ora": {
@@ -4454,6 +4498,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6308,7 +6353,7 @@
         "mocha": "^10.0.0",
         "mock-require": "^3.0.3",
         "nyc": "^15.1.0",
-        "oas": "^18.3.3",
+        "oas": "^18.3.4",
         "object-hash": "^3.0.0",
         "ora": "^5.4.1",
         "prompts": "^2.4.2",
@@ -6404,6 +6449,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -6665,7 +6711,8 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "content-type": {
       "version": "1.0.4",
@@ -7300,6 +7347,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
       "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -8191,6 +8239,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -8607,16 +8656,16 @@
       }
     },
     "oas": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-18.3.1.tgz",
-      "integrity": "sha512-xVGaimVxIrDw5s2/clIEYiU4szW2yG3l2UZbFY/810+JLNdOTPLWgAJ+SJVVdf0jqFVbl6rdLVPg2gNcTn6pdA==",
+      "version": "18.3.4",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-18.3.4.tgz",
+      "integrity": "sha512-mNaTC91kXLcfJjdLSxd2h06JlOAxFFa9+po+KbF7ifMb5PNYy0t0wvxllo0oS/Erztt8W917/fKX3kHVHWvBKw==",
       "peer": true,
       "requires": {
         "@readme/json-schema-ref-parser": "^1.1.0",
         "@types/json-schema": "^7.0.11",
         "cardinal": "^2.1.1",
         "chalk": "^4.1.2",
-        "glob": "^7.1.2",
+        "glob": "^8.0.1",
         "inquirer": "^8.1.2",
         "json-schema-merge-allof": "^0.8.1",
         "json2yaml": "^1.1.0",
@@ -8624,7 +8673,7 @@
         "memoizee": "^0.4.14",
         "minimist": "^1.2.0",
         "oas-normalize": "^6.0.0",
-        "openapi-types": "^10.0.0",
+        "openapi-types": "^12.0.0",
         "path-to-regexp": "^6.2.0",
         "swagger-inline": "^6.0.0"
       },
@@ -8636,6 +8685,15 @@
           "peer": true,
           "requires": {
             "color-convert": "^2.0.1"
+          }
+        },
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "peer": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
           }
         },
         "chalk": {
@@ -8663,11 +8721,33 @@
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "peer": true
         },
+        "glob": {
+          "version": "8.0.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
+          "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
+          "peer": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^5.0.1",
+            "once": "^1.3.0"
+          }
+        },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "peer": true
+        },
+        "minimatch": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+          "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+          "peer": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
         },
         "supports-color": {
           "version": "7.2.0",
@@ -8812,9 +8892,9 @@
       }
     },
     "openapi-types": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-10.0.0.tgz",
-      "integrity": "sha512-Y8xOCT2eiKGYDzMW9R4x5cmfc3vGaaI4EL2pwhDmodWw1HlK18YcZ4uJxc7Rdp7/gGzAygzH9SXr6GKYIXbRcQ==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.0.0.tgz",
+      "integrity": "sha512-6Wd9k8nmGQHgCbehZCP6wwWcfXcvinhybUTBatuhjRsCxUIujuYFZc9QnGeae75CyHASewBtxs0HX/qwREReUw==",
       "peer": true
     },
     "ora": {
@@ -8915,7 +8995,8 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "path-key": {
       "version": "3.1.1",

--- a/packages/httpsnippet-client-api/package.json
+++ b/packages/httpsnippet-client-api/package.json
@@ -29,7 +29,7 @@
   },
   "peerDependencies": {
     "@readme/httpsnippet": "^4.0.3",
-    "oas": "^18.0.1"
+    "oas": "^18.3.4"
   },
   "devDependencies": {
     "@readme/oas-examples": "^5.4.1",

--- a/packages/httpsnippet-client-api/src/index.ts
+++ b/packages/httpsnippet-client-api/src/index.ts
@@ -1,5 +1,5 @@
 import type { Operation } from 'oas';
-import type { HttpMethods, OASDocument } from 'oas/@types/rmoas.types';
+import type { HttpMethods, OASDocument } from 'oas/dist/rmoas.types';
 import type { Client } from '@readme/httpsnippet/dist/targets/targets';
 import stringifyObject from 'stringify-object';
 import { CodeBuilder } from '@readme/httpsnippet/dist/helpers/code-builder';

--- a/packages/httpsnippet-client-api/test/__datasets__/application-form-encoded/index.ts
+++ b/packages/httpsnippet-client-api/test/__datasets__/application-form-encoded/index.ts
@@ -1,4 +1,4 @@
-import type { OASDocument } from 'oas/@types/rmoas.types';
+import type { OASDocument } from 'oas/dist/rmoas.types';
 import type { SnippetMock } from '../../index.test';
 import definition from './openapi.json';
 

--- a/packages/httpsnippet-client-api/test/__datasets__/application-json/index.ts
+++ b/packages/httpsnippet-client-api/test/__datasets__/application-json/index.ts
@@ -1,4 +1,4 @@
-import type { OASDocument } from 'oas/@types/rmoas.types';
+import type { OASDocument } from 'oas/dist/rmoas.types';
 import type { SnippetMock } from '../../index.test';
 import definition from './openapi.json';
 

--- a/packages/httpsnippet-client-api/test/__datasets__/auth-apikey-cookie/index.ts
+++ b/packages/httpsnippet-client-api/test/__datasets__/auth-apikey-cookie/index.ts
@@ -1,4 +1,4 @@
-import type { OASDocument } from 'oas/@types/rmoas.types';
+import type { OASDocument } from 'oas/dist/rmoas.types';
 import type { SnippetMock } from '../../index.test';
 import definition from '@readme/oas-examples/3.0/json/security.json';
 

--- a/packages/httpsnippet-client-api/test/__datasets__/auth-apikey-header/index.ts
+++ b/packages/httpsnippet-client-api/test/__datasets__/auth-apikey-header/index.ts
@@ -1,4 +1,4 @@
-import type { OASDocument } from 'oas/@types/rmoas.types';
+import type { OASDocument } from 'oas/dist/rmoas.types';
 import type { SnippetMock } from '../../index.test';
 import definition from '@readme/oas-examples/3.0/json/security.json';
 

--- a/packages/httpsnippet-client-api/test/__datasets__/auth-basic-full/index.ts
+++ b/packages/httpsnippet-client-api/test/__datasets__/auth-basic-full/index.ts
@@ -1,4 +1,4 @@
-import type { OASDocument } from 'oas/@types/rmoas.types';
+import type { OASDocument } from 'oas/dist/rmoas.types';
 import type { SnippetMock } from '../../index.test';
 import definition from '@readme/oas-examples/3.0/json/readme.json';
 

--- a/packages/httpsnippet-client-api/test/__datasets__/auth-basic-password-only/index.ts
+++ b/packages/httpsnippet-client-api/test/__datasets__/auth-basic-password-only/index.ts
@@ -1,4 +1,4 @@
-import type { OASDocument } from 'oas/@types/rmoas.types';
+import type { OASDocument } from 'oas/dist/rmoas.types';
 import type { SnippetMock } from '../../index.test';
 import definition from '@readme/oas-examples/3.0/json/readme.json';
 

--- a/packages/httpsnippet-client-api/test/__datasets__/auth-basic-username-only/index.ts
+++ b/packages/httpsnippet-client-api/test/__datasets__/auth-basic-username-only/index.ts
@@ -1,4 +1,4 @@
-import type { OASDocument } from 'oas/@types/rmoas.types';
+import type { OASDocument } from 'oas/dist/rmoas.types';
 import type { SnippetMock } from '../../index.test';
 import definition from '@readme/oas-examples/3.0/json/readme.json';
 

--- a/packages/httpsnippet-client-api/test/__datasets__/auth-bearer/index.ts
+++ b/packages/httpsnippet-client-api/test/__datasets__/auth-bearer/index.ts
@@ -1,4 +1,4 @@
-import type { OASDocument } from 'oas/@types/rmoas.types';
+import type { OASDocument } from 'oas/dist/rmoas.types';
 import type { SnippetMock } from '../../index.test';
 import definition from '@readme/oas-examples/3.0/json/security.json';
 

--- a/packages/httpsnippet-client-api/test/__datasets__/auth-query/index.ts
+++ b/packages/httpsnippet-client-api/test/__datasets__/auth-query/index.ts
@@ -1,4 +1,4 @@
-import type { OASDocument } from 'oas/@types/rmoas.types';
+import type { OASDocument } from 'oas/dist/rmoas.types';
 import type { SnippetMock } from '../../index.test';
 import definition from '@readme/oas-examples/3.0/json/security.json';
 

--- a/packages/httpsnippet-client-api/test/__datasets__/cookies/index.ts
+++ b/packages/httpsnippet-client-api/test/__datasets__/cookies/index.ts
@@ -1,4 +1,4 @@
-import type { OASDocument } from 'oas/@types/rmoas.types';
+import type { OASDocument } from 'oas/dist/rmoas.types';
 import type { SnippetMock } from '../../index.test';
 import definition from './openapi.json';
 

--- a/packages/httpsnippet-client-api/test/__datasets__/full-many-query-params/index.ts
+++ b/packages/httpsnippet-client-api/test/__datasets__/full-many-query-params/index.ts
@@ -1,4 +1,4 @@
-import type { OASDocument } from 'oas/@types/rmoas.types';
+import type { OASDocument } from 'oas/dist/rmoas.types';
 import type { SnippetMock } from '../../index.test';
 import definition from './openapi.json';
 

--- a/packages/httpsnippet-client-api/test/__datasets__/full/index.ts
+++ b/packages/httpsnippet-client-api/test/__datasets__/full/index.ts
@@ -1,4 +1,4 @@
-import type { OASDocument } from 'oas/@types/rmoas.types';
+import type { OASDocument } from 'oas/dist/rmoas.types';
 import type { SnippetMock } from '../../index.test';
 import definition from './openapi.json';
 

--- a/packages/httpsnippet-client-api/test/__datasets__/headers/index.ts
+++ b/packages/httpsnippet-client-api/test/__datasets__/headers/index.ts
@@ -1,4 +1,4 @@
-import type { OASDocument } from 'oas/@types/rmoas.types';
+import type { OASDocument } from 'oas/dist/rmoas.types';
 import type { SnippetMock } from '../../index.test';
 import definition from './openapi.json';
 

--- a/packages/httpsnippet-client-api/test/__datasets__/http-insecure/index.ts
+++ b/packages/httpsnippet-client-api/test/__datasets__/http-insecure/index.ts
@@ -1,4 +1,4 @@
-import type { OASDocument } from 'oas/@types/rmoas.types';
+import type { OASDocument } from 'oas/dist/rmoas.types';
 import type { SnippetMock } from '../../index.test';
 import definition from './openapi.json';
 

--- a/packages/httpsnippet-client-api/test/__datasets__/issue-128/index.ts
+++ b/packages/httpsnippet-client-api/test/__datasets__/issue-128/index.ts
@@ -1,4 +1,4 @@
-import type { OASDocument } from 'oas/@types/rmoas.types';
+import type { OASDocument } from 'oas/dist/rmoas.types';
 import type { SnippetMock } from '../../index.test';
 import definition from './openapi.json';
 

--- a/packages/httpsnippet-client-api/test/__datasets__/issue-76/index.ts
+++ b/packages/httpsnippet-client-api/test/__datasets__/issue-76/index.ts
@@ -1,4 +1,4 @@
-import type { OASDocument } from 'oas/@types/rmoas.types';
+import type { OASDocument } from 'oas/dist/rmoas.types';
 import type { SnippetMock } from '../../index.test';
 import definition from './openapi.json';
 

--- a/packages/httpsnippet-client-api/test/__datasets__/issue-78-operationid/index.ts
+++ b/packages/httpsnippet-client-api/test/__datasets__/issue-78-operationid/index.ts
@@ -1,4 +1,4 @@
-import type { OASDocument } from 'oas/@types/rmoas.types';
+import type { OASDocument } from 'oas/dist/rmoas.types';
 import type { SnippetMock } from '../../index.test';
 import definition from './openapi.json';
 

--- a/packages/httpsnippet-client-api/test/__datasets__/issue-78/index.ts
+++ b/packages/httpsnippet-client-api/test/__datasets__/issue-78/index.ts
@@ -1,4 +1,4 @@
-import type { OASDocument } from 'oas/@types/rmoas.types';
+import type { OASDocument } from 'oas/dist/rmoas.types';
 import type { SnippetMock } from '../../index.test';
 import definition from './openapi.json';
 

--- a/packages/httpsnippet-client-api/test/__datasets__/jsonObj-multiline/index.ts
+++ b/packages/httpsnippet-client-api/test/__datasets__/jsonObj-multiline/index.ts
@@ -1,4 +1,4 @@
-import type { OASDocument } from 'oas/@types/rmoas.types';
+import type { OASDocument } from 'oas/dist/rmoas.types';
 import type { SnippetMock } from '../../index.test';
 import definition from './openapi.json';
 

--- a/packages/httpsnippet-client-api/test/__datasets__/jsonObj-null-value/index.ts
+++ b/packages/httpsnippet-client-api/test/__datasets__/jsonObj-null-value/index.ts
@@ -1,4 +1,4 @@
-import type { OASDocument } from 'oas/@types/rmoas.types';
+import type { OASDocument } from 'oas/dist/rmoas.types';
 import type { SnippetMock } from '../../index.test';
 import definition from './openapi.json';
 

--- a/packages/httpsnippet-client-api/test/__datasets__/multipart-data/index.ts
+++ b/packages/httpsnippet-client-api/test/__datasets__/multipart-data/index.ts
@@ -1,4 +1,4 @@
-import type { OASDocument } from 'oas/@types/rmoas.types';
+import type { OASDocument } from 'oas/dist/rmoas.types';
 import type { SnippetMock } from '../../index.test';
 import definition from './openapi.json';
 import { streamToString } from '../../helpers/fetch-mock';

--- a/packages/httpsnippet-client-api/test/__datasets__/multipart-file/index.ts
+++ b/packages/httpsnippet-client-api/test/__datasets__/multipart-file/index.ts
@@ -1,4 +1,4 @@
-import type { OASDocument } from 'oas/@types/rmoas.types';
+import type { OASDocument } from 'oas/dist/rmoas.types';
 import type { SnippetMock } from '../../index.test';
 import definition from './openapi.json';
 import { streamToString } from '../../helpers/fetch-mock';

--- a/packages/httpsnippet-client-api/test/__datasets__/multipart-form-data-no-params/index.ts
+++ b/packages/httpsnippet-client-api/test/__datasets__/multipart-form-data-no-params/index.ts
@@ -1,4 +1,4 @@
-import type { OASDocument } from 'oas/@types/rmoas.types';
+import type { OASDocument } from 'oas/dist/rmoas.types';
 import type { SnippetMock } from '../../index.test';
 import definition from './openapi.json';
 

--- a/packages/httpsnippet-client-api/test/__datasets__/multipart-form-data/index.ts
+++ b/packages/httpsnippet-client-api/test/__datasets__/multipart-form-data/index.ts
@@ -1,4 +1,4 @@
-import type { OASDocument } from 'oas/@types/rmoas.types';
+import type { OASDocument } from 'oas/dist/rmoas.types';
 import type { SnippetMock } from '../../index.test';
 import definition from './openapi.json';
 import { streamToString } from '../../helpers/fetch-mock';

--- a/packages/httpsnippet-client-api/test/__datasets__/operationid-non-alphanumerical/index.ts
+++ b/packages/httpsnippet-client-api/test/__datasets__/operationid-non-alphanumerical/index.ts
@@ -1,4 +1,4 @@
-import type { OASDocument } from 'oas/@types/rmoas.types';
+import type { OASDocument } from 'oas/dist/rmoas.types';
 import type { SnippetMock } from '../../index.test';
 import definition from './openapi.json';
 

--- a/packages/httpsnippet-client-api/test/__datasets__/operationid-with-underscores/index.ts
+++ b/packages/httpsnippet-client-api/test/__datasets__/operationid-with-underscores/index.ts
@@ -1,4 +1,4 @@
-import type { OASDocument } from 'oas/@types/rmoas.types';
+import type { OASDocument } from 'oas/dist/rmoas.types';
 import type { SnippetMock } from '../../index.test';
 import definition from './openapi.json';
 

--- a/packages/httpsnippet-client-api/test/__datasets__/operationid-with-underscores/output.js
+++ b/packages/httpsnippet-client-api/test/__datasets__/operationid-with-underscores/output.js
@@ -1,5 +1,5 @@
 const sdk = require('api')('https://api.example.com/operationid-with-underscores.json');
 
-sdk.anythingOperation()
+sdk.anything_Operation()
   .then(res => console.log(res))
   .catch(err => console.error(err));

--- a/packages/httpsnippet-client-api/test/__datasets__/petstore/index.ts
+++ b/packages/httpsnippet-client-api/test/__datasets__/petstore/index.ts
@@ -1,4 +1,4 @@
-import type { OASDocument } from 'oas/@types/rmoas.types';
+import type { OASDocument } from 'oas/dist/rmoas.types';
 import type { SnippetMock } from '../../index.test';
 import definition from '@readme/oas-examples/3.0/json/petstore.json';
 

--- a/packages/httpsnippet-client-api/test/__datasets__/query/index.ts
+++ b/packages/httpsnippet-client-api/test/__datasets__/query/index.ts
@@ -1,4 +1,4 @@
-import type { OASDocument } from 'oas/@types/rmoas.types';
+import type { OASDocument } from 'oas/dist/rmoas.types';
 import type { SnippetMock } from '../../index.test';
 import definition from './openapi.json';
 

--- a/packages/httpsnippet-client-api/test/__datasets__/short/index.ts
+++ b/packages/httpsnippet-client-api/test/__datasets__/short/index.ts
@@ -1,4 +1,4 @@
-import type { OASDocument } from 'oas/@types/rmoas.types';
+import type { OASDocument } from 'oas/dist/rmoas.types';
 import type { SnippetMock } from '../../index.test';
 import definition from './openapi.json';
 

--- a/packages/httpsnippet-client-api/test/__datasets__/text-plain/index.ts
+++ b/packages/httpsnippet-client-api/test/__datasets__/text-plain/index.ts
@@ -1,4 +1,4 @@
-import type { OASDocument } from 'oas/@types/rmoas.types';
+import type { OASDocument } from 'oas/dist/rmoas.types';
 import type { SnippetMock } from '../../index.test';
 import definition from './openapi.json';
 

--- a/packages/httpsnippet-client-api/test/index.test.ts
+++ b/packages/httpsnippet-client-api/test/index.test.ts
@@ -2,7 +2,7 @@
 /* eslint-disable mocha/no-setup-in-describe */
 import type { HarRequest, Request } from '@readme/httpsnippet';
 import type { Client } from '@readme/httpsnippet/dist/targets/targets';
-import type { OASDocument } from 'oas/@types/rmoas.types';
+import type { OASDocument } from 'oas/dist/rmoas.types';
 import type { MockMatcher, MockOptions } from 'fetch-mock';
 
 import 'isomorphic-fetch';


### PR DESCRIPTION
| 🚥 Fix #488 |
| :-- |

## 🧰 Changes

This fixes a bug we had where if an operationID had underscores in it like `ExchangeRESTAPI_GetAccounts` our `oas` library would convert it into `ExchangeRESTAPIGetAccounts` because weren't recognizing underscores as being valid characters for a JS method accessor. This would result in calls to `sdk.ExchangeRESTAPI_GetAccounts` failing because it wasn't recognized as a valid operationID.

See https://github.com/readmeio/oas/pull/671 for the `oas` side of this fix.

## 🧬 QA & Testing

So we actually had some tests in place for this sort of thing but they were assuming a that underscores weren't valid. Egg on my face.