### PR TITLE
fix: prefix schema titles that start with numbers to fix a type generation bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -780,9 +780,9 @@
       }
     },
     "node_modules/@exodus/schemasafe": {
-      "version": "1.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@exodus/schemasafe/-/schemasafe-1.0.0-rc.6.tgz",
-      "integrity": "sha512-dDnQizD94EdBwEj/fh3zPRa/HWCS9O5au2PuHhZBbuM3xWHxuaKzPBOEWze7Nn0xW68MIpZ7Xdyn1CoCpjKCuQ=="
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@exodus/schemasafe/-/schemasafe-1.0.0-rc.9.tgz",
+      "integrity": "sha512-dGGHpb61hLwifAu7sotuHFDBw6GTdpG8aKC0fsK17EuTzMRvUrH7lEAr6LTJ+sx3AZYed9yZ77rltVDHyg2hRg=="
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.10.7",
@@ -1016,12 +1016,6 @@
         "url": "https://opencollective.com/unts"
       }
     },
-    "node_modules/@pkgr/utils/node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-      "dev": true
-    },
     "node_modules/@readme/better-ajv-errors": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@readme/better-ajv-errors/-/better-ajv-errors-1.5.0.tgz",
@@ -1136,24 +1130,24 @@
       "dev": true
     },
     "node_modules/@readme/oas-extensions": {
-      "version": "14.4.0",
-      "resolved": "https://registry.npmjs.org/@readme/oas-extensions/-/oas-extensions-14.4.0.tgz",
-      "integrity": "sha512-vNrZ1s7SyvWfqJAW9OI3lciDe9fbgJYXz2XIGoyi6f3Q8MMHbKx1GCVsX4SiAFai7lUIZDe2ltEKKtoxTfOKNQ==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/oas-extensions/-/oas-extensions-16.0.0.tgz",
+      "integrity": "sha512-oNsbsFR6X2+jAcT+CMnWFoFEUPJvKgavvVNoq8O473YfpXKJ/1pTFy3Dv+pHeEQ6c54lgoTUVuErUy+cIuDb0g==",
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "oas": "^17.1.0 || ^18.0.0"
+        "oas": "^19.0.0"
       }
     },
     "node_modules/@readme/oas-to-har": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-18.0.0.tgz",
-      "integrity": "sha512-sMNVAgxI9tRG3QAECzilwJtZ5c4M64qoYG145eW9R9aUSNmtgIKprKkn66dDnwYDw7zo/23L0YbMvZCsWeRN4Q==",
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-19.0.0.tgz",
+      "integrity": "sha512-UAgd9jVBBj5rroqBRStzs74IAPx1yp+7k5sqTpuJTApryw28xJNUtvMEwKGSRS17qqOfe1mVInBqeGtEOhxiPQ==",
       "dependencies": {
         "@readme/data-urls": "^1.0.1",
-        "@readme/oas-extensions": "^14.4.0",
-        "oas": "^18.3.1",
+        "@readme/oas-extensions": "^16.0.0",
+        "oas": "^19.0.0",
         "qs": "^6.10.5",
         "remove-undefined-objects": "^2.0.0"
       },
@@ -2205,7 +2199,7 @@
     "node_modules/ansicolors": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
-      "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk="
+      "integrity": "sha512-QXu7BPrP29VllRxH8GwB7x5iX5qWKAAMLqKQGWTeLWVlNHNOpVMJ91dsxQAIWXpjuW5wqvxu3Jd/nRjrJ+0pqg=="
     },
     "node_modules/any-promise": {
       "version": "1.3.0",
@@ -2753,7 +2747,7 @@
     "node_modules/cardinal": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-2.1.1.tgz",
-      "integrity": "sha1-fMEFXYItISlU0HsIXeolHMe8VQU=",
+      "integrity": "sha512-JSr5eOgoEymtYHBjNWyjrMqet9Am2miJhlfKNdqLp6zoeAh0KN5dRAcxlecj5mAJrmQomgiOBj35xHLrFjqBpw==",
       "dependencies": {
         "ansicolors": "~0.3.2",
         "redeyed": "~2.1.0"
@@ -3513,8 +3507,7 @@
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
-      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-      "dev": true
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
     },
     "node_modules/default-require-extensions": {
       "version": "3.0.0",
@@ -3728,16 +3721,17 @@
       }
     },
     "node_modules/es-aggregate-error": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/es-aggregate-error/-/es-aggregate-error-1.0.7.tgz",
-      "integrity": "sha512-Zob/KUAOQUTvCzqgL2FEgtqNLPX5rYW3VhlldZ6La4W2mJUv3J8DmD0/sPxuD+kSAKF6nuceJ3uOSvCaaTLUyQ==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/es-aggregate-error/-/es-aggregate-error-1.0.8.tgz",
+      "integrity": "sha512-AKUb5MKLWMozPlFRHOKqWD7yta5uaEhH21qwtnf6FlKjNjTJOoqFi0/G14+FfSkIQhhu6X68Af4xgRC6y8qG4A==",
       "dependencies": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.0",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5",
         "function-bind": "^1.1.1",
-        "functions-have-names": "^1.2.2",
+        "functions-have-names": "^1.2.3",
         "get-intrinsic": "^1.1.1",
-        "globalthis": "^1.0.2"
+        "globalthis": "^1.0.2",
+        "has-property-descriptors": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3827,7 +3821,7 @@
     "node_modules/es6-promise": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
-      "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM="
+      "integrity": "sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg=="
     },
     "node_modules/es6-symbol": {
       "version": "3.1.3",
@@ -3876,6 +3870,82 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/escodegen": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
+      "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=4.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/escodegen/node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/escodegen/node_modules/levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
+      "dependencies": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/escodegen/node_modules/optionator": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+      "dependencies": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.6",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "word-wrap": "~1.2.3"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/escodegen/node_modules/prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/escodegen/node_modules/type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
+      "dependencies": {
+        "prelude-ls": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/eslint": {
@@ -4805,7 +4875,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4933,8 +5002,7 @@
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-      "dev": true
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "node_modules/fast-safe-stringify": {
       "version": "2.1.1",
@@ -5485,9 +5553,9 @@
       }
     },
     "node_modules/globalthis": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.2.tgz",
-      "integrity": "sha512-ZQnSFO1la8P7auIOQECnm0sSuoMeaSq0EEdXMBFF2QJO4uNcwbyhSgG3MruWNbFTqCLmxVwGOl7LZ9kASvHdeQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
+      "integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
       "dependencies": {
         "define-properties": "^1.1.3"
       },
@@ -6396,9 +6464,9 @@
       "dev": true
     },
     "node_modules/inquirer": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.0.tgz",
-      "integrity": "sha512-0crLweprevJ02tTuA6ThpoAERAGyVILC4sS74uib58Xf/zSr1/ZWtmm7D5CI+bSQEaA04f0K7idaHpQbSWgiVQ==",
+      "version": "8.2.4",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.4.tgz",
+      "integrity": "sha512-nn4F01dxU8VeKfq192IjLsxu0/OmMZ4Lg3xKAns148rCaXP6ntAoEkVYZThWjwON8AlzdZZi6oqnhNbxUG9hVg==",
       "dependencies": {
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.1.1",
@@ -6410,13 +6478,14 @@
         "mute-stream": "0.0.8",
         "ora": "^5.4.1",
         "run-async": "^2.4.0",
-        "rxjs": "^7.2.0",
+        "rxjs": "^7.5.5",
         "string-width": "^4.1.0",
         "strip-ansi": "^6.0.0",
-        "through": "^2.3.6"
+        "through": "^2.3.6",
+        "wrap-ansi": "^7.0.0"
       },
       "engines": {
-        "node": ">=8.0.0"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/internal-slot": {
@@ -7217,7 +7286,7 @@
     "node_modules/json2yaml": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/json2yaml/-/json2yaml-1.1.0.tgz",
-      "integrity": "sha1-VBTZB/mBZYa4DFE+wuOusquBmmw=",
+      "integrity": "sha512-/xse+m0SlllfZahQrNOelmLrFNfeZv4QG0QKlvg7VsPSGIxpB3X+ggLkdffwmI1DdQ3o9XjZX+K+EOI1epdKgg==",
       "dependencies": {
         "remedial": "1.x"
       },
@@ -7266,6 +7335,28 @@
       "engines": [
         "node >= 0.2.0"
       ]
+    },
+    "node_modules/jsonpath": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/jsonpath/-/jsonpath-1.1.1.tgz",
+      "integrity": "sha512-l6Cg7jRpixfbgoWgkrl77dgEj8RPvND0wMH6TwQmi9Qs4TFfS9u5cUFnbeKTwj5ga5Y3BTGGNI28k117LJ009w==",
+      "dependencies": {
+        "esprima": "1.2.2",
+        "static-eval": "2.0.2",
+        "underscore": "1.12.1"
+      }
+    },
+    "node_modules/jsonpath/node_modules/esprima": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.2.tgz",
+      "integrity": "sha512-+JpPZam9w5DuJ3Q67SqsMGtiHKENSMRVoxvArfJZK01/BfLEObtZ6orJa/MtoGNR/rfMgp5837T41PAmTwAv/A==",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/jsonpointer": {
       "version": "5.0.0",
@@ -7481,7 +7572,7 @@
     "node_modules/line-counter": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/line-counter/-/line-counter-1.1.0.tgz",
-      "integrity": "sha1-EN8sBGrTVG5yT7pV+nLN4YpqAfM="
+      "integrity": "sha512-6bmXJG/pOX5HBb2aIJZrI9CALBgY1VMbS0GPuXfJaT13UEfee/2xxPCsOOJdXLl3KPRyBf2/D+cjiG8hU9S7LA=="
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
@@ -9285,7 +9376,7 @@
     "node_modules/node-readfiles": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/node-readfiles/-/node-readfiles-0.2.0.tgz",
-      "integrity": "sha1-271K8SE04uY1wkXvk//Pb2BnOl0=",
+      "integrity": "sha512-SU00ZarexNlE4Rjdm83vglt5Y9yiQ+XI1XpflWlb7q7UTN1JUItm69xMeiQCTxtTfnzt+83T8Cx+vI2ED++VDA==",
       "dependencies": {
         "es6-promise": "^3.2.1"
       }
@@ -9524,9 +9615,9 @@
       }
     },
     "node_modules/oas": {
-      "version": "18.3.4",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-18.3.4.tgz",
-      "integrity": "sha512-mNaTC91kXLcfJjdLSxd2h06JlOAxFFa9+po+KbF7ifMb5PNYy0t0wvxllo0oS/Erztt8W917/fKX3kHVHWvBKw==",
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-19.0.0.tgz",
+      "integrity": "sha512-sN2oW57IXPgxWsfm5IbpLkjeMjs7VzRcBgqhrMZNyPWOkFPsGizRQolMuL4FqeUhIdcaFnv+2DcRLbwliF4g4w==",
       "dependencies": {
         "@readme/json-schema-ref-parser": "^1.1.0",
         "@types/json-schema": "^7.0.11",
@@ -9536,10 +9627,11 @@
         "inquirer": "^8.1.2",
         "json-schema-merge-allof": "^0.8.1",
         "json2yaml": "^1.1.0",
+        "jsonpath": "^1.1.1",
         "jsonpointer": "^5.0.0",
         "memoizee": "^0.4.14",
         "minimist": "^1.2.0",
-        "oas-normalize": "^6.0.0",
+        "oas-normalize": "^7.0.0",
         "openapi-types": "^12.0.0",
         "path-to-regexp": "^6.2.0",
         "swagger-inline": "^6.0.0"
@@ -9573,13 +9665,14 @@
       }
     },
     "node_modules/oas-normalize": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-6.0.0.tgz",
-      "integrity": "sha512-BYVM3tpl4J5uVAN0EXeFaBKfwMufpCziIfEkU8tfer579p+RKj3qlXaF+rblvTZh4vEmnjNLR4ULmciHfDPF8w==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-7.0.0.tgz",
+      "integrity": "sha512-K/ChGYwdXPR1Vl0fnIdeAmEeQIw/MV90QmRL3DLsRGIS27/VaDn+ChMZ0GvTrE2lxjlDiGkm8cgKqS95F2jQNQ==",
       "dependencies": {
         "@readme/openapi-parser": "^2.2.0",
         "js-yaml": "^4.1.0",
         "node-fetch": "^2.6.1",
+        "openapi-types": "^12.0.0",
         "swagger2openapi": "^7.0.8"
       },
       "engines": {
@@ -10109,9 +10202,9 @@
       "dev": true
     },
     "node_modules/path-to-regexp": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.0.tgz",
-      "integrity": "sha512-f66KywYG6+43afgE/8j/GoiNyygk/bnoCbps++3ErRKsIYkGGupyv07R2Ok5m9i67Iqc+T2g1eAUGUPzWhYTyg=="
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
+      "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw=="
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -10494,7 +10587,7 @@
     "node_modules/quotemeta": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/quotemeta/-/quotemeta-0.0.0.tgz",
-      "integrity": "sha1-UdOgbuD81uO1AdvSiQQ1Gtelo4w="
+      "integrity": "sha512-1XGObUh7RN5b58vKuAsrlfqT+Rc4vmw8N4pP9gFCq1GFlTdV0Ex/D2Ro1Drvrqj++HPi3ig0Np17XPslELeMRA=="
     },
     "node_modules/rambda": {
       "version": "7.2.0",
@@ -10711,7 +10804,7 @@
     "node_modules/redeyed": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-2.1.1.tgz",
-      "integrity": "sha1-iYS1gV2ZyyIEacme7v/jiRPmzAs=",
+      "integrity": "sha512-FNpGGo1DycYAdnrKFxCMmKYgo/mILAqtRYbkdQD8Ep/Hk2PQ5+aEAEx+IU713RTDmuBaH0c8P5ZozurNu5ObRQ==",
       "dependencies": {
         "esprima": "~4.0.0"
       }
@@ -11160,9 +11253,9 @@
       }
     },
     "node_modules/rxjs": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.5.tgz",
