### PR TITLE
fix: compatibility with yarn installs where `package.json` needs `version`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1616,6 +1616,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/semver": {
+      "version": "7.3.13",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
+      "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+      "dev": true
+    },
     "node_modules/@types/sinon": {
       "version": "10.0.12",
       "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.12.tgz",
@@ -12999,6 +13005,7 @@
         "prettier": "^2.7.1",
         "prompts": "^2.4.2",
         "remove-undefined-objects": "^2.0.1",
+        "semver": "^7.3.8",
         "ssri": "^10.0.0",
         "ts-morph": "^16.0.0",
         "validate-npm-package-name": "^5.0.0"
@@ -13020,6 +13027,7 @@
         "@types/mocha": "^10.0.0",
         "@types/prettier": "^2.7.1",
         "@types/prompts": "^2.0.14",
+        "@types/semver": "^7.3.13",
         "@types/sinon-chai": "^3.2.8",
         "@types/ssri": "^7.1.1",
         "@types/validate-npm-package-name": "^4.0.0",
@@ -13031,6 +13039,7 @@
         "oas-normalize": "^7.1.0",
         "sinon": "^14.0.0",
         "sinon-chai": "^3.7.0",
+        "type-fest": "^3.2.0",
         "typescript": "^4.7.4",
         "unique-temp-dir": "^1.0.0"
       },
@@ -13050,6 +13059,32 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "packages/api/node_modules/semver": {
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "packages/api/node_modules/type-fest": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.2.0.tgz",
+      "integrity": "sha512-Il3wdLRzWvbAEtocgxGQA9YOoRVeVUGOMBtel5LdEpNeEAol6GJTLw8GbX6Z8EIMfvfhoOXs2bwOijtAZdK5og==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "packages/httpsnippet-client-api": {
       "version": "5.0.2",
@@ -14397,6 +14432,12 @@
         "@types/node": "*"
       }
     },
+    "@types/semver": {
+      "version": "7.3.13",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
+      "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+      "dev": true
+    },
     "@types/sinon": {
       "version": "10.0.12",
       "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.12.tgz",
@@ -14794,6 +14835,7 @@
         "@types/mocha": "^10.0.0",
         "@types/prettier": "^2.7.1",
         "@types/prompts": "^2.0.14",
+        "@types/semver": "^7.3.13",
         "@types/sinon-chai": "^3.2.8",
         "@types/ssri": "^7.1.1",
         "@types/validate-npm-package-name": "^4.0.0",
@@ -14830,10 +14872,12 @@
         "prettier": "^2.7.1",
         "prompts": "^2.4.2",
         "remove-undefined-objects": "^2.0.1",
+        "semver": "^7.3.8",
         "sinon": "^14.0.0",
         "sinon-chai": "^3.7.0",
         "ssri": "^10.0.0",
         "ts-morph": "^16.0.0",
+        "type-fest": "^3.2.0",
         "typescript": "^4.7.4",
         "unique-temp-dir": "^1.0.0",
         "validate-npm-package-name": "^5.0.0"
@@ -14848,6 +14892,20 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
           "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+        },
+        "semver": {
+          "version": "7.3.8",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "type-fest": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.2.0.tgz",
+          "integrity": "sha512-Il3wdLRzWvbAEtocgxGQA9YOoRVeVUGOMBtel5LdEpNeEAol6GJTLw8GbX6Z8EIMfvfhoOXs2bwOijtAZdK5og==",
+          "dev": true
         }
       }
     },

--- a/packages/api/package-lock.json
+++ b/packages/api/package-lock.json
@@ -38,6 +38,7 @@
         "prettier": "^2.7.1",
         "prompts": "^2.4.2",
         "remove-undefined-objects": "^2.0.1",
+        "semver": "^7.3.8",
         "ssri": "^10.0.0",
         "ts-morph": "^16.0.0",
         "validate-npm-package-name": "^5.0.0"
@@ -59,6 +60,7 @@
         "@types/mocha": "^10.0.0",
         "@types/prettier": "^2.7.1",
         "@types/prompts": "^2.0.14",
+        "@types/semver": "^7.3.13",
         "@types/sinon-chai": "^3.2.8",
         "@types/ssri": "^7.1.1",
         "@types/validate-npm-package-name": "^4.0.0",
