### PR TITLE
Fix example in README

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -25,7 +25,7 @@
 `api` is a library that facilitates creating an SDK from an OpenAPI definition. You can use its codegen offering to create an opinionated SDK for TypeScript or JS (+ TypeScript types).
 
 ```sh
-$ npx api install https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/examples/v3.0/petstore.json
+$ npx api@beta install https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/examples/v3.0/petstore.json
 ```
 
 ```js


### PR DESCRIPTION
The original example was failing with a `could not determine executable to run` error.