-      "integrity": "sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==",
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.7.tgz",
+      "integrity": "sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==",
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -11291,7 +11384,7 @@
     "node_modules/should-format": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/should-format/-/should-format-3.0.3.tgz",
-      "integrity": "sha1-m/yPdPo5IFxT04w01xcwPidxJPE=",
+      "integrity": "sha512-hZ58adtulAk0gKtua7QxevgUaXTTXxIi8t41L3zo9AHvjXO1/7sdLECuHeIN2SRtYXpNkmhoUP2pdeWgricQ+Q==",
       "dependencies": {
         "should-type": "^1.3.0",
         "should-type-adaptors": "^1.0.1"
@@ -11300,7 +11393,7 @@
     "node_modules/should-type": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/should-type/-/should-type-1.4.0.tgz",
-      "integrity": "sha1-B1bYzoRt/QmEOmlHcZ36DUz/XPM="
+      "integrity": "sha512-MdAsTu3n25yDbIe1NeN69G4n6mUnJGtSJHygX3+oN0ZbO3DTiATnf7XnYJdGT42JCXurTb1JI0qOBR65shvhPQ=="
     },
     "node_modules/should-type-adaptors": {
       "version": "1.1.0",
@@ -11394,7 +11487,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11675,6 +11768,14 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
+    "node_modules/static-eval": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.0.2.tgz",
+      "integrity": "sha512-N/D219Hcr2bPjLxPiV+TQE++Tsmrady7TqAJugLy7Xk1EumfDWS/f5dtBbkRCGE7wKKXuYockQoj8Rm2/pVKyg==",
+      "dependencies": {
+        "escodegen": "^1.8.1"
+      }
+    },
     "node_modules/stream-combiner": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
@@ -11884,9 +11985,9 @@
       }
     },
     "node_modules/swagger-inline": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/swagger-inline/-/swagger-inline-6.0.0.tgz",
-      "integrity": "sha512-JMin/1saGVuVhWdngKK+3fpICiV+GlAkYznNcXsSPTL8Cs9c3+Rlsalct5JcP+DUvPRcnqiVxnVqeYe69kSUKw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/swagger-inline/-/swagger-inline-6.1.0.tgz",
+      "integrity": "sha512-LAaA4otoy37HZ7qlzyrjCl2XMAt0X1WMHKenYh9J6mKrLN8mjckaQDElEZSiW2rKddwUoQb6sPtEAj+RYL1SkQ==",
       "dependencies": {
         "commander": "^6.0.0",
         "globby": "^11.0.1",
@@ -11942,12 +12043,6 @@
       "funding": {
         "url": "https://opencollective.com/unts"
       }
-    },
-    "node_modules/synckit/node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-      "dev": true
     },
     "node_modules/tapable": {
       "version": "2.2.1",
@@ -12220,9 +12315,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -12330,6 +12425,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/underscore": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
+      "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
     },
     "node_modules/unherit": {
       "version": "3.0.0",
@@ -12799,17 +12899,17 @@
     "node_modules/validate.io-array": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/validate.io-array/-/validate.io-array-1.0.6.tgz",
-      "integrity": "sha1-W1osr9j4uFq7L4hroVPy2Tond00="
+      "integrity": "sha512-DeOy7CnPEziggrOO5CZhVKJw6S3Yi7e9e65R1Nl/RTN1vTQKnzjfvks0/8kQ40FP/dsjRAOd4hxmJ7uLa6vxkg=="
     },
     "node_modules/validate.io-function": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/validate.io-function/-/validate.io-function-1.0.2.tgz",
-      "integrity": "sha1-NDoZgC7TsZaCaceA5VjpNBHAutc="
+      "integrity": "sha512-LlFybRJEriSuBnUhQyG5bwglhh50EpTL2ul23MPIuR1odjO7XaMLFV8vHGwp7AZciFxtYOeiSCT5st+XSPONiQ=="
     },
     "node_modules/validate.io-integer": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/validate.io-integer/-/validate.io-integer-1.0.5.tgz",
-      "integrity": "sha1-FoSWSAuVviJH7EQ/IjPeT4mHgGg=",
+      "integrity": "sha512-22izsYSLojN/P6bppBqhgUDjCkr5RY2jd+N2a3DCAUey8ydvrZ/OkGvFPR7qfOpwR2LC5p4Ngzxz36g5Vgr/hQ==",
       "dependencies": {
         "validate.io-number": "^1.0.3"
       }
@@ -12817,7 +12917,7 @@
     "node_modules/validate.io-integer-array": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/validate.io-integer-array/-/validate.io-integer-array-1.0.0.tgz",
-      "integrity": "sha1-LKveAzKTpry+Bj/q/pHq9GsToIk=",
+      "integrity": "sha512-mTrMk/1ytQHtCY0oNO3dztafHYyGU88KL+jRxWuzfOmQb+4qqnWmI+gykvGp8usKZOM0H7keJHEbRaFiYA0VrA==",
       "dependencies": {
         "validate.io-array": "^1.0.3",
         "validate.io-integer": "^1.0.4"
@@ -12826,7 +12926,7 @@
     "node_modules/validate.io-number": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/validate.io-number/-/validate.io-number-1.0.3.tgz",
-      "integrity": "sha1-9j/+2iSL8opnqNSODjtGGhZluvg="
+      "integrity": "sha512-kRAyotcbNaSYoDnXvb4MHg/0a1egJdLwS6oJ38TJY7aw9n93Fl/3blIXdyYvPOp55CNxywooG/3BcrwNrBpcSg=="
     },
     "node_modules/vfile": {
       "version": "5.3.4",
@@ -13085,7 +13185,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13285,7 +13384,7 @@
       "version": "5.0.0-beta.3",
       "license": "MIT",
       "dependencies": {
-        "@readme/oas-to-har": "^18.0.0",
+        "@readme/oas-to-har": "^19.0.0",
         "@readme/openapi-parser": "^2.2.0",
         "caseless": "^0.12.0",
         "chalk": "^4.1.2",
@@ -13304,7 +13403,7 @@
         "json-schema-traverse": "^1.0.0",
         "lodash.merge": "^4.6.2",
         "make-dir": "^3.1.0",
-        "oas": "^18.3.4",
+        "oas": "^19.0.0",
         "object-hash": "^3.0.0",
         "ora": "^5.4.1",
         "prompts": "^2.4.2",
@@ -13436,7 +13535,7 @@
       },
       "peerDependencies": {
         "@readme/httpsnippet": "^4.0.3",
-        "oas": "^18.3.4"
+        "oas": "^19.0.0"
       }
     }
   },
@@ -14031,9 +14130,9 @@
       }
     },
     "@exodus/schemasafe": {
-      "version": "1.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@exodus/schemasafe/-/schemasafe-1.0.0-rc.6.tgz",
-      "integrity": "sha512-dDnQizD94EdBwEj/fh3zPRa/HWCS9O5au2PuHhZBbuM3xWHxuaKzPBOEWze7Nn0xW68MIpZ7Xdyn1CoCpjKCuQ=="
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@exodus/schemasafe/-/schemasafe-1.0.0-rc.9.tgz",
+      "integrity": "sha512-dGGHpb61hLwifAu7sotuHFDBw6GTdpG8aKC0fsK17EuTzMRvUrH7lEAr6LTJ+sx3AZYed9yZ77rltVDHyg2hRg=="
     },
     "@humanwhocodes/config-array": {
       "version": "0.10.7",
@@ -14208,14 +14307,6 @@
         "picocolors": "^1.0.0",
         "tiny-glob": "^0.2.9",
         "tslib": "^2.4.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-          "dev": true
-        }
       }
     },
     "@readme/better-ajv-errors": {
@@ -14312,19 +14403,19 @@
       "dev": true
     },
     "@readme/oas-extensions": {
-      "version": "14.4.0",
-      "resolved": "https://registry.npmjs.org/@readme/oas-extensions/-/oas-extensions-14.4.0.tgz",
-      "integrity": "sha512-vNrZ1s7SyvWfqJAW9OI3lciDe9fbgJYXz2XIGoyi6f3Q8MMHbKx1GCVsX4SiAFai7lUIZDe2ltEKKtoxTfOKNQ==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/oas-extensions/-/oas-extensions-16.0.0.tgz",
+      "integrity": "sha512-oNsbsFR6X2+jAcT+CMnWFoFEUPJvKgavvVNoq8O473YfpXKJ/1pTFy3Dv+pHeEQ6c54lgoTUVuErUy+cIuDb0g==",
       "requires": {}
     },
     "@readme/oas-to-har": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-18.0.0.tgz",
-      "integrity": "sha512-sMNVAgxI9tRG3QAECzilwJtZ5c4M64qoYG145eW9R9aUSNmtgIKprKkn66dDnwYDw7zo/23L0YbMvZCsWeRN4Q==",
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-19.0.0.tgz",
+      "integrity": "sha512-UAgd9jVBBj5rroqBRStzs74IAPx1yp+7k5sqTpuJTApryw28xJNUtvMEwKGSRS17qqOfe1mVInBqeGtEOhxiPQ==",
       "requires": {
         "@readme/data-urls": "^1.0.1",
-        "@readme/oas-extensions": "^14.4.0",
-        "oas": "^18.3.1",
+        "@readme/oas-extensions": "^16.0.0",
+        "oas": "^19.0.0",
         "qs": "^6.10.5",
         "remove-undefined-objects": "^2.0.0"
       }
@@ -15137,7 +15228,7 @@
     "ansicolors": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
-      "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk="
+      "integrity": "sha512-QXu7BPrP29VllRxH8GwB7x5iX5qWKAAMLqKQGWTeLWVlNHNOpVMJ91dsxQAIWXpjuW5wqvxu3Jd/nRjrJ+0pqg=="
     },
     "any-promise": {
       "version": "1.3.0",
@@ -15158,7 +15249,7 @@
       "version": "file:packages/api",
       "requires": {
         "@readme/oas-examples": "^5.5.0",
-        "@readme/oas-to-har": "^18.0.0",
+        "@readme/oas-to-har": "^19.0.0",
         "@readme/openapi-parser": "^2.2.0",
         "@types/caseless": "^0.12.2",
         "@types/chai": "^4.3.1",
@@ -15193,7 +15284,7 @@
         "mocha": "^10.0.0",
         "mock-require": "^3.0.3",
         "nyc": "^15.1.0",
-        "oas": "^18.3.4",
+        "oas": "^19.0.0",
         "object-hash": "^3.0.0",
         "ora": "^5.4.1",
         "prompts": "^2.4.2",
@@ -15630,7 +15721,7 @@
     "cardinal": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-2.1.1.tgz",
-      "integrity": "sha1-fMEFXYItISlU0HsIXeolHMe8VQU=",
+      "integrity": "sha512-JSr5eOgoEymtYHBjNWyjrMqet9Am2miJhlfKNdqLp6zoeAh0KN5dRAcxlecj5mAJrmQomgiOBj35xHLrFjqBpw==",
       "requires": {
         "ansicolors": "~0.3.2",
         "redeyed": "~2.1.0"
@@ -16201,8 +16292,7 @@
     "deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
-      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-      "dev": true
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
     },
     "default-require-extensions": {
       "version": "3.0.0",
@@ -16377,16 +16467,17 @@
       }
     },
     "es-aggregate-error": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/es-aggregate-error/-/es-aggregate-error-1.0.7.tgz",
-      "integrity": "sha512-Zob/KUAOQUTvCzqgL2FEgtqNLPX5rYW3VhlldZ6La4W2mJUv3J8DmD0/sPxuD+kSAKF6nuceJ3uOSvCaaTLUyQ==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/es-aggregate-error/-/es-aggregate-error-1.0.8.tgz",
+      "integrity": "sha512-AKUb5MKLWMozPlFRHOKqWD7yta5uaEhH21qwtnf6FlKjNjTJOoqFi0/G14+FfSkIQhhu6X68Af4xgRC6y8qG4A==",
       "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.0",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5",
         "function-bind": "^1.1.1",
-        "functions-have-names": "^1.2.2",
+        "functions-have-names": "^1.2.3",
         "get-intrinsic": "^1.1.1",
-        "globalthis": "^1.0.2"
+        "globalthis": "^1.0.2",
+        "has-property-descriptors": "^1.0.0"
       }
     },
     "es-array-method-boxes-properly": {
@@ -16457,7 +16548,7 @@
     "es6-promise": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
-      "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM="
+      "integrity": "sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg=="
     },
     "es6-symbol": {
       "version": "3.1.3",
@@ -16495,6 +16586,60 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true
+    },
+    "escodegen": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
+      "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
+      "requires": {
+        "esprima": "^4.0.1",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+          "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
+        },
+        "levn": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+          "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
+          "requires": {
+            "prelude-ls": "~1.1.2",
+            "type-check": "~0.3.2"
+          }
+        },
+        "optionator": {
+          "version": "0.8.3",
+          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+          "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+          "requires": {
+            "deep-is": "~0.1.3",
+            "fast-levenshtein": "~2.0.6",
+            "levn": "~0.3.0",
+            "prelude-ls": "~1.1.2",
+            "type-check": "~0.3.2",
+            "word-wrap": "~1.2.3"
+          }
+        },
+        "prelude-ls": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+          "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w=="
+        },
+        "type-check": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+          "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
+          "requires": {
+            "prelude-ls": "~1.1.2"
+          }
+        }
+      }
     },
     "eslint": {
       "version": "8.24.0",
@@ -17153,8 +17298,7 @@
     "esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "dev": true
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
     },
     "event-emitter": {
       "version": "0.3.5",
@@ -17268,8 +17412,7 @@
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-      "dev": true
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "fast-safe-stringify": {
       "version": "2.1.1",
@@ -17673,9 +17816,9 @@
       }
     },
     "globalthis": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.2.tgz",
-      "integrity": "sha512-ZQnSFO1la8P7auIOQECnm0sSuoMeaSq0EEdXMBFF2QJO4uNcwbyhSgG3MruWNbFTqCLmxVwGOl7LZ9kASvHdeQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
+      "integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
       "requires": {
         "define-properties": "^1.1.3"
       }
