### PR TITLE
feat: allow original operationIDs to be used in dynamic SDKs

### DIFF
--- a/packages/api/test/__fixtures__/definitions/operationid-quirks.json
+++ b/packages/api/test/__fixtures__/definitions/operationid-quirks.json
@@ -28,8 +28,8 @@
     },
     "/hyphenated-operation-id": {
       "get": {
-        "operationId": "get-pet",
-        "description": "This operation has an `operationId` with hypens yet it should still be accessible in the dynamic `api` flow"
+        "operationId": "hyphenated-operation-id",
+        "description": "This operation has an `operationId` with hypens yet it should still be accessible in the dynamic `api` flow."
       }
     }
   }

--- a/packages/api/test/__fixtures__/definitions/operationid-quirks.json
+++ b/packages/api/test/__fixtures__/definitions/operationid-quirks.json
@@ -25,6 +25,12 @@
       "get": {
         "description": "This operation has no `operationId` but because path starts with an HTTP method when we generate an `operationId` that has `get` doubled."
       }
+    },
+    "/hyphenated-operation-id": {
+      "get": {
+        "operationId": "get-pet",
+        "description": "This operation has an `operationId` with hypens yet it should still be accessible in the dynamic `api` flow"
+      }
     }
   }
 }

--- a/packages/api/test/__fixtures__/sdk/operationid-quirks/index.d.ts
+++ b/packages/api/test/__fixtures__/sdk/operationid-quirks/index.d.ts
@@ -60,10 +60,20 @@ declare class SDK {
    */
   get<T = unknown>(path: '/quirky-operationId'): Promise<T>;
   /**
+   * This operation has an `operationId` with hypens yet it should still be accessible in the dynamic `api` flow.
+   *
+   */
+  get<T = unknown>(path: '/hyphenated-operation-id'): Promise<T>;
+  /**
    * This mess of a string is intentionally nasty so we can be sure that we're not including anything that wouldn't look right as an operationID for a potential method accessor in `api`.
    *
    */
   quirky_OperationId_string<T = unknown>(): Promise<T>;
+  /**
+   * This operation has an `operationId` with hypens yet it should still be accessible in the dynamic `api` flow.
+   *
+   */
+  hyphenatedOperationId<T = unknown>(): Promise<T>;
 }
 declare const createSDK: SDK;
 export default createSDK;

--- a/packages/api/test/__fixtures__/sdk/operationid-quirks/index.ts
+++ b/packages/api/test/__fixtures__/sdk/operationid-quirks/index.ts
@@ -77,6 +77,11 @@ class SDK {
    */
   get<T = unknown>(path: '/quirky-operationId'): Promise<T>;
   /**
+   * This operation has an `operationId` with hypens yet it should still be accessible in the dynamic `api` flow.
+   *
+   */
+  get<T = unknown>(path: '/hyphenated-operation-id'): Promise<T>;
+  /**
    * Access any GET endpoint on your API.
    *
    * @param path API path to make a request against.
@@ -92,6 +97,14 @@ class SDK {
    */
   quirky_OperationId_string<T = unknown>(): Promise<T> {
     return this.core.fetch('/quirky-operationId', 'get');
+  }
+
+  /**
+   * This operation has an `operationId` with hypens yet it should still be accessible in the dynamic `api` flow.
+   *
+   */
+  hyphenatedOperationId<T = unknown>(): Promise<T> {
+    return this.core.fetch('/hyphenated-operation-id', 'get');
   }
 }
 

--- a/packages/api/test/index.test.ts
+++ b/packages/api/test/index.test.ts
@@ -122,8 +122,8 @@ describe('api', function () {
       it('should work with operationIds that contain hyphens', async function () {
         fetchMock.get('https://httpbin.org/anything/hyphenated-operation-id', mockResponses.real('it worked!'));
 
-        expect(await operationIDQuirksSDK['get-pet']()).to.equal('it worked!');
-        expect(await operationIDQuirksSDK.getPet()).to.equal('it worked!');
+        expect(await operationIDQuirksSDK['hyphenated-operation-id']()).to.equal('it worked!');
+        expect(await operationIDQuirksSDK.hyphenatedOperationId()).to.equal('it worked!');
       });
 
       it('should support an operationId that was dynamically cleaned up within `Operation.getOperationId', async function () {


### PR DESCRIPTION
## 🧰 Changes

This resolves a compatibility issue I introduced in v5 where because we now prefer cleaner, JS-method acessors to be used everywhere if you have an `operationId` that we deem to not be valid as a method accessor and clean it up, you can no longer use your original `operationId`.

For example if you have an operation that has `get-pet` as its `operationId` under v4 our code snippets would have you do this:

```js
await sdk['get-pet']().then(console.log);
```

In v5, and with our code snippets now in production we have you do this:

```js
await sdk.getPet().then(console.log);
```

If you upgrade from v4 to the v5 beta and have `sdk['get-pet']` we'll throw an error because though `get-pet` is in your spec we've rewritten it to be `getPet` and no longer recognize `get-pet`.

With this work here we'll now recognize both `sdk.getPet()` and `sdk['get-pet']()` as valid operationID accessors but will we'll continue to recommend you use `sdk.getPet()` as it's cleaner.