### PR TITLE
fix: resolving typing issues in JS codegen

### DIFF
--- a/packages/api/src/cli/codegen/languages/typescript.ts
+++ b/packages/api/src/cli/codegen/languages/typescript.ts
@@ -177,8 +177,8 @@ export default class TSGenerator extends CodeGeneratorLanguage {
        * exported individually because TS has no way right now of allowing us to do
        * `export type * from './types'` on a non-named entry.
        *
-       * Types in the main entry point are only being exported for TS ouputs as JS users won't be
-       * able to use these them and it clashes with the default SDK export present.
+       * Types in the main entry point are only being exported for TS outputs as JS users won't be
+       * able to use them and it clashes with the default SDK export present.
        *
        * @see {@link https://github.com/microsoft/TypeScript/issues/37238}
        * @see {@link https://github.com/readmeio/api/issues/588}

--- a/packages/api/src/cli/codegen/languages/typescript.ts
+++ b/packages/api/src/cli/codegen/languages/typescript.ts
@@ -172,22 +172,29 @@ export default class TSGenerator extends CodeGeneratorLanguage {
       this.createSchemasFile();
       this.createTypesFile();
 
-      // Export all of our available types so they can be used in SDK implementations.
-      //
-      // We're exporting all of the types individually because TS has no way right now of allowing
-      // us to do `export type * from './types'` on a non-named entry.
-      //
-      // https://github.com/microsoft/TypeScript/issues/37238
-      const types = Array.from(this.types.keys());
-      types.sort();
+      /**
+       * Export all of our available types so they can be used in SDK implementations. Types are
+       * exported individually because TS has no way right now of allowing us to do
+       * `export type * from './types'` on a non-named entry.
+       *
+       * Types in the main entry point are only being exported for TS ouputs as JS users won't be
+       * able to use these them and it clashes with the default SDK export present.
+       *
+       * @see {@link https://github.com/microsoft/TypeScript/issues/37238}
+       * @see {@link https://github.com/readmeio/api/issues/588}
+       */
+      if (!this.outputJS) {
+        const types = Array.from(this.types.keys());
+        types.sort();
 
-      sdkSource.addExportDeclarations([
-        {
-          isTypeOnly: true,
-          namedExports: types,
-          moduleSpecifier: './types',
-        },
-      ]);
+        sdkSource.addExportDeclarations([
+          {
+            isTypeOnly: true,
+            namedExports: types,
+            moduleSpecifier: './types',
+          },
+        ]);
+      }
     } else {
       // If we don't have any schemas then we shouldn't import a `types` file that doesn't exist.
       sdkSource

--- a/packages/api/src/cli/codegen/languages/typescript.ts
+++ b/packages/api/src/cli/codegen/languages/typescript.ts
@@ -413,7 +413,14 @@ sdk.server('https://eu.api.example.com/v14');`)
       ],
     });
 
-    sourceFile.addExportAssignment({ isExportEquals: false, expression: 'createSDK' });
+    sourceFile.addExportAssignment({
+      // Because CJS targets have `createSDK` exported with `module.exports`, but the TS type side
+      // of things to work right we need to set this as `export =`. Thankfully `ts-morph` will
+      // handle this accordingly and still create our JS file with `module.exports` and not
+      // `export =` -- only TS types will have this export style.
+      isExportEquals: this.compilerTarget === 'cjs' && this.outputJS,
+      expression: 'createSDK'
+    });
 
     return sourceFile;
   }

--- a/packages/api/src/cli/codegen/languages/typescript.ts
+++ b/packages/api/src/cli/codegen/languages/typescript.ts
@@ -419,7 +419,7 @@ sdk.server('https://eu.api.example.com/v14');`)
       // handle this accordingly and still create our JS file with `module.exports` and not
       // `export =` -- only TS types will have this export style.
       isExportEquals: this.compilerTarget === 'cjs' && this.outputJS,
-      expression: 'createSDK'
+      expression: 'createSDK',
     });
 
     return sourceFile;

--- a/packages/api/test/__fixtures__/sdk/simple-js-cjs/index.d.ts
+++ b/packages/api/test/__fixtures__/sdk/simple-js-cjs/index.d.ts
@@ -66,4 +66,4 @@ declare class SDK {
   ): Promise<FetchResponse<200, types.FindPetsByStatusResponse200>>;
 }
 declare const createSDK: SDK;
-export default createSDK;
+export = createSDK;

--- a/packages/api/test/__fixtures__/sdk/simple-js-cjs/index.d.ts
+++ b/packages/api/test/__fixtures__/sdk/simple-js-cjs/index.d.ts
@@ -67,13 +67,3 @@ declare class SDK {
 }
 declare const createSDK: SDK;
 export default createSDK;
-export type {
-  ApiResponse,
-  Category,
-  FindPetsByStatusMetadataParam,
-  FindPetsByStatusResponse200,
-  Order,
-  Pet,
-  Tag,
-  User,
-} from './types';

--- a/packages/api/test/__fixtures__/sdk/simple-js-esm/index.d.ts
+++ b/packages/api/test/__fixtures__/sdk/simple-js-esm/index.d.ts
@@ -67,13 +67,3 @@ declare class SDK {
 }
 declare const createSDK: SDK;
 export default createSDK;
-export type {
-  ApiResponse,
-  Category,
-  FindPetsByStatusMetadataParam,
-  FindPetsByStatusResponse200,
-  Order,
-  Pet,
-  Tag,
-  User,
-} from './types';


### PR DESCRIPTION
| 🚥 Fixes #588 |
| :---------------- |

## 🧰 Changes

* [x] Update codegen for CJS exports to have the main `createSDK` export set as `export =` in the `.d.ts` file. Having it as `export default createSDK` was causing issues where the typing was expecting you to to do `sdk.default.someOperation` even though the way you load the SDK doesn't require you to have to destructure it off `default`.
* [x] This also updates JS type generation to no longer export types in the main SDK entry point as it's causing issues with the affformentioned default export issue and also JS users can't import these types anyways. They'll still have access to them by way of TS intellisense but if you want to import these types you'll obviously need to use TS codegen or load them from `types.d.ts`. And yes this does work even though the file has a `.d.ts` extension:

![Screen Shot 2022-12-09 at 1 01 46 PM](https://user-images.githubusercontent.com/33762/206795529-6f1dcf70-ed0f-4373-9874-bbbade183b60.png)

## 🧬 QA & Testing

This is what using a CJS SDK looks like now:

![Screen Shot 2022-12-09 at 1 03 55 PM](https://user-images.githubusercontent.com/33762/206795812-c9b931c4-0436-48a8-a0d2-ef94f4c5e186.png)

What it looked like before (with `export default createSDK` in the `index.d.ts` file):

![Screen Shot 2022-12-09 at 1 04 33 PM](https://user-images.githubusercontent.com/33762/206795911-1502fe1c-aed9-4b3d-bd8f-1cfe252586a2.png)