@@ -18355,9 +18498,9 @@
       "dev": true
     },
     "inquirer": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.0.tgz",
-      "integrity": "sha512-0crLweprevJ02tTuA6ThpoAERAGyVILC4sS74uib58Xf/zSr1/ZWtmm7D5CI+bSQEaA04f0K7idaHpQbSWgiVQ==",
+      "version": "8.2.4",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.4.tgz",
+      "integrity": "sha512-nn4F01dxU8VeKfq192IjLsxu0/OmMZ4Lg3xKAns148rCaXP6ntAoEkVYZThWjwON8AlzdZZi6oqnhNbxUG9hVg==",
       "requires": {
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.1.1",
@@ -18369,10 +18512,11 @@
         "mute-stream": "0.0.8",
         "ora": "^5.4.1",
         "run-async": "^2.4.0",
-        "rxjs": "^7.2.0",
+        "rxjs": "^7.5.5",
         "string-width": "^4.1.0",
         "strip-ansi": "^6.0.0",
-        "through": "^2.3.6"
+        "through": "^2.3.6",
+        "wrap-ansi": "^7.0.0"
       }
     },
     "internal-slot": {
@@ -18936,7 +19080,7 @@
     "json2yaml": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/json2yaml/-/json2yaml-1.1.0.tgz",
-      "integrity": "sha1-VBTZB/mBZYa4DFE+wuOusquBmmw=",
+      "integrity": "sha512-/xse+m0SlllfZahQrNOelmLrFNfeZv4QG0QKlvg7VsPSGIxpB3X+ggLkdffwmI1DdQ3o9XjZX+K+EOI1epdKgg==",
       "requires": {
         "remedial": "1.x"
       }
@@ -18965,6 +19109,23 @@
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
       "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
       "dev": true
+    },
+    "jsonpath": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/jsonpath/-/jsonpath-1.1.1.tgz",
+      "integrity": "sha512-l6Cg7jRpixfbgoWgkrl77dgEj8RPvND0wMH6TwQmi9Qs4TFfS9u5cUFnbeKTwj5ga5Y3BTGGNI28k117LJ009w==",
+      "requires": {
+        "esprima": "1.2.2",
+        "static-eval": "2.0.2",
+        "underscore": "1.12.1"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.2.tgz",
+          "integrity": "sha512-+JpPZam9w5DuJ3Q67SqsMGtiHKENSMRVoxvArfJZK01/BfLEObtZ6orJa/MtoGNR/rfMgp5837T41PAmTwAv/A=="
+        }
+      }
     },
     "jsonpointer": {
       "version": "5.0.0",
@@ -19133,7 +19294,7 @@
     "line-counter": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/line-counter/-/line-counter-1.1.0.tgz",
-      "integrity": "sha1-EN8sBGrTVG5yT7pV+nLN4YpqAfM="
+      "integrity": "sha512-6bmXJG/pOX5HBb2aIJZrI9CALBgY1VMbS0GPuXfJaT13UEfee/2xxPCsOOJdXLl3KPRyBf2/D+cjiG8hU9S7LA=="
     },
     "lines-and-columns": {
       "version": "1.2.4",
@@ -20399,7 +20560,7 @@
     "node-readfiles": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/node-readfiles/-/node-readfiles-0.2.0.tgz",
-      "integrity": "sha1-271K8SE04uY1wkXvk//Pb2BnOl0=",
+      "integrity": "sha512-SU00ZarexNlE4Rjdm83vglt5Y9yiQ+XI1XpflWlb7q7UTN1JUItm69xMeiQCTxtTfnzt+83T8Cx+vI2ED++VDA==",
       "requires": {
         "es6-promise": "^3.2.1"
       }
@@ -20592,9 +20753,9 @@
       }
     },
     "oas": {
-      "version": "18.3.4",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-18.3.4.tgz",
-      "integrity": "sha512-mNaTC91kXLcfJjdLSxd2h06JlOAxFFa9+po+KbF7ifMb5PNYy0t0wvxllo0oS/Erztt8W917/fKX3kHVHWvBKw==",
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-19.0.0.tgz",
+      "integrity": "sha512-sN2oW57IXPgxWsfm5IbpLkjeMjs7VzRcBgqhrMZNyPWOkFPsGizRQolMuL4FqeUhIdcaFnv+2DcRLbwliF4g4w==",
       "requires": {
         "@readme/json-schema-ref-parser": "^1.1.0",
         "@types/json-schema": "^7.0.11",
@@ -20604,10 +20765,11 @@
         "inquirer": "^8.1.2",
         "json-schema-merge-allof": "^0.8.1",
         "json2yaml": "^1.1.0",
+        "jsonpath": "^1.1.1",
         "jsonpointer": "^5.0.0",
         "memoizee": "^0.4.14",
         "minimist": "^1.2.0",
-        "oas-normalize": "^6.0.0",
+        "oas-normalize": "^7.0.0",
         "openapi-types": "^12.0.0",
         "path-to-regexp": "^6.2.0",
         "swagger-inline": "^6.0.0"
@@ -20662,13 +20824,14 @@
       }
     },
     "oas-normalize": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-6.0.0.tgz",
-      "integrity": "sha512-BYVM3tpl4J5uVAN0EXeFaBKfwMufpCziIfEkU8tfer579p+RKj3qlXaF+rblvTZh4vEmnjNLR4ULmciHfDPF8w==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-7.0.0.tgz",
+      "integrity": "sha512-K/ChGYwdXPR1Vl0fnIdeAmEeQIw/MV90QmRL3DLsRGIS27/VaDn+ChMZ0GvTrE2lxjlDiGkm8cgKqS95F2jQNQ==",
       "requires": {
         "@readme/openapi-parser": "^2.2.0",
         "js-yaml": "^4.1.0",
         "node-fetch": "^2.6.1",
+        "openapi-types": "^12.0.0",
         "swagger2openapi": "^7.0.8"
       }
     },
@@ -21024,9 +21187,9 @@
       "dev": true
     },
     "path-to-regexp": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.0.tgz",
-      "integrity": "sha512-f66KywYG6+43afgE/8j/GoiNyygk/bnoCbps++3ErRKsIYkGGupyv07R2Ok5m9i67Iqc+T2g1eAUGUPzWhYTyg=="
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
+      "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw=="
     },
     "path-type": {
       "version": "4.0.0",
@@ -21298,7 +21461,7 @@
     "quotemeta": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/quotemeta/-/quotemeta-0.0.0.tgz",
-      "integrity": "sha1-UdOgbuD81uO1AdvSiQQ1Gtelo4w="
+      "integrity": "sha512-1XGObUh7RN5b58vKuAsrlfqT+Rc4vmw8N4pP9gFCq1GFlTdV0Ex/D2Ro1Drvrqj++HPi3ig0Np17XPslELeMRA=="
     },
     "rambda": {
       "version": "7.2.0",
@@ -21473,7 +21636,7 @@
     "redeyed": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-2.1.1.tgz",
-      "integrity": "sha1-iYS1gV2ZyyIEacme7v/jiRPmzAs=",
+      "integrity": "sha512-FNpGGo1DycYAdnrKFxCMmKYgo/mILAqtRYbkdQD8Ep/Hk2PQ5+aEAEx+IU713RTDmuBaH0c8P5ZozurNu5ObRQ==",
       "requires": {
         "esprima": "~4.0.0"
       }
@@ -21794,9 +21957,9 @@
       }
     },
     "rxjs": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.5.tgz",
-      "integrity": "sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==",
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.7.tgz",
+      "integrity": "sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==",
       "requires": {
         "tslib": "^2.1.0"
       }
@@ -21906,7 +22069,7 @@
     "should-format": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/should-format/-/should-format-3.0.3.tgz",
-      "integrity": "sha1-m/yPdPo5IFxT04w01xcwPidxJPE=",
+      "integrity": "sha512-hZ58adtulAk0gKtua7QxevgUaXTTXxIi8t41L3zo9AHvjXO1/7sdLECuHeIN2SRtYXpNkmhoUP2pdeWgricQ+Q==",
       "requires": {
         "should-type": "^1.3.0",
         "should-type-adaptors": "^1.0.1"
@@ -21915,7 +22078,7 @@
     "should-type": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/should-type/-/should-type-1.4.0.tgz",
-      "integrity": "sha1-B1bYzoRt/QmEOmlHcZ36DUz/XPM="
+      "integrity": "sha512-MdAsTu3n25yDbIe1NeN69G4n6mUnJGtSJHygX3+oN0ZbO3DTiATnf7XnYJdGT42JCXurTb1JI0qOBR65shvhPQ=="
     },
     "should-type-adaptors": {
       "version": "1.1.0",
@@ -21995,7 +22158,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true
+      "devOptional": true
     },
     "space-separated-tokens": {
       "version": "2.0.1",
@@ -22249,6 +22412,14 @@
         "minipass": "^3.1.1"
       }
     },
+    "static-eval": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.0.2.tgz",
+      "integrity": "sha512-N/D219Hcr2bPjLxPiV+TQE++Tsmrady7TqAJugLy7Xk1EumfDWS/f5dtBbkRCGE7wKKXuYockQoj8Rm2/pVKyg==",
+      "requires": {
+        "escodegen": "^1.8.1"
+      }
+    },
     "stream-combiner": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
@@ -22401,9 +22572,9 @@
       "dev": true
     },
     "swagger-inline": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/swagger-inline/-/swagger-inline-6.0.0.tgz",
-      "integrity": "sha512-JMin/1saGVuVhWdngKK+3fpICiV+GlAkYznNcXsSPTL8Cs9c3+Rlsalct5JcP+DUvPRcnqiVxnVqeYe69kSUKw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/swagger-inline/-/swagger-inline-6.1.0.tgz",
+      "integrity": "sha512-LAaA4otoy37HZ7qlzyrjCl2XMAt0X1WMHKenYh9J6mKrLN8mjckaQDElEZSiW2rKddwUoQb6sPtEAj+RYL1SkQ==",
       "requires": {
         "commander": "^6.0.0",
         "globby": "^11.0.1",
@@ -22438,14 +22609,6 @@
       "requires": {
         "@pkgr/utils": "^2.3.0",
         "tslib": "^2.4.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-          "dev": true
-        }
       }
     },
     "tapable": {
@@ -22655,9 +22818,9 @@
       }
     },
     "tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "tsutils": {
       "version": "3.21.0",
@@ -22739,6 +22902,11 @@
         "has-symbols": "^1.0.2",
         "which-boxed-primitive": "^1.0.2"
       }
+    },
+    "underscore": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
+      "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
     },
     "unherit": {
       "version": "3.0.0",
@@ -23090,17 +23258,17 @@
     "validate.io-array": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/validate.io-array/-/validate.io-array-1.0.6.tgz",
-      "integrity": "sha1-W1osr9j4uFq7L4hroVPy2Tond00="
+      "integrity": "sha512-DeOy7CnPEziggrOO5CZhVKJw6S3Yi7e9e65R1Nl/RTN1vTQKnzjfvks0/8kQ40FP/dsjRAOd4hxmJ7uLa6vxkg=="
     },
     "validate.io-function": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/validate.io-function/-/validate.io-function-1.0.2.tgz",
-      "integrity": "sha1-NDoZgC7TsZaCaceA5VjpNBHAutc="
+      "integrity": "sha512-LlFybRJEriSuBnUhQyG5bwglhh50EpTL2ul23MPIuR1odjO7XaMLFV8vHGwp7AZciFxtYOeiSCT5st+XSPONiQ=="
     },
     "validate.io-integer": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/validate.io-integer/-/validate.io-integer-1.0.5.tgz",
-      "integrity": "sha1-FoSWSAuVviJH7EQ/IjPeT4mHgGg=",
+      "integrity": "sha512-22izsYSLojN/P6bppBqhgUDjCkr5RY2jd+N2a3DCAUey8ydvrZ/OkGvFPR7qfOpwR2LC5p4Ngzxz36g5Vgr/hQ==",
       "requires": {
         "validate.io-number": "^1.0.3"
       }
@@ -23108,7 +23276,7 @@
     "validate.io-integer-array": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/validate.io-integer-array/-/validate.io-integer-array-1.0.0.tgz",
