### PR TITLE
fix: installs not actually installing the api

### DIFF
--- a/packages/api/src/cli/codegen/languages/typescript.ts
+++ b/packages/api/src/cli/codegen/languages/typescript.ts
@@ -142,7 +142,7 @@ export default class TSGenerator extends CodeGeneratorLanguage {
     // This will install the installed SDK as a dependency within the current working directory,
     // adding `@api/<sdk identifier>` as a dependency there so you can load it with
     // `require('@api/<sdk identifier>)`.
-    return execa('npm', [...npmInstall].filter(Boolean)).then(res => {
+    return execa('npm', [...npmInstall, installDir].filter(Boolean)).then(res => {
       if (opts.dryRun) {
         (opts.logger ? opts.logger : logger)(res.command);
         (opts.logger ? opts.logger : logger)(res.stdout);

--- a/packages/api/test/cli/codegen/languages/typescript.test.ts
+++ b/packages/api/test/cli/codegen/languages/typescript.test.ts
@@ -71,7 +71,7 @@ describe('typescript', function () {
       await ts.installer(storage, { logger, dryRun: true });
 
       expect(logger).to.be.calledWith('npm install --save --dry-run api json-schema-to-ts oas');
-      expect(logger).to.be.calledWith('npm install --save --dry-run'); // This is the `@api/petstore` install.
+      expect(logger).to.be.calledWith(`npm install --save --dry-run ${storage.getIdentifierStorageDir()}`);
     });
   });
 


### PR DESCRIPTION
| 🚥 Fixes https://github.com/readmeio/api/issues/561 |
| :-- |

## 🧰 Changes

Not sure what happened but neither our tests assert that `npm install` in the root is installing the installed api, but the api isn't getting installed either.