### PR TITLE
feat: allowing `accept` headers to always be sent through as metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1131,9 +1131,9 @@
       }
     },
     "node_modules/@readme/oas-to-har": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-19.0.0.tgz",
-      "integrity": "sha512-UAgd9jVBBj5rroqBRStzs74IAPx1yp+7k5sqTpuJTApryw28xJNUtvMEwKGSRS17qqOfe1mVInBqeGtEOhxiPQ==",
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-19.1.0.tgz",
+      "integrity": "sha512-Do7zhE9FWRV/HXEQKBIxfym3HorPBv+wc+QkOHIITv0q35Gkhh/7wAlpuT1itiSqHgKjkiyysOiL+PPv4W/Q8Q==",
       "dependencies": {
         "@readme/data-urls": "^1.0.1",
         "@readme/oas-extensions": "^16.0.0",
@@ -13346,7 +13346,7 @@
       "version": "5.0.0-beta.3",
       "license": "MIT",
       "dependencies": {
-        "@readme/oas-to-har": "^19.0.0",
+        "@readme/oas-to-har": "^19.1.0",
         "@readme/openapi-parser": "^2.2.0",
         "caseless": "^0.12.0",
         "chalk": "^4.1.2",
@@ -14320,9 +14320,9 @@
       "requires": {}
     },
     "@readme/oas-to-har": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-19.0.0.tgz",
-      "integrity": "sha512-UAgd9jVBBj5rroqBRStzs74IAPx1yp+7k5sqTpuJTApryw28xJNUtvMEwKGSRS17qqOfe1mVInBqeGtEOhxiPQ==",
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-19.1.0.tgz",
+      "integrity": "sha512-Do7zhE9FWRV/HXEQKBIxfym3HorPBv+wc+QkOHIITv0q35Gkhh/7wAlpuT1itiSqHgKjkiyysOiL+PPv4W/Q8Q==",
       "requires": {
         "@readme/data-urls": "^1.0.1",
         "@readme/oas-extensions": "^16.0.0",
@@ -15174,7 +15174,7 @@
       "version": "file:packages/api",
       "requires": {
         "@readme/oas-examples": "^5.5.0",
-        "@readme/oas-to-har": "^19.0.0",
+        "@readme/oas-to-har": "^19.1.0",
         "@readme/openapi-parser": "^2.2.0",
         "@types/caseless": "^0.12.2",
         "@types/chai": "^4.3.1",

--- a/packages/api/package-lock.json
+++ b/packages/api/package-lock.json
@@ -9,7 +9,7 @@
       "version": "5.0.0-beta.3",
       "license": "MIT",
       "dependencies": {
-        "@readme/oas-to-har": "^19.0.0",
+        "@readme/oas-to-har": "^19.1.0",
         "@readme/openapi-parser": "^2.2.0",
         "caseless": "^0.12.0",
         "chalk": "^4.1.2",
@@ -724,9 +724,9 @@
       }
     },
     "node_modules/@readme/oas-to-har": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-19.0.0.tgz",
-      "integrity": "sha512-UAgd9jVBBj5rroqBRStzs74IAPx1yp+7k5sqTpuJTApryw28xJNUtvMEwKGSRS17qqOfe1mVInBqeGtEOhxiPQ==",
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-19.1.0.tgz",
+      "integrity": "sha512-Do7zhE9FWRV/HXEQKBIxfym3HorPBv+wc+QkOHIITv0q35Gkhh/7wAlpuT1itiSqHgKjkiyysOiL+PPv4W/Q8Q==",
       "dependencies": {
         "@readme/data-urls": "^1.0.1",
         "@readme/oas-extensions": "^16.0.0",
@@ -4824,14 +4824,14 @@
       "dev": true
     },
     "node_modules/ssri": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-9.0.0.tgz",
-      "integrity": "sha512-Y1Z6J8UYnexKFN1R/hxUaYoY2LVdKEzziPmVAFKiKX8fiwvCJTVzn/xYE9TEWod5OVyNfIHHuVfIEuBClL/uJQ==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-10.0.0.tgz",
+      "integrity": "sha512-64ghGOpqW0k+jh7m5jndBGdVEoPikWwGQmBNN5ks6jyUSMymzHDTlnNHOvzp+6MmHOljr2MokUzvRksnTwG0Iw==",
       "dependencies": {
         "minipass": "^3.1.1"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/static-eval": {
@@ -5237,14 +5237,14 @@
       }
     },
     "node_modules/validate-npm-package-name": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-4.0.0.tgz",
-      "integrity": "sha512-mzR0L8ZDktZjpX4OB46KT+56MAhl4EIazWP/+G/HPGuvfdaqg4YsCdtOm6U9+LOFyYDoh4dpnpxZRB9MQQns5Q==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.0.tgz",
+      "integrity": "sha512-YuKoXDAhBYxY7SfOKxHBDoSyENFeW5VvIIQp2TGQuit8gpK6MnWaQelBKxso72DoxTZfZdcP3W90LqpSkgPzLQ==",
       "dependencies": {
         "builtins": "^5.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/validate.io-array": {
@@ -5942,9 +5942,9 @@
       "requires": {}
     },
     "@readme/oas-to-har": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-19.0.0.tgz",
-      "integrity": "sha512-UAgd9jVBBj5rroqBRStzs74IAPx1yp+7k5sqTpuJTApryw28xJNUtvMEwKGSRS17qqOfe1mVInBqeGtEOhxiPQ==",
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-19.1.0.tgz",
+      "integrity": "sha512-Do7zhE9FWRV/HXEQKBIxfym3HorPBv+wc+QkOHIITv0q35Gkhh/7wAlpuT1itiSqHgKjkiyysOiL+PPv4W/Q8Q==",
       "requires": {
         "@readme/data-urls": "^1.0.1",
         "@readme/oas-extensions": "^16.0.0",
@@ -9061,9 +9061,9 @@
       "dev": true
     },
     "ssri": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-9.0.0.tgz",
-      "integrity": "sha512-Y1Z6J8UYnexKFN1R/hxUaYoY2LVdKEzziPmVAFKiKX8fiwvCJTVzn/xYE9TEWod5OVyNfIHHuVfIEuBClL/uJQ==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-10.0.0.tgz",
+      "integrity": "sha512-64ghGOpqW0k+jh7m5jndBGdVEoPikWwGQmBNN5ks6jyUSMymzHDTlnNHOvzp+6MmHOljr2MokUzvRksnTwG0Iw==",
       "requires": {
         "minipass": "^3.1.1"
       }
@@ -9386,9 +9386,9 @@
       "dev": true
     },
     "validate-npm-package-name": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-4.0.0.tgz",
-      "integrity": "sha512-mzR0L8ZDktZjpX4OB46KT+56MAhl4EIazWP/+G/HPGuvfdaqg4YsCdtOm6U9+LOFyYDoh4dpnpxZRB9MQQns5Q==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.0.tgz",
+      "integrity": "sha512-YuKoXDAhBYxY7SfOKxHBDoSyENFeW5VvIIQp2TGQuit8gpK6MnWaQelBKxso72DoxTZfZdcP3W90LqpSkgPzLQ==",
       "requires": {
         "builtins": "^5.0.0"
       }

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -36,7 +36,7 @@
     "swagger"
   ],
   "dependencies": {
-    "@readme/oas-to-har": "^19.0.0",
+    "@readme/oas-to-har": "^19.1.0",
     "@readme/openapi-parser": "^2.2.0",
     "caseless": "^0.12.0",
     "chalk": "^4.1.2",

--- a/packages/api/test/cache.test.ts
+++ b/packages/api/test/cache.test.ts
@@ -3,6 +3,7 @@ import type { OASDocument } from 'oas/dist/rmoas.types';
 import fs from 'fs/promises';
 import path from 'path';
 
+import petstoreSpec from '@readme/oas-examples/3.0/json/petstore.json';
 import readmeSpec from '@readme/oas-examples/3.0/json/readme.json';
 import chai, { assert, expect } from 'chai';
 import fetchMock from 'fetch-mock';
@@ -23,9 +24,19 @@ describe('cache', function () {
   });
 
   describe('#load', function () {
-    it('should return a raw object if a JSON object was initially supplied', async function () {
-      const res = await new Cache(readmeSpec as unknown as OASDocument).load();
-      expect(res).to.deep.equal(readmeSpec);
+    describe('raw object', function () {
+      it('should return a raw object if a JSON object was initially supplied', async function () {
+        const res = await new Cache(readmeSpec as unknown as OASDocument).load();
+        expect(res).to.deep.equal(readmeSpec);
+      });
+
+      it('should return a raw object if supplied, but still validate and dereference it', async function () {
+        const res = await new Cache(petstoreSpec as unknown as OASDocument).load();
+        expect(Object.keys((res.paths['/pet'].post as any).requestBody.content)).to.deep.equal([
+          'application/json',
+          'application/xml',
+        ]);
+      });
     });
 
     describe('ReadMe registry UUID', function () {

--- a/packages/api/test/core/prepareParams.test.ts
+++ b/packages/api/test/core/prepareParams.test.ts
@@ -389,6 +389,51 @@ describe('#prepareParams', function () {
       });
     });
 
+    describe('`accept` header overrides', function () {
+      it('should support supplying an `accept` header parameter', async function () {
+        const operation = parameterStyle.operation('/anything/headers', 'get');
+        const metadata = {
+          primitive: 'buster',
+          accept: 'application/json',
+        };
+
+        expect(await prepareParams(operation, metadata)).to.deep.equal({
+          header: {
+            primitive: 'buster',
+            accept: 'application/json',
+          },
+        });
+      });
+
+      it('should support supplying a case-insensitive `accept` header parameter', async function () {
+        const operation = parameterStyle.operation('/anything/headers', 'get');
+        const metadata = {
+          primitive: 'buster',
+          ACCept: 'application/json',
+        };
+
+        expect(await prepareParams(operation, metadata)).to.deep.equal({
+          header: {
+            primitive: 'buster',
+            accept: 'application/json',
+          },
+        });
+      });
+
+      it('should support supplying **only** an `accept` header parameter', async function () {
+        const operation = parameterStyle.operation('/anything/headers', 'get');
+        const metadata = {
+          accept: 'application/json',
+        };
+
+        expect(await prepareParams(operation, metadata)).to.deep.equal({
+          header: {
+            accept: 'application/json',
+          },
+        });
+      });
+    });
+
     it('should support path parameters', async function () {
       const operation = parameterStyle.operation('/anything/path/{primitive}/{array}/{object}', 'get');
       const metadata = {

--- a/packages/api/test/index.test.ts
+++ b/packages/api/test/index.test.ts
@@ -282,6 +282,11 @@ describe('api', function () {
 
       beforeEach(function () {
         queryEncoding = api({
+          openapi: '3.1.0',
+          info: {
+            version: '1.0.0',
+            title: '',
+          },
           servers: [{ url: 'https://httpbin.org/' }],
           paths: {
             '/anything': {

--- a/packages/api/test/integration.test.ts
+++ b/packages/api/test/integration.test.ts
@@ -1,6 +1,7 @@
 import type { OASDocument } from 'oas/dist/rmoas.types';
 
 import fileUploads from '@readme/oas-examples/3.0/json/file-uploads.json';
+import petstore from '@readme/oas-examples/3.0/json/petstore.json';
 import parametersStyle from '@readme/oas-examples/3.1/json/parameters-style.json';
 import chai, { expect } from 'chai';
 import datauri from 'datauri';
@@ -95,6 +96,41 @@ describe('integration tests', function () {
     expect(res.requestBody).to.equal(await datauri(file));
     expect(res.headers).to.have.deep.property('content-type', 'image/png');
     expect(res.headers).to.have.a.customUserAgent;
+  });
+
+  describe('header handling', function () {
+    it('should support supplying an `accept` header', async function () {
+      fetchMock.post('http://petstore.swagger.io/v2/pet', mockResponse.all);
+
+      const body = {
+        id: 1234,
+        name: 'buster',
+      };
+
+      const metadata = {
+        accept: 'text/xml',
+      };
+
+      const res = await api(petstore as unknown as OASDocument).post('/pet', body, metadata);
+      expect(res.uri).to.equal('/v2/pet');
+      expect(res.requestBody).to.equal('{"id":1234,"name":"buster"}');
+      expect(res.headers).to.have.deep.property('accept', 'text/xml');
+      expect(res.headers).to.have.a.customUserAgent;
+    });
+
+    it('should support supplying **only** an `accept` header', async function () {
+      fetchMock.post('http://petstore.swagger.io/v2/pet', mockResponse.all);
+
+      const metadata = {
+        accept: 'text/xml',
+      };
+
+      const res = await api(petstore as unknown as OASDocument).post('/pet', metadata);
+      expect(res.uri).to.equal('/v2/pet');
+      expect(res.requestBody).to.be.undefined;
+      expect(res.headers).to.have.deep.property('accept', 'text/xml');
+      expect(res.headers).to.have.a.customUserAgent;
+    });
   });
 
   describe('multipart/form-data', function () {

--- a/packages/httpsnippet-client-api/package-lock.json
+++ b/packages/httpsnippet-client-api/package-lock.json
@@ -40,7 +40,7 @@
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@readme/oas-to-har": "^19.0.0",
+        "@readme/oas-to-har": "^19.1.0",
         "@readme/openapi-parser": "^2.2.0",
         "caseless": "^0.12.0",
         "chalk": "^4.1.2",
@@ -68,9 +68,9 @@
         "prettier": "^2.7.1",
         "prompts": "^2.4.2",
         "remove-undefined-objects": "^2.0.1",
-        "ssri": "^9.0.0",
+        "ssri": "^10.0.0",
         "ts-morph": "^16.0.0",
-        "validate-npm-package-name": "^4.0.0"
+        "validate-npm-package-name": "^5.0.0"
       },
       "bin": {
         "api": "bin/api"
@@ -6523,7 +6523,7 @@
       "version": "file:../api",
       "requires": {
         "@readme/oas-examples": "^5.5.0",
-        "@readme/oas-to-har": "^19.0.0",
+        "@readme/oas-to-har": "^19.1.0",
         "@readme/openapi-parser": "^2.2.0",
         "@types/caseless": "^0.12.2",
         "@types/chai": "^4.3.1",
@@ -6573,11 +6573,11 @@
         "remove-undefined-objects": "^2.0.1",
         "sinon": "^14.0.0",
         "sinon-chai": "^3.7.0",
-        "ssri": "^9.0.0",
+        "ssri": "^10.0.0",
         "ts-morph": "^16.0.0",
         "typescript": "^4.7.4",
         "unique-temp-dir": "^1.0.0",
-        "validate-npm-package-name": "^4.0.0"
+        "validate-npm-package-name": "^5.0.0"
       }
     },
     "append-transform": {


### PR DESCRIPTION
| 🚥 Fix #448 |
| :-- |

## 🧰 Changes

* [ ] Updates our parameter digestion and analysis to allow `Accept` headers to always be sent.
* [ ] Updates [@readme/oas-to-har](https://npm.im/@readme/oas-to-har) to fix a quirk where we might prefer non-JSON responses. 
  * https://github.com/readmeio/oas-to-har/pull/130
* [ ] Removing some dead code from our caching architecture.

## 🧬 QA & Testing

Provide as much information as you can on how to test what you've done.