-      "integrity": "sha1-LKveAzKTpry+Bj/q/pHq9GsToIk=",
+      "integrity": "sha512-mTrMk/1ytQHtCY0oNO3dztafHYyGU88KL+jRxWuzfOmQb+4qqnWmI+gykvGp8usKZOM0H7keJHEbRaFiYA0VrA==",
       "requires": {
         "validate.io-array": "^1.0.3",
         "validate.io-integer": "^1.0.4"
@@ -23117,7 +23285,7 @@
     "validate.io-number": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/validate.io-number/-/validate.io-number-1.0.3.tgz",
-      "integrity": "sha1-9j/+2iSL8opnqNSODjtGGhZluvg="
+      "integrity": "sha512-kRAyotcbNaSYoDnXvb4MHg/0a1egJdLwS6oJ38TJY7aw9n93Fl/3blIXdyYvPOp55CNxywooG/3BcrwNrBpcSg=="
     },
     "vfile": {
       "version": "5.3.4",
@@ -23306,8 +23474,7 @@
     "word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-      "dev": true
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
     },
     "workerpool": {
       "version": "6.2.1",

--- a/packages/api/package-lock.json
+++ b/packages/api/package-lock.json
@@ -9,7 +9,7 @@
       "version": "5.0.0-beta.3",
       "license": "MIT",
       "dependencies": {
-        "@readme/oas-to-har": "^18.0.0",
+        "@readme/oas-to-har": "^19.0.0",
         "@readme/openapi-parser": "^2.2.0",
         "caseless": "^0.12.0",
         "chalk": "^4.1.2",
@@ -28,7 +28,7 @@
         "json-schema-traverse": "^1.0.0",
         "lodash.merge": "^4.6.2",
         "make-dir": "^3.1.0",
-        "oas": "^18.3.4",
+        "oas": "^19.0.0",
         "object-hash": "^3.0.0",
         "ora": "^5.4.1",
         "prompts": "^2.4.2",
@@ -479,9 +479,9 @@
       }
     },
     "node_modules/@exodus/schemasafe": {
-      "version": "1.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@exodus/schemasafe/-/schemasafe-1.0.0-rc.6.tgz",
-      "integrity": "sha512-dDnQizD94EdBwEj/fh3zPRa/HWCS9O5au2PuHhZBbuM3xWHxuaKzPBOEWze7Nn0xW68MIpZ7Xdyn1CoCpjKCuQ=="
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@exodus/schemasafe/-/schemasafe-1.0.0-rc.9.tgz",
+      "integrity": "sha512-dGGHpb61hLwifAu7sotuHFDBw6GTdpG8aKC0fsK17EuTzMRvUrH7lEAr6LTJ+sx3AZYed9yZ77rltVDHyg2hRg=="
     },
     "node_modules/@humanwhocodes/momoa": {
       "version": "2.0.4",
@@ -716,24 +716,24 @@
       "dev": true
     },
     "node_modules/@readme/oas-extensions": {
-      "version": "14.3.0",
-      "resolved": "https://registry.npmjs.org/@readme/oas-extensions/-/oas-extensions-14.3.0.tgz",
-      "integrity": "sha512-Xep76bMSz5rNw/KM3tdK698u1UEDt5/QGrIvzFFc8o25M5U+8CtsQRZdoQduBxnGT8IGZbVzFRCNoVOXpugWIQ==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/oas-extensions/-/oas-extensions-16.0.0.tgz",
+      "integrity": "sha512-oNsbsFR6X2+jAcT+CMnWFoFEUPJvKgavvVNoq8O473YfpXKJ/1pTFy3Dv+pHeEQ6c54lgoTUVuErUy+cIuDb0g==",
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "oas": "^17.1.0 || ^18.0.0"
+        "oas": "^19.0.0"
       }
     },
     "node_modules/@readme/oas-to-har": {
-      "version": "17.1.2",
-      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-17.1.2.tgz",
-      "integrity": "sha512-jQXZy5LAbsg5DVM6W69Ea0P/yom1G0zS3DD8mFntn0AkGzelBuNYOIIed/ey7ssYlPnx8CBc/Chz/++qNherow==",
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-19.0.0.tgz",
+      "integrity": "sha512-UAgd9jVBBj5rroqBRStzs74IAPx1yp+7k5sqTpuJTApryw28xJNUtvMEwKGSRS17qqOfe1mVInBqeGtEOhxiPQ==",
       "dependencies": {
         "@readme/data-urls": "^1.0.1",
-        "@readme/oas-extensions": "^14.3.0",
-        "oas": "^18.3.1",
+        "@readme/oas-extensions": "^16.0.0",
+        "oas": "^19.0.0",
         "qs": "^6.10.5",
         "remove-undefined-objects": "^2.0.0"
       },
@@ -826,9 +826,9 @@
       "dev": true
     },
     "node_modules/@ts-morph/common": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.16.0.tgz",
-      "integrity": "sha512-SgJpzkTgZKLKqQniCjLaE3c2L2sdL7UShvmTmPBejAKd2OKV/yfMpQ2IWpAuA+VY5wy7PkSUaEObIqEK6afFuw==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.17.0.tgz",
+      "integrity": "sha512-RMSSvSfs9kb0VzkvQ2NWobwnj7TxCA9vI/IjR9bDHqgAyVbu2T0DN4wiKVqomyDWqO7dPr/tErSfq7urQ1Q37g==",
       "dependencies": {
         "fast-glob": "^3.2.11",
         "minimatch": "^5.1.0",
@@ -929,9 +929,9 @@
       "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ=="
     },
     "node_modules/@types/mocha": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.1.tgz",
-      "integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.0.tgz",
+      "integrity": "sha512-rADY+HtTOA52l9VZWtgQfn4p+UDVM2eDVkMZT1I6syp0YKxW2F9v+0pbRZLsvskhQv/vMb6ZfCay81GHbz5SHg==",
       "dev": true
     },
     "node_modules/@types/node": {
@@ -1511,6 +1511,7 @@
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
       "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
@@ -1526,17 +1527,9 @@
       }
     },
     "node_modules/code-block-writer": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-11.0.0.tgz",
-      "integrity": "sha512-GEqWvEWWsOvER+g9keO4ohFoD3ymwyCnqY3hoTr7GZipYFwEhMHJw+TtV0rfgRhNImM6QWZGO2XYjlJVyYT62w==",
-      "dependencies": {
-        "tslib": "2.3.1"
-      }
-    },
-    "node_modules/code-block-writer/node_modules/tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-11.0.3.tgz",
+      "integrity": "sha512-NiujjUFB4SwScJq2bwbYUtXbZhBSlY6vYzm++3Q6oC+U+injTqfPYFK8wS9COOmb2lueqp0ZRB4nK1VYeHgNyw=="
     },
     "node_modules/code-error-fragment": {
       "version": "0.0.230",
@@ -1700,6 +1693,11 @@
       "engines": {
         "node": ">=0.12"
       }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
     },
     "node_modules/default-require-extensions": {
       "version": "3.0.0",
@@ -1900,7 +1898,7 @@
     "node_modules/es6-promise": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
-      "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM="
+      "integrity": "sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg=="
     },
     "node_modules/es6-symbol": {
       "version": "3.1.3",
@@ -1938,6 +1936,36 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/escodegen": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
+      "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=4.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/escodegen/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -1948,6 +1976,22 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/event-emitter": {
@@ -2032,6 +2076,11 @@
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "peer": true
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
     },
     "node_modules/fast-safe-stringify": {
       "version": "2.1.1",
@@ -3211,6 +3260,28 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonpath": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/jsonpath/-/jsonpath-1.1.1.tgz",
+      "integrity": "sha512-l6Cg7jRpixfbgoWgkrl77dgEj8RPvND0wMH6TwQmi9Qs4TFfS9u5cUFnbeKTwj5ga5Y3BTGGNI28k117LJ009w==",
+      "dependencies": {
+        "esprima": "1.2.2",
+        "static-eval": "2.0.2",
+        "underscore": "1.12.1"
+      }
+    },
+    "node_modules/jsonpath/node_modules/esprima": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.2.tgz",
+      "integrity": "sha512-+JpPZam9w5DuJ3Q67SqsMGtiHKENSMRVoxvArfJZK01/BfLEObtZ6orJa/MtoGNR/rfMgp5837T41PAmTwAv/A==",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/jsonpointer": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.0.tgz",
@@ -3239,6 +3310,18 @@
       "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
+      "dependencies": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/line-counter": {
@@ -3780,7 +3863,7 @@
     "node_modules/node-readfiles": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/node-readfiles/-/node-readfiles-0.2.0.tgz",
-      "integrity": "sha1-271K8SE04uY1wkXvk//Pb2BnOl0=",
+      "integrity": "sha512-SU00ZarexNlE4Rjdm83vglt5Y9yiQ+XI1XpflWlb7q7UTN1JUItm69xMeiQCTxtTfnzt+83T8Cx+vI2ED++VDA==",
       "dependencies": {
         "es6-promise": "^3.2.1"
       }
@@ -3906,9 +3989,9 @@
       }
     },
     "node_modules/oas": {
-      "version": "18.3.4",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-18.3.4.tgz",
-      "integrity": "sha512-mNaTC91kXLcfJjdLSxd2h06JlOAxFFa9+po+KbF7ifMb5PNYy0t0wvxllo0oS/Erztt8W917/fKX3kHVHWvBKw==",
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-19.0.0.tgz",
+      "integrity": "sha512-sN2oW57IXPgxWsfm5IbpLkjeMjs7VzRcBgqhrMZNyPWOkFPsGizRQolMuL4FqeUhIdcaFnv+2DcRLbwliF4g4w==",
       "dependencies": {
         "@readme/json-schema-ref-parser": "^1.1.0",
         "@types/json-schema": "^7.0.11",
@@ -3918,10 +4001,11 @@
         "inquirer": "^8.1.2",
         "json-schema-merge-allof": "^0.8.1",
         "json2yaml": "^1.1.0",
+        "jsonpath": "^1.1.1",
         "jsonpointer": "^5.0.0",
         "memoizee": "^0.4.14",
         "minimist": "^1.2.0",
-        "oas-normalize": "^6.0.0",
+        "oas-normalize": "^7.0.0",
         "openapi-types": "^12.0.0",
         "path-to-regexp": "^6.2.0",
         "swagger-inline": "^6.0.0"
@@ -3955,13 +4039,14 @@
       }
     },
     "node_modules/oas-normalize": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-6.0.0.tgz",
-      "integrity": "sha512-BYVM3tpl4J5uVAN0EXeFaBKfwMufpCziIfEkU8tfer579p+RKj3qlXaF+rblvTZh4vEmnjNLR4ULmciHfDPF8w==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-7.0.0.tgz",
+      "integrity": "sha512-K/ChGYwdXPR1Vl0fnIdeAmEeQIw/MV90QmRL3DLsRGIS27/VaDn+ChMZ0GvTrE2lxjlDiGkm8cgKqS95F2jQNQ==",
       "dependencies": {
         "@readme/openapi-parser": "^2.2.0",
         "js-yaml": "^4.1.0",
         "node-fetch": "^2.6.1",
+        "openapi-types": "^12.0.0",
         "swagger2openapi": "^7.0.8"
       },
       "engines": {
@@ -3986,12 +4071,25 @@
         "url": "https://github.com/Mermade/oas-kit?sponsor=1"
       }
     },
-    "node_modules/oas-resolver/node_modules/yargs": {
-      "version": "17.4.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.4.1.tgz",
-      "integrity": "sha512-WSZD9jgobAg3ZKuCQZSa3g9QOJeCCqLoLAykiWgmXnDo9EPnn4RPf5qVTtzgOx66o6/oqhcA5tHtJXpG8pMt3g==",
+    "node_modules/oas-resolver/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "dependencies": {
-        "cliui": "^7.0.2",
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/oas-resolver/node_modules/yargs": {
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.0.tgz",
+      "integrity": "sha512-8H/wTDqlSwoSnScvV2N/JHfLWOKuh5MVla9hqLjK3nsfyy6Y4kDSYSvkU5YCUEPOSnRXfIyx3Sq+B/IWudTo4g==",
+      "dependencies": {
+        "cliui": "^8.0.1",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
@@ -4004,9 +4102,9 @@
       }
     },
     "node_modules/oas-resolver/node_modules/yargs-parser": {
-      "version": "21.0.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
-      "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "engines": {
         "node": ">=12"
       }
@@ -4146,6 +4244,22 @@
       "version": "12.0.0",
       "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.0.0.tgz",
       "integrity": "sha512-6Wd9k8nmGQHgCbehZCP6wwWcfXcvinhybUTBatuhjRsCxUIujuYFZc9QnGeae75CyHASewBtxs0HX/qwREReUw=="
+    },
+    "node_modules/optionator": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+      "dependencies": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.6",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "word-wrap": "~1.2.3"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
     "node_modules/ora": {
       "version": "5.4.1",
@@ -4303,6 +4417,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/prettier": {
@@ -4663,7 +4785,7 @@
     "node_modules/should-format": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/should-format/-/should-format-3.0.3.tgz",
-      "integrity": "sha1-m/yPdPo5IFxT04w01xcwPidxJPE=",
+      "integrity": "sha512-hZ58adtulAk0gKtua7QxevgUaXTTXxIi8t41L3zo9AHvjXO1/7sdLECuHeIN2SRtYXpNkmhoUP2pdeWgricQ+Q==",
       "dependencies": {
         "should-type": "^1.3.0",
         "should-type-adaptors": "^1.0.1"
@@ -4672,7 +4794,7 @@
     "node_modules/should-type": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/should-type/-/should-type-1.4.0.tgz",
-      "integrity": "sha1-B1bYzoRt/QmEOmlHcZ36DUz/XPM="
+      "integrity": "sha512-MdAsTu3n25yDbIe1NeN69G4n6mUnJGtSJHygX3+oN0ZbO3DTiATnf7XnYJdGT42JCXurTb1JI0qOBR65shvhPQ=="
     },
     "node_modules/should-type-adaptors": {
       "version": "1.1.0",
@@ -4785,6 +4907,14 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/static-eval": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.0.2.tgz",
+      "integrity": "sha512-N/D219Hcr2bPjLxPiV+TQE++Tsmrady7TqAJugLy7Xk1EumfDWS/f5dtBbkRCGE7wKKXuYockQoj8Rm2/pVKyg==",
+      "dependencies": {
+        "escodegen": "^1.8.1"
       }
     },
     "node_modules/string_decoder": {
@@ -4944,12 +5074,25 @@
         "url": "https://github.com/Mermade/oas-kit?sponsor=1"
       }
     },
-    "node_modules/swagger2openapi/node_modules/yargs": {
-      "version": "17.4.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.4.1.tgz",
-      "integrity": "sha512-WSZD9jgobAg3ZKuCQZSa3g9QOJeCCqLoLAykiWgmXnDo9EPnn4RPf5qVTtzgOx66o6/oqhcA5tHtJXpG8pMt3g==",
+    "node_modules/swagger2openapi/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "dependencies": {
-        "cliui": "^7.0.2",
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/swagger2openapi/node_modules/yargs": {
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.0.tgz",
+      "integrity": "sha512-8H/wTDqlSwoSnScvV2N/JHfLWOKuh5MVla9hqLjK3nsfyy6Y4kDSYSvkU5YCUEPOSnRXfIyx3Sq+B/IWudTo4g==",
+      "dependencies": {
+        "cliui": "^8.0.1",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
@@ -4962,9 +5105,9 @@
       }
     },
     "node_modules/swagger2openapi/node_modules/yargs-parser": {
-      "version": "21.0.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
-      "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "engines": {
         "node": ">=12"
       }
@@ -5057,18 +5200,29 @@
       }
     },
     "node_modules/ts-morph": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-15.1.0.tgz",
