### PR TITLE
fix(snippet): bug where path params may lose hyphens if they have one

### DIFF
--- a/packages/httpsnippet-client-api/test/__datasets__/parameter-special-characters/index.ts
+++ b/packages/httpsnippet-client-api/test/__datasets__/parameter-special-characters/index.ts
@@ -1,0 +1,32 @@
+import type { SnippetMock } from '../../index.test';
+import type { OASDocument } from 'oas/dist/rmoas.types';
+
+import definition from './openapi.json';
+
+const mock: SnippetMock = {
+  har: {
+    bodySize: 0,
+    cookies: [],
+    headers: [],
+    headersSize: 0,
+    httpVersion: 'HTTP/1.1',
+    method: 'GET',
+    postData: {
+      mimeType: 'application/json',
+    },
+    queryString: [],
+    url: 'https://httpbin.org/anything/1234/5678/installs_report/v5',
+  },
+  definition: definition as unknown as OASDocument,
+  fetch: {
+    req: {
+      url: 'https://httpbin.org/anything/1234/5678/installs_report/v5',
+      method: 'get',
+    },
+    res: {
+      status: 200,
+    },
+  },
+};
+
+export default mock;

--- a/packages/httpsnippet-client-api/test/__datasets__/parameter-special-characters/openapi.json
+++ b/packages/httpsnippet-client-api/test/__datasets__/parameter-special-characters/openapi.json
@@ -1,0 +1,41 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "version": "1.0.0",
+    "title": "A path parameter with a hyphen in it."
+  },
+  "servers": [
+    {
+      "url": "https://httpbin.org/anything"
+    }
+  ],
+  "paths": {
+    "/{app-id}/{num}/installs_report/v5": {
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "app-id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "num",
+            "required": true,
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/httpsnippet-client-api/test/__datasets__/parameter-special-characters/output.js
+++ b/packages/httpsnippet-client-api/test/__datasets__/parameter-special-characters/output.js
@@ -1,0 +1,5 @@
+const sdk = require('api')('https://api.example.com/parameter-special-characters.json');
+
+sdk.getAppIdNumInstalls_reportV5({'app-id': '1234', num: '5678'})
+  .then(({ data }) => console.log(data))
+  .catch(err => console.error(err));


### PR DESCRIPTION
| 🚥 Fixes CX-380 |
| :---------------- |

## 🧰 Changes

This fixes a quirk in snippet generation where if a path param in an OpenAPI definition had a hyphen like `app-id` then the snippet that we'd generate for this would be `appid`. This would cause these requests in `api` code to fail because `appid` is not a parameter that exists.