@@ -70,6 +72,7 @@
         "oas-normalize": "^7.1.0",
         "sinon": "^14.0.0",
         "sinon-chai": "^3.7.0",
+        "type-fest": "^3.2.0",
         "typescript": "^4.7.4",
         "unique-temp-dir": "^1.0.0"
       },
@@ -160,6 +163,15 @@
         "url": "https://opencollective.com/babel"
       }
     },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/@babel/generator": {
       "version": "7.17.3",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.3.tgz",
@@ -190,6 +202,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/@babel/helper-environment-visitor": {
@@ -977,6 +998,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/semver": {
+      "version": "7.3.13",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
+      "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+      "dev": true
+    },
     "node_modules/@types/sinon": {
       "version": "10.0.12",
       "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.12.tgz",
@@ -1256,20 +1283,6 @@
       "integrity": "sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==",
       "dependencies": {
         "semver": "^7.0.0"
-      }
-    },
-    "node_modules/builtins/node_modules/semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/caching-transform": {
@@ -2487,6 +2500,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/istanbul-lib-instrument/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/istanbul-lib-processinfo": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.2.tgz",
@@ -2806,6 +2828,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/memoizee": {
@@ -3942,11 +3972,17 @@
       "dev": true
     },
     "node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
       "bin": {
         "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/serialize-javascript": {
@@ -4380,6 +4416,18 @@
         "node": ">=4"
       }
     },
+    "node_modules/type-fest": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.2.0.tgz",
+      "integrity": "sha512-Il3wdLRzWvbAEtocgxGQA9YOoRVeVUGOMBtel5LdEpNeEAol6GJTLw8GbX6Z8EIMfvfhoOXs2bwOijtAZdK5og==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/typedarray-to-buffer": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
@@ -4754,6 +4802,14 @@
         "gensync": "^1.0.0-beta.2",
         "json5": "^2.1.2",
         "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
       }
     },
     "@babel/generator": {
@@ -4777,6 +4833,14 @@
         "@babel/helper-validator-option": "^7.16.7",
         "browserslist": "^4.17.5",
         "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
       }
     },
     "@babel/helper-environment-visitor": {
@@ -5368,6 +5432,12 @@
         "@types/node": "*"
       }
     },
+    "@types/semver": {
+      "version": "7.3.13",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
+      "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+      "dev": true
+    },
     "@types/sinon": {
       "version": "10.0.12",
       "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.12.tgz",
@@ -5577,16 +5647,6 @@
       "integrity": "sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==",
       "requires": {
         "semver": "^7.0.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "7.3.7",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        }
       }
     },
     "caching-transform": {
@@ -6475,6 +6535,14 @@
         "@istanbuljs/schema": "^0.1.2",
         "istanbul-lib-coverage": "^3.0.0",
         "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
       }
     },
     "istanbul-lib-processinfo": {
@@ -6736,6 +6804,13 @@
       "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
       "requires": {
         "semver": "^6.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        }
       }
     },
     "memoizee": {
@@ -7598,9 +7673,12 @@
       "dev": true
     },
     "semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
     },
     "serialize-javascript": {
       "version": "6.0.0",
@@ -7951,6 +8029,12 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
+    },
+    "type-fest": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.2.0.tgz",
+      "integrity": "sha512-Il3wdLRzWvbAEtocgxGQA9YOoRVeVUGOMBtel5LdEpNeEAol6GJTLw8GbX6Z8EIMfvfhoOXs2bwOijtAZdK5og==",
       "dev": true
     },
     "typedarray-to-buffer": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -66,6 +66,7 @@
     "prettier": "^2.7.1",
     "prompts": "^2.4.2",
     "remove-undefined-objects": "^2.0.1",
+    "semver": "^7.3.8",
     "ssri": "^10.0.0",
     "ts-morph": "^16.0.0",
     "validate-npm-package-name": "^5.0.0"
@@ -84,6 +85,7 @@
     "@types/mocha": "^10.0.0",
     "@types/prettier": "^2.7.1",
     "@types/prompts": "^2.0.14",
+    "@types/semver": "^7.3.13",
     "@types/sinon-chai": "^3.2.8",
     "@types/ssri": "^7.1.1",
     "@types/validate-npm-package-name": "^4.0.0",