-      "integrity": "sha512-RBsGE2sDzUXFTnv8Ba22QfeuKbgvAGJFuTN7HfmIRUkgT/NaVLfDM/8OFm2NlFkGlWEXdpW5OaFIp1jvqdDuOg==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-16.0.0.tgz",
+      "integrity": "sha512-jGNF0GVpFj0orFw55LTsQxVYEUOCWBAbR5Ls7fTYE5pQsbW18ssTb/6UXx/GYAEjS+DQTp8VoTw0vqYMiaaQuw==",
       "dependencies": {
-        "@ts-morph/common": "~0.16.0",
-        "code-block-writer": "^11.0.0"
+        "@ts-morph/common": "~0.17.0",
+        "code-block-writer": "^11.0.3"
       }
     },
     "node_modules/type": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
       "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
+    },
+    "node_modules/type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
+      "dependencies": {
+        "prelude-ls": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
     "node_modules/type-detect": {
       "version": "4.0.8",
@@ -5120,6 +5274,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/underscore": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
+      "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
     },
     "node_modules/unique-temp-dir": {
       "version": "1.0.0",
@@ -5273,6 +5432,14 @@
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/workerpool": {
       "version": "6.2.1",
@@ -5725,9 +5892,9 @@
       }
     },
     "@exodus/schemasafe": {
-      "version": "1.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@exodus/schemasafe/-/schemasafe-1.0.0-rc.6.tgz",
-      "integrity": "sha512-dDnQizD94EdBwEj/fh3zPRa/HWCS9O5au2PuHhZBbuM3xWHxuaKzPBOEWze7Nn0xW68MIpZ7Xdyn1CoCpjKCuQ=="
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@exodus/schemasafe/-/schemasafe-1.0.0-rc.9.tgz",
+      "integrity": "sha512-dGGHpb61hLwifAu7sotuHFDBw6GTdpG8aKC0fsK17EuTzMRvUrH7lEAr6LTJ+sx3AZYed9yZ77rltVDHyg2hRg=="
     },
     "@humanwhocodes/momoa": {
       "version": "2.0.4",
@@ -5861,19 +6028,19 @@
       "dev": true
     },
     "@readme/oas-extensions": {
-      "version": "14.3.0",
-      "resolved": "https://registry.npmjs.org/@readme/oas-extensions/-/oas-extensions-14.3.0.tgz",
-      "integrity": "sha512-Xep76bMSz5rNw/KM3tdK698u1UEDt5/QGrIvzFFc8o25M5U+8CtsQRZdoQduBxnGT8IGZbVzFRCNoVOXpugWIQ==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/oas-extensions/-/oas-extensions-16.0.0.tgz",
+      "integrity": "sha512-oNsbsFR6X2+jAcT+CMnWFoFEUPJvKgavvVNoq8O473YfpXKJ/1pTFy3Dv+pHeEQ6c54lgoTUVuErUy+cIuDb0g==",
       "requires": {}
     },
     "@readme/oas-to-har": {
-      "version": "17.1.2",
-      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-17.1.2.tgz",
-      "integrity": "sha512-jQXZy5LAbsg5DVM6W69Ea0P/yom1G0zS3DD8mFntn0AkGzelBuNYOIIed/ey7ssYlPnx8CBc/Chz/++qNherow==",
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-19.0.0.tgz",
+      "integrity": "sha512-UAgd9jVBBj5rroqBRStzs74IAPx1yp+7k5sqTpuJTApryw28xJNUtvMEwKGSRS17qqOfe1mVInBqeGtEOhxiPQ==",
       "requires": {
         "@readme/data-urls": "^1.0.1",
-        "@readme/oas-extensions": "^14.3.0",
-        "oas": "^18.3.1",
+        "@readme/oas-extensions": "^16.0.0",
+        "oas": "^19.0.0",
         "qs": "^6.10.5",
         "remove-undefined-objects": "^2.0.0"
       }
@@ -5948,9 +6115,9 @@
       "dev": true
     },
     "@ts-morph/common": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.16.0.tgz",
-      "integrity": "sha512-SgJpzkTgZKLKqQniCjLaE3c2L2sdL7UShvmTmPBejAKd2OKV/yfMpQ2IWpAuA+VY5wy7PkSUaEObIqEK6afFuw==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.17.0.tgz",
+      "integrity": "sha512-RMSSvSfs9kb0VzkvQ2NWobwnj7TxCA9vI/IjR9bDHqgAyVbu2T0DN4wiKVqomyDWqO7dPr/tErSfq7urQ1Q37g==",
       "requires": {
         "fast-glob": "^3.2.11",
         "minimatch": "^5.1.0",
@@ -6044,9 +6211,9 @@
       "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ=="
     },
     "@types/mocha": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.1.tgz",
-      "integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.0.tgz",
+      "integrity": "sha512-rADY+HtTOA52l9VZWtgQfn4p+UDVM2eDVkMZT1I6syp0YKxW2F9v+0pbRZLsvskhQv/vMb6ZfCay81GHbz5SHg==",
       "dev": true
     },
     "@types/node": {
@@ -6479,6 +6646,7 @@
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
       "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
       "requires": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
@@ -6491,19 +6659,9 @@
       "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
     },
     "code-block-writer": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-11.0.0.tgz",
-      "integrity": "sha512-GEqWvEWWsOvER+g9keO4ohFoD3ymwyCnqY3hoTr7GZipYFwEhMHJw+TtV0rfgRhNImM6QWZGO2XYjlJVyYT62w==",
-      "requires": {
-        "tslib": "2.3.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
-        }
-      }
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-11.0.3.tgz",
+      "integrity": "sha512-NiujjUFB4SwScJq2bwbYUtXbZhBSlY6vYzm++3Q6oC+U+injTqfPYFK8wS9COOmb2lueqp0ZRB4nK1VYeHgNyw=="
     },
     "code-error-fragment": {
       "version": "0.0.230",
@@ -6633,6 +6791,11 @@
       "requires": {
         "type-detect": "^4.0.0"
       }
+    },
+    "deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
     },
     "default-require-extensions": {
       "version": "3.0.0",
@@ -6794,7 +6957,7 @@
     "es6-promise": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
-      "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM="
+      "integrity": "sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg=="
     },
     "es6-symbol": {
       "version": "3.1.3",
@@ -6826,10 +6989,40 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
+    "escodegen": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
+      "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
+      "requires": {
+        "esprima": "^4.0.1",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "optional": true
+        }
+      }
+    },
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+    },
+    "estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
+    },
+    "esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
     },
     "event-emitter": {
       "version": "0.3.5",
@@ -6903,6 +7096,11 @@
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "peer": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
     },
     "fast-safe-stringify": {
       "version": "2.1.1",
@@ -7717,6 +7915,23 @@
         "minimist": "^1.2.5"
       }
     },
+    "jsonpath": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/jsonpath/-/jsonpath-1.1.1.tgz",
+      "integrity": "sha512-l6Cg7jRpixfbgoWgkrl77dgEj8RPvND0wMH6TwQmi9Qs4TFfS9u5cUFnbeKTwj5ga5Y3BTGGNI28k117LJ009w==",
+      "requires": {
+        "esprima": "1.2.2",
+        "static-eval": "2.0.2",
+        "underscore": "1.12.1"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.2.tgz",
+          "integrity": "sha512-+JpPZam9w5DuJ3Q67SqsMGtiHKENSMRVoxvArfJZK01/BfLEObtZ6orJa/MtoGNR/rfMgp5837T41PAmTwAv/A=="
+        }
+      }
+    },
     "jsonpointer": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.0.tgz",
@@ -7737,6 +7952,15 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
       "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A=="
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
+      "requires": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      }
     },
     "line-counter": {
       "version": "1.1.0",
@@ -8154,7 +8378,7 @@
     "node-readfiles": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/node-readfiles/-/node-readfiles-0.2.0.tgz",
-      "integrity": "sha1-271K8SE04uY1wkXvk//Pb2BnOl0=",
+      "integrity": "sha512-SU00ZarexNlE4Rjdm83vglt5Y9yiQ+XI1XpflWlb7q7UTN1JUItm69xMeiQCTxtTfnzt+83T8Cx+vI2ED++VDA==",
       "requires": {
         "es6-promise": "^3.2.1"
       }
@@ -8264,9 +8488,9 @@
       }
     },
     "oas": {
-      "version": "18.3.4",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-18.3.4.tgz",
-      "integrity": "sha512-mNaTC91kXLcfJjdLSxd2h06JlOAxFFa9+po+KbF7ifMb5PNYy0t0wvxllo0oS/Erztt8W917/fKX3kHVHWvBKw==",
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-19.0.0.tgz",
+      "integrity": "sha512-sN2oW57IXPgxWsfm5IbpLkjeMjs7VzRcBgqhrMZNyPWOkFPsGizRQolMuL4FqeUhIdcaFnv+2DcRLbwliF4g4w==",
       "requires": {
         "@readme/json-schema-ref-parser": "^1.1.0",
         "@types/json-schema": "^7.0.11",
@@ -8276,10 +8500,11 @@
         "inquirer": "^8.1.2",
         "json-schema-merge-allof": "^0.8.1",
         "json2yaml": "^1.1.0",
+        "jsonpath": "^1.1.1",
         "jsonpointer": "^5.0.0",
         "memoizee": "^0.4.14",
         "minimist": "^1.2.0",
-        "oas-normalize": "^6.0.0",
+        "oas-normalize": "^7.0.0",
         "openapi-types": "^12.0.0",
         "path-to-regexp": "^6.2.0",
         "swagger-inline": "^6.0.0"
@@ -8334,13 +8559,14 @@
       }
     },
     "oas-normalize": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-6.0.0.tgz",
-      "integrity": "sha512-BYVM3tpl4J5uVAN0EXeFaBKfwMufpCziIfEkU8tfer579p+RKj3qlXaF+rblvTZh4vEmnjNLR4ULmciHfDPF8w==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-7.0.0.tgz",
+      "integrity": "sha512-K/ChGYwdXPR1Vl0fnIdeAmEeQIw/MV90QmRL3DLsRGIS27/VaDn+ChMZ0GvTrE2lxjlDiGkm8cgKqS95F2jQNQ==",
       "requires": {
         "@readme/openapi-parser": "^2.2.0",
         "js-yaml": "^4.1.0",
         "node-fetch": "^2.6.1",
+        "openapi-types": "^12.0.0",
         "swagger2openapi": "^7.0.8"
       }
     },
@@ -8356,12 +8582,22 @@
         "yargs": "^17.0.1"
       },
       "dependencies": {
-        "yargs": {
-          "version": "17.4.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.4.1.tgz",
-          "integrity": "sha512-WSZD9jgobAg3ZKuCQZSa3g9QOJeCCqLoLAykiWgmXnDo9EPnn4RPf5qVTtzgOx66o6/oqhcA5tHtJXpG8pMt3g==",
+        "cliui": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+          "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
           "requires": {
-            "cliui": "^7.0.2",
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.1",
+            "wrap-ansi": "^7.0.0"
+          }
+        },
+        "yargs": {
+          "version": "17.6.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.0.tgz",
+          "integrity": "sha512-8H/wTDqlSwoSnScvV2N/JHfLWOKuh5MVla9hqLjK3nsfyy6Y4kDSYSvkU5YCUEPOSnRXfIyx3Sq+B/IWudTo4g==",
+          "requires": {
+            "cliui": "^8.0.1",
             "escalade": "^3.1.1",
             "get-caller-file": "^2.0.5",
             "require-directory": "^2.1.1",
@@ -8371,9 +8607,9 @@
           }
         },
         "yargs-parser": {
-          "version": "21.0.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
-          "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg=="
+          "version": "21.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+          "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="
         }
       }
     },
@@ -8448,6 +8684,19 @@
       "version": "12.0.0",
       "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.0.0.tgz",
       "integrity": "sha512-6Wd9k8nmGQHgCbehZCP6wwWcfXcvinhybUTBatuhjRsCxUIujuYFZc9QnGeae75CyHASewBtxs0HX/qwREReUw=="
+    },
+    "optionator": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+      "requires": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.6",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "word-wrap": "~1.2.3"
+      }
     },
     "ora": {
       "version": "5.4.1",
@@ -8561,6 +8810,11 @@
       "requires": {
         "find-up": "^4.0.0"
       }
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w=="
     },
     "prettier": {
       "version": "2.7.1",
@@ -8839,7 +9093,7 @@
     "should-format": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/should-format/-/should-format-3.0.3.tgz",
-      "integrity": "sha1-m/yPdPo5IFxT04w01xcwPidxJPE=",
+      "integrity": "sha512-hZ58adtulAk0gKtua7QxevgUaXTTXxIi8t41L3zo9AHvjXO1/7sdLECuHeIN2SRtYXpNkmhoUP2pdeWgricQ+Q==",
       "requires": {
         "should-type": "^1.3.0",
         "should-type-adaptors": "^1.0.1"
@@ -8848,7 +9102,7 @@
     "should-type": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/should-type/-/should-type-1.4.0.tgz",
-      "integrity": "sha1-B1bYzoRt/QmEOmlHcZ36DUz/XPM="
+      "integrity": "sha512-MdAsTu3n25yDbIe1NeN69G4n6mUnJGtSJHygX3+oN0ZbO3DTiATnf7XnYJdGT42JCXurTb1JI0qOBR65shvhPQ=="
     },
     "should-type-adaptors": {
       "version": "1.1.0",
@@ -8942,6 +9196,14 @@
       "integrity": "sha512-Y1Z6J8UYnexKFN1R/hxUaYoY2LVdKEzziPmVAFKiKX8fiwvCJTVzn/xYE9TEWod5OVyNfIHHuVfIEuBClL/uJQ==",
       "requires": {
         "minipass": "^3.1.1"
+      }
+    },
+    "static-eval": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.0.2.tgz",
+      "integrity": "sha512-N/D219Hcr2bPjLxPiV+TQE++Tsmrady7TqAJugLy7Xk1EumfDWS/f5dtBbkRCGE7wKKXuYockQoj8Rm2/pVKyg==",
+      "requires": {
+        "escodegen": "^1.8.1"
       }
     },
     "string_decoder": {
@@ -9058,12 +9320,22 @@
         "yargs": "^17.0.1"
       },
       "dependencies": {
-        "yargs": {
-          "version": "17.4.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.4.1.tgz",
-          "integrity": "sha512-WSZD9jgobAg3ZKuCQZSa3g9QOJeCCqLoLAykiWgmXnDo9EPnn4RPf5qVTtzgOx66o6/oqhcA5tHtJXpG8pMt3g==",
+        "cliui": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+          "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
           "requires": {
-            "cliui": "^7.0.2",
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.1",
+            "wrap-ansi": "^7.0.0"
+          }
+        },
+        "yargs": {
+          "version": "17.6.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.0.tgz",
+          "integrity": "sha512-8H/wTDqlSwoSnScvV2N/JHfLWOKuh5MVla9hqLjK3nsfyy6Y4kDSYSvkU5YCUEPOSnRXfIyx3Sq+B/IWudTo4g==",
+          "requires": {
+            "cliui": "^8.0.1",
             "escalade": "^3.1.1",
             "get-caller-file": "^2.0.5",
             "require-directory": "^2.1.1",
@@ -9073,9 +9345,9 @@
           }
         },
         "yargs-parser": {
-          "version": "21.0.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
-          "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg=="
+          "version": "21.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+          "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="
         }
       }
     },
