### PR TITLE
fix: bug where `@api/identifier` wasn't being installed properly

### DIFF
--- a/packages/api/src/cli/codegen/languages/typescript.ts
+++ b/packages/api/src/cli/codegen/languages/typescript.ts
@@ -142,7 +142,7 @@ export default class TSGenerator extends CodeGeneratorLanguage {
     // This will install the installed SDK as a dependency within the current working directory,
     // adding `@api/<sdk identifier>` as a dependency there so you can load it with
     // `require('@api/<sdk identifier>)`.
-    return execa('npm', [...npmInstall].filter(Boolean), { cwd: storage.getIdentifierStorageDir() }).then(res => {
+    return execa('npm', [...npmInstall].filter(Boolean)).then(res => {
       if (opts.dryRun) {
         (opts.logger ? opts.logger : logger)(res.command);
         (opts.logger ? opts.logger : logger)(res.stdout);


### PR DESCRIPTION
## 🧰 Changes

Running `npx api install <something>` wouldn't install `@api/<something>` to your current working directory -- it would still at least create the SDK and install its own deps, just wouldn't link your root install up to it.