@@ -95,6 +97,7 @@
     "oas-normalize": "^7.1.0",
     "sinon": "^14.0.0",
     "sinon-chai": "^3.7.0",
+    "type-fest": "^3.2.0",
     "typescript": "^4.7.4",
     "unique-temp-dir": "^1.0.0"
   },

--- a/packages/api/test/cli/codegen/languages/typescript.test.ts
+++ b/packages/api/test/cli/codegen/languages/typescript.test.ts
@@ -1,6 +1,9 @@
 /* eslint-disable import/first */
 import type { TSGeneratorOptions } from '../../../../src/cli/codegen/languages/typescript';
 
+import { promises as fs } from 'fs';
+import path from 'path';
+
 import chai, { assert, expect } from 'chai';
 import fetchMock from 'fetch-mock';
 import mockRequire from 'mock-require';
@@ -69,6 +72,17 @@ describe('typescript', function () {
 
       const ts = new TSGenerator(oas, './openapi.json', 'petstore', { compilerTarget: 'cjs' });
       await ts.installer(storage, { logger, dryRun: true });
+
+      const pkgJson = await fs
+        .readFile(path.join(storage.getIdentifierStorageDir(), 'package.json'), 'utf-8')
+        .then(JSON.parse);
+
+      expect(pkgJson).to.deep.equal({
+        name: '@api/petstore',
+        version: '1.0.0',
+        main: './index.ts',
+        types: './index.d.ts',
+      });
 
       expect(logger).to.be.calledWith('npm install --save --dry-run api json-schema-to-ts oas');
       expect(logger).to.be.calledWith(`npm install --save --dry-run ${storage.getIdentifierStorageDir()}`);

--- a/packages/httpsnippet-client-api/package-lock.json
+++ b/packages/httpsnippet-client-api/package-lock.json
@@ -36,7 +36,7 @@
       }
     },
     "../api": {
-      "version": "5.0.0-beta.3",
+      "version": "5.0.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -69,6 +69,7 @@
         "prettier": "^2.7.1",
         "prompts": "^2.4.2",
         "remove-undefined-objects": "^2.0.1",
+        "semver": "^7.3.8",
         "ssri": "^10.0.0",
         "ts-morph": "^16.0.0",
         "validate-npm-package-name": "^5.0.0"
@@ -90,6 +91,7 @@
         "@types/mocha": "^10.0.0",
         "@types/prettier": "^2.7.1",
         "@types/prompts": "^2.0.14",
+        "@types/semver": "^7.3.13",
         "@types/sinon-chai": "^3.2.8",
         "@types/ssri": "^7.1.1",
         "@types/validate-npm-package-name": "^4.0.0",
@@ -101,6 +103,7 @@
         "oas-normalize": "^7.1.0",
         "sinon": "^14.0.0",
         "sinon-chai": "^3.7.0",
+        "type-fest": "^3.2.0",
         "typescript": "^4.7.4",
         "unique-temp-dir": "^1.0.0"
       },
@@ -5060,6 +5063,7 @@
         "@types/mocha": "^10.0.0",
         "@types/prettier": "^2.7.1",
         "@types/prompts": "^2.0.14",
+        "@types/semver": "^7.3.13",
         "@types/sinon-chai": "^3.2.8",
         "@types/ssri": "^7.1.1",
         "@types/validate-npm-package-name": "^4.0.0",
@@ -5096,10 +5100,12 @@
         "prettier": "^2.7.1",
         "prompts": "^2.4.2",
         "remove-undefined-objects": "^2.0.1",
+        "semver": "^7.3.8",
         "sinon": "^14.0.0",
         "sinon-chai": "^3.7.0",
         "ssri": "^10.0.0",
         "ts-morph": "^16.0.0",
+        "type-fest": "^3.2.0",
         "typescript": "^4.7.4",
         "unique-temp-dir": "^1.0.0",
         "validate-npm-package-name": "^5.0.0"


### PR DESCRIPTION
| 🚥 https://github.com/readmeio/api/issues/560 |
| :-- |

## 🧰 Changes

This partially resolves an issue discovered in https://github.com/readmeio/api/issues/560 where because we aren't adding a `version` property into the `package.json` file we create for installed APIs Yarn has issues handling it.

We still don't fully support Yarn with this fix but it's a step towards doing so.