@@ -9152,18 +9424,26 @@
       }
     },
     "ts-morph": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-15.1.0.tgz",
-      "integrity": "sha512-RBsGE2sDzUXFTnv8Ba22QfeuKbgvAGJFuTN7HfmIRUkgT/NaVLfDM/8OFm2NlFkGlWEXdpW5OaFIp1jvqdDuOg==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-16.0.0.tgz",
+      "integrity": "sha512-jGNF0GVpFj0orFw55LTsQxVYEUOCWBAbR5Ls7fTYE5pQsbW18ssTb/6UXx/GYAEjS+DQTp8VoTw0vqYMiaaQuw==",
       "requires": {
-        "@ts-morph/common": "~0.16.0",
-        "code-block-writer": "^11.0.0"
+        "@ts-morph/common": "~0.17.0",
+        "code-block-writer": "^11.0.3"
       }
     },
     "type": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
       "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
+      "requires": {
+        "prelude-ls": "~1.1.2"
+      }
     },
     "type-detect": {
       "version": "4.0.8",
@@ -9202,6 +9482,11 @@
         "has-symbols": "^1.0.2",
         "which-boxed-primitive": "^1.0.2"
       }
+    },
+    "underscore": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
+      "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
     },
     "unique-temp-dir": {
       "version": "1.0.0",
@@ -9333,6 +9618,11 @@
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
+    },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
     },
     "workerpool": {
       "version": "6.2.1",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -36,7 +36,7 @@
     "swagger"
   ],
   "dependencies": {
-    "@readme/oas-to-har": "^18.0.0",
+    "@readme/oas-to-har": "^19.0.0",
     "@readme/openapi-parser": "^2.2.0",
     "caseless": "^0.12.0",
     "chalk": "^4.1.2",
@@ -55,7 +55,7 @@
     "json-schema-traverse": "^1.0.0",
     "lodash.merge": "^4.6.2",
     "make-dir": "^3.1.0",
-    "oas": "^18.3.4",
+    "oas": "^19.0.0",
     "object-hash": "^3.0.0",
     "ora": "^5.4.1",
     "prompts": "^2.4.2",

--- a/packages/api/src/core/prepareParams.ts
+++ b/packages/api/src/core/prepareParams.ts
@@ -145,7 +145,7 @@ export default async function prepareParams(operation: Operation, body?: unknown
   let metadataIntersected = false;
   const digestedParameters = digestParameters(operation.getParameters());
   const hasDigestedParams = !!Object.keys(digestedParameters).length;
-  const jsonSchema = operation.getParametersAsJsonSchema();
+  const jsonSchema = operation.getParametersAsJSONSchema();
 
   /**
    * It might be common for somebody to run `sdk.findPetsByStatus({ status: 'available' }, {})`, in

--- a/packages/api/test/__fixtures__/definitions/response-title-quirks.json
+++ b/packages/api/test/__fixtures__/definitions/response-title-quirks.json
@@ -1,0 +1,77 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Testing an OAS that has response `title` props that start with a number",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://httpbin.org"
+    }
+  ],
+  "paths": {
+    "/anything": {
+      "get": {
+        "operationId": "getAnything",
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "description": "Status values that need to be considered for filter",
+            "required": true,
+            "explode": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": ["available", "pending", "sold"],
+                "default": "available"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "2XX": {
+            "description": "2XX",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "260 Created (token)": {
+                    "value": "{\n\t\"id\": \"e450ec69-dac2-4858-b4c9-6d3af44bb5f8\",\n\t\"user\": {\n\t\t\"id\": \"dd57ae92-bd88-4663-bb9f-5bfd6d75ff85\",\n\t\t\"type\": \"customer\",\n\t\t\"uniqueId\": \"john-smith\"\n\t},\n\t\"session\": {\n\t\t\"id\": \"1063547f-30a1-44c4-ae6f-1dfad5b64403\",\n\t\t\"externalRef\": \"external-session-ref\",\n\t\t\"isAuthenticated\": false\n\t},\n\t\"token\": \"eyJh...\"\n}"
+                  },
+                  "260 Created": {
+                    "value": "{\n\t\"id\": \"e450ec69-dac2-4858-b4c9-6d3af44bb5f8\",\n\t\"user\": {\n\t\t\"id\": \"dd57ae92-bd88-4663-bb9f-5bfd6d75ff85\",\n\t\t\"type\": \"customer\",\n\t\t\"uniqueId\": \"john-smith\"\n\t},\n\t\"session\": {\n\t\t\"id\": \"1063547f-30a1-44c4-ae6f-1dfad5b64403\",\n\t\t\"externalRef\": \"external-session-ref\",\n\t\t\"isAuthenticated\": false\n\t}\n}"
+                  }
+                },
+                "schema": {
+                  "oneOf": [
+                    {
+                      "title": "260 Created (token)",
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "example": "e450ec69-dac2-4858-b4c9-6d3af44bb5f8"
+                        }
+                      }
+                    },
+                    {
+                      "title": "260 Created",
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "example": "e450ec69-dac2-4858-b4c9-6d3af44bb5f8"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/api/test/__fixtures__/sdk/response-title-quirks/index.d.ts
+++ b/packages/api/test/__fixtures__/sdk/response-title-quirks/index.d.ts
@@ -1,0 +1,84 @@
+import Oas from 'oas';
+import APICore from 'api/dist/core';
+declare class SDK {
+  spec: Oas;
+  core: APICore;
+  authKeys: (number | string)[][];
+  constructor();
+  /**
+   * Optionally configure various options, such as response parsing, that the SDK allows.
+   *
+   * @param config Object of supported SDK options and toggles.
+   * @param config.parseResponse If responses are parsed according to its `Content-Type` header.
+   */
+  config(config: ConfigOptions): void;
+  /**
+   * If the API you're using requires authentication you can supply the required credentials
+   * through this method and the library will magically determine how they should be used
+   * within your API request.
+   *
+   * With the exception of OpenID and MutualTLS, it supports all forms of authentication
+   * supported by the OpenAPI specification.
+   *
+   * @example <caption>HTTP Basic auth</caption>
+   * sdk.auth('username', 'password');
+   *
+   * @example <caption>Bearer tokens (HTTP or OAuth 2)</caption>
+   * sdk.auth('myBearerToken');
+   *
+   * @example <caption>API Keys</caption>
+   * sdk.auth('myApiKey');
+   *
+   * @see {@link https://spec.openapis.org/oas/v3.0.3#fixed-fields-22}
+   * @see {@link https://spec.openapis.org/oas/v3.1.0#fixed-fields-22}
+   * @param values Your auth credentials for the API; can specify up to two strings or numbers.
+   */
+  auth(...values: string[] | number[]): this;
+  /**
+   * If the API you're using offers alternate server URLs, and server variables, you can tell
+   * the SDK which one to use with this method. To use it you can supply either one of the
+   * server URLs that are contained within the OpenAPI definition (along with any server
+   * variables), or you can pass it a fully qualified URL to use (that may or may not exist
+   * within the OpenAPI definition).
+   *
+   * @example <caption>Server URL with server variables</caption>
+   * sdk.server('https://{region}.api.example.com/{basePath}', {
+   *   name: 'eu',
+   *   basePath: 'v14',
+   * });
+   *
+   * @example <caption>Fully qualified server URL</caption>
+   * sdk.server('https://eu.api.example.com/v14');
+   *
+   * @param url Server URL
+   * @param variables An object of variables to replace into the server URL.
+   */
+  server(url: string, variables?: {}): void;
+  get(path: '/anything', metadata: GetAnythingMetadataParam): Promise<GetAnything_Response_2XX>;
+  getAnything(metadata: GetAnythingMetadataParam): Promise<GetAnything_Response_2XX>;
+}
+declare const createSDK: SDK;
+export default createSDK;
+interface ConfigOptions {
+  /**
+   * By default we parse the response based on the `Content-Type` header of the request. You
+   * can disable this functionality by negating this option.
+   */
+  parseResponse: boolean;
+}
+declare type GetAnythingMetadataParam = {
+  /**
+   * Status values that need to be considered for filter
+   */
+  status: ('available' | 'pending' | 'sold')[];
+  [k: string]: unknown;
+};
+declare type GetAnything_Response_2XX = _260CreatedToken | _260Created;
+interface _260CreatedToken {
+  id?: string;
+  [k: string]: unknown;
+}
+interface _260Created {
+  id?: string;
+  [k: string]: unknown;
+}

--- a/packages/api/test/__fixtures__/sdk/response-title-quirks/index.ts
+++ b/packages/api/test/__fixtures__/sdk/response-title-quirks/index.ts
@@ -1,0 +1,117 @@
+import Oas from 'oas';
+import APICore from 'api/dist/core';
+import definition from '../../../__fixtures__/definitions/response-title-quirks.json';
+
+class SDK {
+  spec: Oas;
+  core: APICore;
+  authKeys: (number | string)[][] = [];
+
+  constructor() {
+    this.spec = Oas.init(definition);
+    this.core = new APICore(this.spec, 'response-title-quirks/1.0.0 (api/5.0-unit-testing)');
+  }
+
+  /**
+   * Optionally configure various options, such as response parsing, that the SDK allows.
+   *
+   * @param config Object of supported SDK options and toggles.
+   * @param config.parseResponse If responses are parsed according to its `Content-Type` header.
+   */
+  config(config: ConfigOptions) {
+    this.core.setConfig(config);
+  }
+
+  /**
+   * If the API you're using requires authentication you can supply the required credentials
+   * through this method and the library will magically determine how they should be used
+   * within your API request.
+   *
+   * With the exception of OpenID and MutualTLS, it supports all forms of authentication
+   * supported by the OpenAPI specification.
+   *
+   * @example <caption>HTTP Basic auth</caption>
+   * sdk.auth('username', 'password');
+   *
+   * @example <caption>Bearer tokens (HTTP or OAuth 2)</caption>
+   * sdk.auth('myBearerToken');
+   *
+   * @example <caption>API Keys</caption>
+   * sdk.auth('myApiKey');
+   *
+   * @see {@link https://spec.openapis.org/oas/v3.0.3#fixed-fields-22}
+   * @see {@link https://spec.openapis.org/oas/v3.1.0#fixed-fields-22}
+   * @param values Your auth credentials for the API; can specify up to two strings or numbers.
+   */
+  auth(...values: string[] | number[]) {
+    this.core.setAuth(...values);
+    return this;
+  }
+
+  /**
+   * If the API you're using offers alternate server URLs, and server variables, you can tell
+   * the SDK which one to use with this method. To use it you can supply either one of the
+   * server URLs that are contained within the OpenAPI definition (along with any server
+   * variables), or you can pass it a fully qualified URL to use (that may or may not exist
+   * within the OpenAPI definition).
+   *
+   * @example <caption>Server URL with server variables</caption>
+   * sdk.server('https://{region}.api.example.com/{basePath}', {
+   *   name: 'eu',
+   *   basePath: 'v14',
+   * });
+   *
+   * @example <caption>Fully qualified server URL</caption>
+   * sdk.server('https://eu.api.example.com/v14');
+   *
+   * @param url Server URL
+   * @param variables An object of variables to replace into the server URL.
+   */
+  server(url: string, variables = {}) {
+    this.core.setServer(url, variables);
+  }
+
+  get(path: '/anything', metadata: GetAnythingMetadataParam): Promise<GetAnything_Response_2XX>;
+  /**
+   * Access any GET endpoint on your API.
+   *
+   * @param path API path to make a request against.
+   * @param metadata Object containing all path, query, header, and cookie parameters to supply.
+   */
+  get<T = unknown>(path: string, metadata?: Record<string, unknown>): Promise<T> {
+    return this.core.fetch(path, 'get', metadata);
+  }
+
+  getAnything(metadata: GetAnythingMetadataParam): Promise<GetAnything_Response_2XX> {
+    return this.core.fetch('/anything', 'get', metadata);
+  }
+}
+
+const createSDK = (() => {
+  return new SDK();
+})();
+export default createSDK;
+
+interface ConfigOptions {
+  /**
+   * By default we parse the response based on the `Content-Type` header of the request. You
+   * can disable this functionality by negating this option.
+   */
+  parseResponse: boolean;
+}
+type GetAnythingMetadataParam = {
+  /**
+   * Status values that need to be considered for filter
+   */
+  status: ('available' | 'pending' | 'sold')[];
+  [k: string]: unknown;
+};
+type GetAnything_Response_2XX = _260CreatedToken | _260Created;
+interface _260CreatedToken {
+  id?: string;
+  [k: string]: unknown;
+}
+interface _260Created {
+  id?: string;
+  [k: string]: unknown;
+}

--- a/packages/api/test/cli/codegen/languages/typescript.test.ts
+++ b/packages/api/test/cli/codegen/languages/typescript.test.ts
@@ -86,6 +86,11 @@ describe('typescript', function () {
       assertSDKFixture('../../../__fixtures__/definitions/operationid-quirks.json', 'operationid-quirks')
     );
 
+    it(
+      'should handle `title` props that start with a number',
+      assertSDKFixture('../../../__fixtures__/definitions/response-title-quirks.json', 'response-title-quirks')
+    );
+
     describe('javascript generation', function () {
       it(
         'should generate a CommonJS library',

--- a/packages/api/test/core/getJSONSchemaDefaults.test.ts
+++ b/packages/api/test/core/getJSONSchemaDefaults.test.ts
@@ -9,7 +9,7 @@ describe('#getJSONSchemaDefaults()', function () {
     await oas.dereference();
 
     const operation = oas.operation('/{dataset}/{version}/records', 'post');
-    const defaults = getJSONSchemaDefaults(operation.getParametersAsJsonSchema());
+    const defaults = getJSONSchemaDefaults(operation.getParametersAsJSONSchema());
 
     expect(defaults).to.deep.equal({
       path: {
@@ -27,7 +27,7 @@ describe('#getJSONSchemaDefaults()', function () {
     await oas.dereference();
 
     const operation = oas.operation('/pet', 'post');
-    const defaults = getJSONSchemaDefaults(operation.getParametersAsJsonSchema());
+    const defaults = getJSONSchemaDefaults(operation.getParametersAsJSONSchema());
 
     expect(defaults).to.deep.equal({
       body: {
@@ -46,7 +46,7 @@ describe('#getJSONSchemaDefaults()', function () {
     await oas.dereference();
 
     const operation = oas.operation('/cookies', 'get');
-    const defaults = getJSONSchemaDefaults(operation.getParametersAsJsonSchema());
+    const defaults = getJSONSchemaDefaults(operation.getParametersAsJSONSchema());
 
     expect(defaults).to.deep.equal({});
   });

--- a/packages/httpsnippet-client-api/package-lock.json
+++ b/packages/httpsnippet-client-api/package-lock.json
@@ -32,7 +32,7 @@
       },
       "peerDependencies": {
         "@readme/httpsnippet": "^4.0.3",
-        "oas": "^18.3.4"
+        "oas": "^19.0.0"
       }
     },
     "../api": {
@@ -40,7 +40,7 @@
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@readme/oas-to-har": "^17.1.2",
+        "@readme/oas-to-har": "^19.0.0",
         "@readme/openapi-parser": "^2.2.0",
         "caseless": "^0.12.0",
         "chalk": "^4.1.2",
@@ -59,13 +59,13 @@
         "json-schema-traverse": "^1.0.0",
         "lodash.merge": "^4.6.2",
         "make-dir": "^3.1.0",
-        "oas": "^18.3.4",
+        "oas": "^19.0.0",
         "object-hash": "^3.0.0",
         "ora": "^5.4.1",
         "prompts": "^2.4.2",
         "remove-undefined-objects": "^2.0.1",
         "ssri": "^9.0.0",
-        "ts-morph": "^15.1.0",
+        "ts-morph": "^16.0.0",
         "validate-npm-package-name": "^4.0.0"
       },
       "bin": {
@@ -78,7 +78,7 @@
         "@types/find-cache-dir": "^3.2.1",
         "@types/js-yaml": "^4.0.5",
         "@types/lodash.merge": "^4.6.7",
-        "@types/mocha": "^9.1.1",
+        "@types/mocha": "^10.0.0",
         "@types/object-hash": "^2.2.1",
         "@types/prompts": "^2.0.14",
         "@types/sinon-chai": "^3.2.8",
@@ -453,9 +453,9 @@
       }
     },
     "node_modules/@exodus/schemasafe": {
-      "version": "1.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@exodus/schemasafe/-/schemasafe-1.0.0-rc.6.tgz",
-      "integrity": "sha512-dDnQizD94EdBwEj/fh3zPRa/HWCS9O5au2PuHhZBbuM3xWHxuaKzPBOEWze7Nn0xW68MIpZ7Xdyn1CoCpjKCuQ==",
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@exodus/schemasafe/-/schemasafe-1.0.0-rc.9.tgz",
+      "integrity": "sha512-dGGHpb61hLwifAu7sotuHFDBw6GTdpG8aKC0fsK17EuTzMRvUrH7lEAr6LTJ+sx3AZYed9yZ77rltVDHyg2hRg==",
       "peer": true
     },
     "node_modules/@humanwhocodes/momoa": {
@@ -1383,6 +1383,7 @@
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
       "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
@@ -1573,6 +1574,12 @@
       "engines": {
         "node": ">=0.12"
       }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "peer": true
     },
     "node_modules/default-require-extensions": {
       "version": "3.0.0",
@@ -1801,7 +1808,7 @@
     "node_modules/es6-promise": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
-      "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM=",
+      "integrity": "sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg==",
       "peer": true
     },
     "node_modules/es6-symbol": {
@@ -1842,6 +1849,38 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/escodegen": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
+      "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
+      "peer": true,
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=4.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/escodegen/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -1852,6 +1891,24 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "peer": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/event-emitter": {
@@ -1933,6 +1990,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "peer": true
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "peer": true
     },
     "node_modules/fast-safe-stringify": {
@@ -3258,6 +3321,30 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonpath": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/jsonpath/-/jsonpath-1.1.1.tgz",
+      "integrity": "sha512-l6Cg7jRpixfbgoWgkrl77dgEj8RPvND0wMH6TwQmi9Qs4TFfS9u5cUFnbeKTwj5ga5Y3BTGGNI28k117LJ009w==",
+      "peer": true,
+      "dependencies": {
+        "esprima": "1.2.2",
+        "static-eval": "2.0.2",
+        "underscore": "1.12.1"
+      }
+    },
+    "node_modules/jsonpath/node_modules/esprima": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.2.tgz",
+      "integrity": "sha512-+JpPZam9w5DuJ3Q67SqsMGtiHKENSMRVoxvArfJZK01/BfLEObtZ6orJa/MtoGNR/rfMgp5837T41PAmTwAv/A==",
+      "peer": true,
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/jsonpointer": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.0.tgz",
@@ -3278,6 +3365,19 @@
       "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
+      "peer": true,
+      "dependencies": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/line-counter": {
@@ -3818,7 +3918,7 @@
     "node_modules/node-readfiles": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/node-readfiles/-/node-readfiles-0.2.0.tgz",
-      "integrity": "sha1-271K8SE04uY1wkXvk//Pb2BnOl0=",
+      "integrity": "sha512-SU00ZarexNlE4Rjdm83vglt5Y9yiQ+XI1XpflWlb7q7UTN1JUItm69xMeiQCTxtTfnzt+83T8Cx+vI2ED++VDA==",
       "peer": true,
       "dependencies": {
         "es6-promise": "^3.2.1"
@@ -4059,9 +4159,9 @@
       }
     },
     "node_modules/oas": {
-      "version": "18.3.4",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-18.3.4.tgz",
-      "integrity": "sha512-mNaTC91kXLcfJjdLSxd2h06JlOAxFFa9+po+KbF7ifMb5PNYy0t0wvxllo0oS/Erztt8W917/fKX3kHVHWvBKw==",
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-19.0.0.tgz",
+      "integrity": "sha512-sN2oW57IXPgxWsfm5IbpLkjeMjs7VzRcBgqhrMZNyPWOkFPsGizRQolMuL4FqeUhIdcaFnv+2DcRLbwliF4g4w==",
       "peer": true,
       "dependencies": {
         "@readme/json-schema-ref-parser": "^1.1.0",
@@ -4072,10 +4172,11 @@
         "inquirer": "^8.1.2",
         "json-schema-merge-allof": "^0.8.1",
         "json2yaml": "^1.1.0",
+        "jsonpath": "^1.1.1",
         "jsonpointer": "^5.0.0",
         "memoizee": "^0.4.14",
         "minimist": "^1.2.0",
-        "oas-normalize": "^6.0.0",
+        "oas-normalize": "^7.0.0",
         "openapi-types": "^12.0.0",
         "path-to-regexp": "^6.2.0",
         "swagger-inline": "^6.0.0"
@@ -4111,14 +4212,15 @@
       }
     },
     "node_modules/oas-normalize": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-6.0.0.tgz",
-      "integrity": "sha512-BYVM3tpl4J5uVAN0EXeFaBKfwMufpCziIfEkU8tfer579p+RKj3qlXaF+rblvTZh4vEmnjNLR4ULmciHfDPF8w==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-7.0.0.tgz",
+      "integrity": "sha512-K/ChGYwdXPR1Vl0fnIdeAmEeQIw/MV90QmRL3DLsRGIS27/VaDn+ChMZ0GvTrE2lxjlDiGkm8cgKqS95F2jQNQ==",
       "peer": true,
       "dependencies": {
         "@readme/openapi-parser": "^2.2.0",
         "js-yaml": "^4.1.0",
         "node-fetch": "^2.6.1",
+        "openapi-types": "^12.0.0",
         "swagger2openapi": "^7.0.8"
       },
       "engines": {
@@ -4144,13 +4246,27 @@
         "url": "https://github.com/Mermade/oas-kit?sponsor=1"
       }
     },
-    "node_modules/oas-resolver/node_modules/yargs": {
-      "version": "17.4.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.4.1.tgz",
-      "integrity": "sha512-WSZD9jgobAg3ZKuCQZSa3g9QOJeCCqLoLAykiWgmXnDo9EPnn4RPf5qVTtzgOx66o6/oqhcA5tHtJXpG8pMt3g==",
+    "node_modules/oas-resolver/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "peer": true,
       "dependencies": {
-        "cliui": "^7.0.2",
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/oas-resolver/node_modules/yargs": {
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.0.tgz",
+      "integrity": "sha512-8H/wTDqlSwoSnScvV2N/JHfLWOKuh5MVla9hqLjK3nsfyy6Y4kDSYSvkU5YCUEPOSnRXfIyx3Sq+B/IWudTo4g==",
+      "peer": true,
+      "dependencies": {
+        "cliui": "^8.0.1",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
@@ -4163,9 +4279,9 @@
       }
     },
     "node_modules/oas-resolver/node_modules/yargs-parser": {
-      "version": "21.0.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
-      "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "peer": true,
       "engines": {
         "node": ">=12"
@@ -4368,6 +4484,23 @@
       "integrity": "sha512-6Wd9k8nmGQHgCbehZCP6wwWcfXcvinhybUTBatuhjRsCxUIujuYFZc9QnGeae75CyHASewBtxs0HX/qwREReUw==",
       "peer": true
     },
+    "node_modules/optionator": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+      "peer": true,
+      "dependencies": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.6",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "word-wrap": "~1.2.3"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/ora": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
@@ -4554,6 +4687,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/process-on-spawn": {
@@ -4852,7 +4994,7 @@
     "node_modules/should-format": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/should-format/-/should-format-3.0.3.tgz",
-      "integrity": "sha1-m/yPdPo5IFxT04w01xcwPidxJPE=",
+      "integrity": "sha512-hZ58adtulAk0gKtua7QxevgUaXTTXxIi8t41L3zo9AHvjXO1/7sdLECuHeIN2SRtYXpNkmhoUP2pdeWgricQ+Q==",
       "peer": true,
       "dependencies": {
         "should-type": "^1.3.0",
@@ -4862,7 +5004,7 @@
     "node_modules/should-type": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/should-type/-/should-type-1.4.0.tgz",
-      "integrity": "sha1-B1bYzoRt/QmEOmlHcZ36DUz/XPM=",
+      "integrity": "sha512-MdAsTu3n25yDbIe1NeN69G4n6mUnJGtSJHygX3+oN0ZbO3DTiATnf7XnYJdGT42JCXurTb1JI0qOBR65shvhPQ==",
       "peer": true
     },
     "node_modules/should-type-adaptors": {
@@ -4998,6 +5140,15 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
+    },
+    "node_modules/static-eval": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.0.2.tgz",
+      "integrity": "sha512-N/D219Hcr2bPjLxPiV+TQE++Tsmrady7TqAJugLy7Xk1EumfDWS/f5dtBbkRCGE7wKKXuYockQoj8Rm2/pVKyg==",
+      "peer": true,
+      "dependencies": {
+        "escodegen": "^1.8.1"
+      }
     },
     "node_modules/stream-combiner": {
       "version": "0.2.2",
@@ -5169,13 +5320,27 @@
         "url": "https://github.com/Mermade/oas-kit?sponsor=1"
       }
     },
-    "node_modules/swagger2openapi/node_modules/yargs": {
-      "version": "17.4.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.4.1.tgz",
-      "integrity": "sha512-WSZD9jgobAg3ZKuCQZSa3g9QOJeCCqLoLAykiWgmXnDo9EPnn4RPf5qVTtzgOx66o6/oqhcA5tHtJXpG8pMt3g==",
+    "node_modules/swagger2openapi/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "peer": true,
       "dependencies": {
-        "cliui": "^7.0.2",
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/swagger2openapi/node_modules/yargs": {
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.0.tgz",
+      "integrity": "sha512-8H/wTDqlSwoSnScvV2N/JHfLWOKuh5MVla9hqLjK3nsfyy6Y4kDSYSvkU5YCUEPOSnRXfIyx3Sq+B/IWudTo4g==",
+      "peer": true,
+      "dependencies": {
+        "cliui": "^8.0.1",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
@@ -5188,9 +5353,9 @@
       }
     },
     "node_modules/swagger2openapi/node_modules/yargs-parser": {
-      "version": "21.0.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
-      "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "peer": true,
       "engines": {
         "node": ">=12"
@@ -5269,6 +5434,18 @@
       "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
       "peer": true
     },
+    "node_modules/type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
+      "peer": true,
+      "dependencies": {
+        "prelude-ls": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -5314,6 +5491,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/underscore": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
+      "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw==",
+      "peer": true
     },
     "node_modules/uri-js": {
       "version": "4.2.2",
@@ -5441,6 +5624,15 @@
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/workerpool": {
       "version": "6.2.1",
@@ -5878,9 +6070,9 @@
       }
     },
     "@exodus/schemasafe": {
-      "version": "1.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@exodus/schemasafe/-/schemasafe-1.0.0-rc.6.tgz",
-      "integrity": "sha512-dDnQizD94EdBwEj/fh3zPRa/HWCS9O5au2PuHhZBbuM3xWHxuaKzPBOEWze7Nn0xW68MIpZ7Xdyn1CoCpjKCuQ==",
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@exodus/schemasafe/-/schemasafe-1.0.0-rc.9.tgz",
+      "integrity": "sha512-dGGHpb61hLwifAu7sotuHFDBw6GTdpG8aKC0fsK17EuTzMRvUrH7lEAr6LTJ+sx3AZYed9yZ77rltVDHyg2hRg==",
       "peer": true
     },
     "@humanwhocodes/momoa": {
@@ -6323,14 +6515,14 @@
       "version": "file:../api",
       "requires": {
         "@readme/oas-examples": "^5.5.0",
-        "@readme/oas-to-har": "^17.1.2",
+        "@readme/oas-to-har": "^19.0.0",
         "@readme/openapi-parser": "^2.2.0",
         "@types/caseless": "^0.12.2",
         "@types/chai": "^4.3.1",
         "@types/find-cache-dir": "^3.2.1",
         "@types/js-yaml": "^4.0.5",
         "@types/lodash.merge": "^4.6.7",
-        "@types/mocha": "^9.1.1",
+        "@types/mocha": "^10.0.0",
         "@types/object-hash": "^2.2.1",
         "@types/prompts": "^2.0.14",
         "@types/sinon-chai": "^3.2.8",
@@ -6358,7 +6550,7 @@
         "mocha": "^10.0.0",
         "mock-require": "^3.0.3",
         "nyc": "^15.1.0",
-        "oas": "^18.3.4",
+        "oas": "^19.0.0",
         "object-hash": "^3.0.0",
         "ora": "^5.4.1",
         "prompts": "^2.4.2",
@@ -6366,7 +6558,7 @@
         "sinon": "^14.0.0",
         "sinon-chai": "^3.7.0",
         "ssri": "^9.0.0",
-        "ts-morph": "^15.1.0",
+        "ts-morph": "^16.0.0",
         "typescript": "^4.7.4",
         "unique-temp-dir": "^1.0.0",
         "validate-npm-package-name": "^4.0.0"
@@ -6631,6 +6823,7 @@
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
       "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
       "requires": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
@@ -6784,6 +6977,12 @@
       "requires": {
         "type-detect": "^4.0.0"
       }
+    },
+    "deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "peer": true
     },
     "default-require-extensions": {
       "version": "3.0.0",
@@ -6976,7 +7175,7 @@
     "es6-promise": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
-      "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM=",
+      "integrity": "sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg==",
       "peer": true
     },
     "es6-symbol": {
@@ -7011,10 +7210,44 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
+    "escodegen": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
+      "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
+      "peer": true,
+      "requires": {
+        "esprima": "^4.0.1",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "optional": true,
+          "peer": true
+        }
+      }
+    },
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+    },
+    "estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "peer": true
+    },
+    "esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "peer": true
     },
     "event-emitter": {
       "version": "0.3.5",
@@ -7091,6 +7324,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "peer": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "peer": true
     },
     "fast-safe-stringify": {
@@ -8041,6 +8280,25 @@
         "minimist": "^1.2.5"
       }
     },
+    "jsonpath": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/jsonpath/-/jsonpath-1.1.1.tgz",
+      "integrity": "sha512-l6Cg7jRpixfbgoWgkrl77dgEj8RPvND0wMH6TwQmi9Qs4TFfS9u5cUFnbeKTwj5ga5Y3BTGGNI28k117LJ009w==",
+      "peer": true,
+      "requires": {
+        "esprima": "1.2.2",
+        "static-eval": "2.0.2",
+        "underscore": "1.12.1"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.2.tgz",
+          "integrity": "sha512-+JpPZam9w5DuJ3Q67SqsMGtiHKENSMRVoxvArfJZK01/BfLEObtZ6orJa/MtoGNR/rfMgp5837T41PAmTwAv/A==",
+          "peer": true
+        }
+      }
+    },
     "jsonpointer": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.0.tgz",
@@ -8056,6 +8314,16 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
       "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A=="
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
+      "peer": true,
+      "requires": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      }
     },
     "line-counter": {
       "version": "1.1.0",
@@ -8470,7 +8738,7 @@
     "node-readfiles": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/node-readfiles/-/node-readfiles-0.2.0.tgz",
-      "integrity": "sha1-271K8SE04uY1wkXvk//Pb2BnOl0=",
+      "integrity": "sha512-SU00ZarexNlE4Rjdm83vglt5Y9yiQ+XI1XpflWlb7q7UTN1JUItm69xMeiQCTxtTfnzt+83T8Cx+vI2ED++VDA==",
       "peer": true,
       "requires": {
         "es6-promise": "^3.2.1"
@@ -8662,9 +8930,9 @@
       }
     },
     "oas": {
-      "version": "18.3.4",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-18.3.4.tgz",
-      "integrity": "sha512-mNaTC91kXLcfJjdLSxd2h06JlOAxFFa9+po+KbF7ifMb5PNYy0t0wvxllo0oS/Erztt8W917/fKX3kHVHWvBKw==",
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-19.0.0.tgz",
+      "integrity": "sha512-sN2oW57IXPgxWsfm5IbpLkjeMjs7VzRcBgqhrMZNyPWOkFPsGizRQolMuL4FqeUhIdcaFnv+2DcRLbwliF4g4w==",
       "peer": true,
       "requires": {
         "@readme/json-schema-ref-parser": "^1.1.0",
@@ -8675,10 +8943,11 @@
         "inquirer": "^8.1.2",
         "json-schema-merge-allof": "^0.8.1",
         "json2yaml": "^1.1.0",
+        "jsonpath": "^1.1.1",
         "jsonpointer": "^5.0.0",
         "memoizee": "^0.4.14",
         "minimist": "^1.2.0",
-        "oas-normalize": "^6.0.0",
+        "oas-normalize": "^7.0.0",
         "openapi-types": "^12.0.0",
         "path-to-regexp": "^6.2.0",
         "swagger-inline": "^6.0.0"
@@ -8787,14 +9056,15 @@
       }
     },
     "oas-normalize": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-6.0.0.tgz",
-      "integrity": "sha512-BYVM3tpl4J5uVAN0EXeFaBKfwMufpCziIfEkU8tfer579p+RKj3qlXaF+rblvTZh4vEmnjNLR4ULmciHfDPF8w==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-7.0.0.tgz",
+      "integrity": "sha512-K/ChGYwdXPR1Vl0fnIdeAmEeQIw/MV90QmRL3DLsRGIS27/VaDn+ChMZ0GvTrE2lxjlDiGkm8cgKqS95F2jQNQ==",
       "peer": true,
       "requires": {
         "@readme/openapi-parser": "^2.2.0",
         "js-yaml": "^4.1.0",
         "node-fetch": "^2.6.1",
+        "openapi-types": "^12.0.0",
         "swagger2openapi": "^7.0.8"
       }
     },
@@ -8811,13 +9081,24 @@
         "yargs": "^17.0.1"
       },
       "dependencies": {
-        "yargs": {
-          "version": "17.4.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.4.1.tgz",
-          "integrity": "sha512-WSZD9jgobAg3ZKuCQZSa3g9QOJeCCqLoLAykiWgmXnDo9EPnn4RPf5qVTtzgOx66o6/oqhcA5tHtJXpG8pMt3g==",
+        "cliui": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+          "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
           "peer": true,
           "requires": {
-            "cliui": "^7.0.2",
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.1",
+            "wrap-ansi": "^7.0.0"
+          }
+        },
+        "yargs": {
+          "version": "17.6.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.0.tgz",
+          "integrity": "sha512-8H/wTDqlSwoSnScvV2N/JHfLWOKuh5MVla9hqLjK3nsfyy6Y4kDSYSvkU5YCUEPOSnRXfIyx3Sq+B/IWudTo4g==",
+          "peer": true,
+          "requires": {
+            "cliui": "^8.0.1",
             "escalade": "^3.1.1",
             "get-caller-file": "^2.0.5",
             "require-directory": "^2.1.1",
@@ -8827,9 +9108,9 @@
           }
         },
         "yargs-parser": {
-          "version": "21.0.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
-          "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
+          "version": "21.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+          "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
           "peer": true
         }
       }
