### PR TITLE
feat: add install flag to bypass prompt

### DIFF
--- a/packages/api/src/cli/commands/install.ts
+++ b/packages/api/src/cli/commands/install.ts
@@ -26,8 +26,8 @@ cmd
       'ts',
     ])
   )
-  .addOption(new Option('-i, --install', 'Do not prompt to install packages'))
-  .action(async (uri: string, options: { lang: string; install?: boolean }) => {
+  .addOption(new Option('-y, --yes', 'Automatically answer "yes" to any prompts printed'))
+  .action(async (uri: string, options: { lang: string; yes?: boolean }) => {
     let language: SupportedLanguages;
     if (options.lang) {
       language = options.lang as SupportedLanguages;
@@ -156,7 +156,7 @@ cmd
         logger(`  ${figures.pointerSmall} ${pkg}: ${pkgInfo.reason} ${pkgInfo.url}`);
       });
 
-      if (!options.install) {
+      if (!options.yes) {
         await promptTerminal({
           type: 'confirm',
           name: 'value',

--- a/packages/api/src/cli/commands/install.ts
+++ b/packages/api/src/cli/commands/install.ts
@@ -26,7 +26,8 @@ cmd
       'ts',
     ])
   )
-  .action(async (uri: string, options: { lang: string }) => {
+  .addOption(new Option('-i, --install', 'Do not prompt to install packages'))
+  .action(async (uri: string, options: { lang: string; install?: boolean }) => {
     let language: SupportedLanguages;
     if (options.lang) {
       language = options.lang as SupportedLanguages;
@@ -155,18 +156,20 @@ cmd
         logger(`  ${figures.pointerSmall} ${pkg}: ${pkgInfo.reason} ${pkgInfo.url}`);
       });
 
-      await promptTerminal({
-        type: 'confirm',
-        name: 'value',
-        message: 'OK to proceed with package installation?',
-        initial: true,
-      }).then(({ value }) => {
-        if (!value) {
-          // @todo cleanup installed files
-          logger('Installation cancelled.', true);
-          process.exit(1);
-        }
-      });
+      if (!options.install) {
+        await promptTerminal({
+          type: 'confirm',
+          name: 'value',
+          message: 'OK to proceed with package installation?',
+          initial: true,
+        }).then(({ value }) => {
+          if (!value) {
+            // @todo cleanup installed files
+            logger('Installation cancelled.', true);
+            process.exit(1);
+          }
+        });
+      }
 
       spinner = ora('Installing required packages').start();
       try {


### PR DESCRIPTION
When dependencies are not installed, the CLI prompts to install packages

This PR adds an `-y`/`--yes` flag that can be passed that acts as a `yes` input to the prompt.

## 🧬 QA & Testing

N/A