@@ -8902,6 +9183,20 @@
       "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.0.0.tgz",
       "integrity": "sha512-6Wd9k8nmGQHgCbehZCP6wwWcfXcvinhybUTBatuhjRsCxUIujuYFZc9QnGeae75CyHASewBtxs0HX/qwREReUw==",
       "peer": true
+    },
+    "optionator": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+      "peer": true,
+      "requires": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.6",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "word-wrap": "~1.2.3"
+      }
     },
     "ora": {
       "version": "5.4.1",
@@ -9041,6 +9336,12 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
       "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw=="
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
+      "peer": true
     },
     "process-on-spawn": {
       "version": "1.0.0",
@@ -9284,7 +9585,7 @@
     "should-format": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/should-format/-/should-format-3.0.3.tgz",
-      "integrity": "sha1-m/yPdPo5IFxT04w01xcwPidxJPE=",
+      "integrity": "sha512-hZ58adtulAk0gKtua7QxevgUaXTTXxIi8t41L3zo9AHvjXO1/7sdLECuHeIN2SRtYXpNkmhoUP2pdeWgricQ+Q==",
       "peer": true,
       "requires": {
         "should-type": "^1.3.0",
@@ -9294,7 +9595,7 @@
     "should-type": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/should-type/-/should-type-1.4.0.tgz",
-      "integrity": "sha1-B1bYzoRt/QmEOmlHcZ36DUz/XPM=",
+      "integrity": "sha512-MdAsTu3n25yDbIe1NeN69G4n6mUnJGtSJHygX3+oN0ZbO3DTiATnf7XnYJdGT42JCXurTb1JI0qOBR65shvhPQ==",
       "peer": true
     },
     "should-type-adaptors": {
@@ -9407,6 +9708,15 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
+    },
+    "static-eval": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.0.2.tgz",
+      "integrity": "sha512-N/D219Hcr2bPjLxPiV+TQE++Tsmrady7TqAJugLy7Xk1EumfDWS/f5dtBbkRCGE7wKKXuYockQoj8Rm2/pVKyg==",
+      "peer": true,
+      "requires": {
+        "escodegen": "^1.8.1"
+      }
     },
     "stream-combiner": {
       "version": "0.2.2",
@@ -9536,13 +9846,24 @@
         "yargs": "^17.0.1"
       },
       "dependencies": {
-        "yargs": {
-          "version": "17.4.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.4.1.tgz",
-          "integrity": "sha512-WSZD9jgobAg3ZKuCQZSa3g9QOJeCCqLoLAykiWgmXnDo9EPnn4RPf5qVTtzgOx66o6/oqhcA5tHtJXpG8pMt3g==",
+        "cliui": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+          "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
           "peer": true,
           "requires": {
-            "cliui": "^7.0.2",
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.1",
+            "wrap-ansi": "^7.0.0"
+          }
+        },
+        "yargs": {
+          "version": "17.6.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.0.tgz",
+          "integrity": "sha512-8H/wTDqlSwoSnScvV2N/JHfLWOKuh5MVla9hqLjK3nsfyy6Y4kDSYSvkU5YCUEPOSnRXfIyx3Sq+B/IWudTo4g==",
+          "peer": true,
+          "requires": {
+            "cliui": "^8.0.1",
             "escalade": "^3.1.1",
             "get-caller-file": "^2.0.5",
             "require-directory": "^2.1.1",
@@ -9552,9 +9873,9 @@
           }
         },
         "yargs-parser": {
-          "version": "21.0.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
-          "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
+          "version": "21.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+          "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
           "peer": true
         }
       }
@@ -9620,6 +9941,15 @@
       "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
       "peer": true
     },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
+      "peer": true,
+      "requires": {
+        "prelude-ls": "~1.1.2"
+      }
+    },
     "type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -9652,6 +9982,12 @@
         "has-symbols": "^1.0.2",
         "which-boxed-primitive": "^1.0.2"
       }
+    },
+    "underscore": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
+      "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw==",
+      "peer": true
     },
     "uri-js": {
       "version": "4.2.2",
@@ -9766,6 +10102,12 @@
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
+    },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "peer": true
     },
     "workerpool": {
       "version": "6.2.1",

--- a/packages/httpsnippet-client-api/package.json
+++ b/packages/httpsnippet-client-api/package.json
@@ -29,7 +29,7 @@
   },
   "peerDependencies": {
     "@readme/httpsnippet": "^4.0.3",
-    "oas": "^18.3.4"
+    "oas": "^19.0.0"
   },
   "devDependencies": {
     "@readme/oas-examples": "^5.5.0",


### PR DESCRIPTION
| 🚥 Fix #523 |
| :-- |

## 🧰 Changes

A problem with `json-schema-to-typescript` was uncovered in https://github.com/readmeio/api/issues/523 where if a schema `title` prop starts with a number, that library will generate an invalid TypeScript interface causing codegen to fully crash out. To resolve this I've added a new `transformer` hook into [oas](https://npm.im/oas) in https://github.com/readmeio/oas/pull/695 to allow to adhoc transform these problematic to `json-schema-to-typescript` schemas into ones that can be used by prefixing them with an underscore. It's not a great solution but it's functional.

I've also upgraded all of our `oas`-related dependencies in the process as this change to `oas` to facilitate this new transformer incurred a breaking change there.

## 🧬 QA & Testing

I've added a test case for one of these schemas so all tests should be passing.