### PR TITLE
fix(codegen): don't surface error responses as method return types

### DIFF
--- a/packages/api/src/core/errors/fetchError.ts
+++ b/packages/api/src/core/errors/fetchError.ts
@@ -1,9 +1,9 @@
-class FetchError extends Error {
+class FetchError<Status = number, Data = unknown> extends Error {
   /** HTTP Status */
-  status: number;
+  status: Status;
 
   /** The content of the response. */
-  data: unknown;
+  data: Data;
 
   /** The Headers of the response. */
   headers: Headers;
@@ -11,7 +11,7 @@ class FetchError extends Error {
   /** The raw `Response` object. */
   res: Response;
 
-  constructor(status: number, data: unknown, headers: Headers, res: Response) {
+  constructor(status: Status, data: Data, headers: Headers, res: Response) {
     super(res.statusText);
 
     this.name = 'FetchError';

--- a/packages/api/src/core/index.ts
+++ b/packages/api/src/core/index.ts
@@ -128,7 +128,12 @@ export default class APICore {
           const parsed = await parseResponse(res);
 
           if (res.status >= 400 && res.status <= 599) {
-            throw new FetchError(parsed.status, parsed.data, parsed.headers, parsed.res);
+            throw new FetchError<typeof parsed.status, typeof parsed.data>(
+              parsed.status,
+              parsed.data,
+              parsed.headers,
+              parsed.res
+            );
           }
 
           return parsed;

--- a/packages/api/test/__fixtures__/sdk/alby/index.ts
+++ b/packages/api/test/__fixtures__/sdk/alby/index.ts
@@ -77,15 +77,13 @@ class SDK {
    * List all applications for the specified account ID.
    *
    * @summary Lists apps
+   * @throws FetchError<401, types.Error> Authentication failed
+   * @throws FetchError<404, types.Error> Account not found
+   * @throws FetchError<500, types.Error> Internal server error
    */
   getAccountsAccount_idApps(
     metadata: types.GetAccountsAccountIdAppsMetadataParam
-  ): Promise<
-    | FetchResponse<200, types.GetAccountsAccountIdAppsResponse200>
-    | FetchResponse<401, types.Error>
-    | FetchResponse<404, types.Error>
-    | FetchResponse<500, types.Error>
-  > {
+  ): Promise<FetchResponse<200, types.GetAccountsAccountIdAppsResponse200>> {
     return this.core.fetch('/accounts/{account_id}/apps', 'get', metadata);
   }
 
@@ -93,18 +91,16 @@ class SDK {
    * Creates an application with the specified properties.
    *
    * @summary Creates an app
+   * @throws FetchError<400, types.Error> Bad request
+   * @throws FetchError<401, types.Error> Authentication failed
+   * @throws FetchError<404, types.Error> Account not found
+   * @throws FetchError<422, types.Error> Invalid request
+   * @throws FetchError<500, types.Error> Internal server error
    */
   postAccountsAccount_idApps(
     body: types.AppPost,
     metadata: types.PostAccountsAccountIdAppsMetadataParam
-  ): Promise<
-    | FetchResponse<201, types.AppResponse>
-    | FetchResponse<400, types.Error>
-    | FetchResponse<401, types.Error>
-    | FetchResponse<404, types.Error>
-    | FetchResponse<422, types.Error>
-    | FetchResponse<500, types.Error>
-  > {
+  ): Promise<FetchResponse<201, types.AppResponse>> {
     return this.core.fetch('/accounts/{account_id}/apps', 'post', body, metadata);
   }
 
@@ -112,16 +108,14 @@ class SDK {
    * Lists the API keys associated with the application ID.
    *
    * @summary Lists app keys
+   * @throws FetchError<401, types.Error> Authentication failed
+   * @throws FetchError<404, types.Error> App not found
+   * @throws FetchError<500, types.Error> Internal server error
+   * @throws FetchError<504, types.Error> Gateway timeout
    */
   getAppsApp_idKeys(
     metadata: types.GetAppsAppIdKeysMetadataParam
-  ): Promise<
-    | FetchResponse<200, types.GetAppsAppIdKeysResponse200>
-    | FetchResponse<401, types.Error>
-    | FetchResponse<404, types.Error>
-    | FetchResponse<500, types.Error>
-    | FetchResponse<504, types.Error>
-  > {
+  ): Promise<FetchResponse<200, types.GetAppsAppIdKeysResponse200>> {
     return this.core.fetch('/apps/{app_id}/keys', 'get', metadata);
   }
 
@@ -129,18 +123,16 @@ class SDK {
    * Creates an API key for the application specified.
    *
    * @summary Creates a key
+   * @throws FetchError<400, types.Error> Bad request
+   * @throws FetchError<401, types.Error> Authentication failed
+   * @throws FetchError<404, types.Error> App not found
+   * @throws FetchError<422, types.Error> Invalid request
+   * @throws FetchError<500, types.Error> Internal server error
    */
   postAppsApp_idKeys(
     body: types.KeyPost,
     metadata: types.PostAppsAppIdKeysMetadataParam
-  ): Promise<
-    | FetchResponse<201, types.KeyResponse>
-    | FetchResponse<400, types.Error>
-    | FetchResponse<401, types.Error>
-    | FetchResponse<404, types.Error>
-    | FetchResponse<422, types.Error>
-    | FetchResponse<500, types.Error>
-  > {
+  ): Promise<FetchResponse<201, types.KeyResponse>> {
     return this.core.fetch('/apps/{app_id}/keys', 'post', body, metadata);
   }
 
@@ -149,54 +141,24 @@ class SDK {
    * application ID.
    *
    * @summary Updates a key
+   * @throws FetchError<400, types.Error> Bad request
+   * @throws FetchError<401, types.Error> Authentication failed
+   * @throws FetchError<404, types.Error> App not found
+   * @throws FetchError<422, types.Error> Invalid request
+   * @throws FetchError<500, types.Error> Internal server error
+   * @throws FetchError<504, types.Error> Gateway timeout
    */
   patchAppsApp_idKeysKey_id(
     body: types.KeyPatch,
     metadata: types.PatchAppsAppIdKeysKeyIdMetadataParam
-  ): Promise<
-    | FetchResponse<200, types.KeyResponse>
-    | FetchResponse<400, types.Error>
-    | FetchResponse<401, types.Error>
-    | FetchResponse<404, types.Error>
-    | FetchResponse<422, types.Error>
-    | FetchResponse<500, types.Error>
-    | FetchResponse<504, types.Error>
-  >;
-  /**
-   * Update the API key with the specified key ID, for the application with the specified
-   * application ID.
-   *
-   * @summary Updates a key
-   */
+  ): Promise<FetchResponse<200, types.KeyResponse>>;
   patchAppsApp_idKeysKey_id(
     metadata: types.PatchAppsAppIdKeysKeyIdMetadataParam
-  ): Promise<
-    | FetchResponse<200, types.KeyResponse>
-    | FetchResponse<400, types.Error>
-    | FetchResponse<401, types.Error>
-    | FetchResponse<404, types.Error>
-    | FetchResponse<422, types.Error>
-    | FetchResponse<500, types.Error>
-    | FetchResponse<504, types.Error>
-  >;
-  /**
-   * Update the API key with the specified key ID, for the application with the specified
-   * application ID.
-   *
-   * @summary Updates a key
-   */
+  ): Promise<FetchResponse<200, types.KeyResponse>>;
   patchAppsApp_idKeysKey_id(
     body?: types.KeyPatch | types.PatchAppsAppIdKeysKeyIdMetadataParam,
     metadata?: types.PatchAppsAppIdKeysKeyIdMetadataParam
-  ): Promise<
-    | FetchResponse<200, types.KeyResponse>
-    | FetchResponse<400, types.Error>
-    | FetchResponse<401, types.Error>
-    | FetchResponse<404, types.Error>
-    | FetchResponse<422, types.Error>
-    | FetchResponse<500, types.Error>
-    | FetchResponse<504, types.Error>
-  > {
+  ): Promise<FetchResponse<200, types.KeyResponse>> {
     return this.core.fetch('/apps/{app_id}/keys/{key_id}', 'patch', body, metadata);
   }
 
@@ -205,15 +167,14 @@ class SDK {
    * key.
    *
    * @summary Revokes a key
+   * @throws FetchError<401, types.Error> Authentication failed
+   * @throws FetchError<404, types.Error> Not found
+   * @throws FetchError<500, types.Error> Internal server error
+   * @throws FetchError<504, types.Error> Gateway timeout
    */
   postAppsApp_idKeysKey_idRevoke(
     metadata: types.PostAppsAppIdKeysKeyIdRevokeMetadataParam
-  ): Promise<
-    | FetchResponse<401, types.Error>
-    | FetchResponse<404, types.Error>
-    | FetchResponse<500, types.Error>
-    | FetchResponse<504, types.Error>
-  > {
+  ): Promise<FetchResponse<number, unknown>> {
     return this.core.fetch('/apps/{app_id}/keys/{key_id}/revoke', 'post', metadata);
   }
 
@@ -221,16 +182,14 @@ class SDK {
    * List the namespaces for the specified application ID.
    *
    * @summary Lists namespaces
+   * @throws FetchError<401, types.Error> Authentication failed
+   * @throws FetchError<404, types.Error> App not found
+   * @throws FetchError<500, types.Error> Internal server error
+   * @throws FetchError<504, types.Error> Gateway timeout
    */
   getAppsApp_idNamespaces(
     metadata: types.GetAppsAppIdNamespacesMetadataParam
-  ): Promise<
-    | FetchResponse<200, types.GetAppsAppIdNamespacesResponse200>
-    | FetchResponse<401, types.Error>
-    | FetchResponse<404, types.Error>
-    | FetchResponse<500, types.Error>
-    | FetchResponse<504, types.Error>
-  > {
+  ): Promise<FetchResponse<200, types.GetAppsAppIdNamespacesResponse200>> {
     return this.core.fetch('/apps/{app_id}/namespaces', 'get', metadata);
   }
 
@@ -238,18 +197,16 @@ class SDK {
    * Creates a namespace for the specified application ID.
    *
    * @summary Creates a namespace
+   * @throws FetchError<400, types.Error> Bad request
+   * @throws FetchError<401, types.Error> Authentication failed
+   * @throws FetchError<404, types.Error> App not found
+   * @throws FetchError<422, types.Error> Invalid request
+   * @throws FetchError<500, types.Error> Internal server error
    */
   postAppsApp_idNamespaces(
     body: types.NamespacePost,
     metadata: types.PostAppsAppIdNamespacesMetadataParam
-  ): Promise<
-    | FetchResponse<201, types.NamespaceResponse>
-    | FetchResponse<400, types.Error>
-    | FetchResponse<401, types.Error>
-    | FetchResponse<404, types.Error>
-    | FetchResponse<422, types.Error>
-    | FetchResponse<500, types.Error>
-  > {
+  ): Promise<FetchResponse<201, types.NamespaceResponse>> {
     return this.core.fetch('/apps/{app_id}/namespaces', 'post', body, metadata);
   }
 
@@ -257,15 +214,14 @@ class SDK {
    * Deletes the namespace with the specified ID, for the specified application ID.
    *
    * @summary Deletes a namespace
+   * @throws FetchError<401, types.Error> Authentication failed
+   * @throws FetchError<404, types.Error> Not found
+   * @throws FetchError<500, types.Error> Internal server error
+   * @throws FetchError<504, types.Error> Gateway timeout
    */
   deleteAppsApp_idNamespacesNamespace_id(
     metadata: types.DeleteAppsAppIdNamespacesNamespaceIdMetadataParam
-  ): Promise<
-    | FetchResponse<401, types.Error>
-    | FetchResponse<404, types.Error>
-    | FetchResponse<500, types.Error>
-    | FetchResponse<504, types.Error>
-  > {
+  ): Promise<FetchResponse<number, unknown>> {
     return this.core.fetch('/apps/{app_id}/namespaces/{namespace_id}', 'delete', metadata);
   }
 
@@ -274,51 +230,23 @@ class SDK {
    * application ID.
    *
    * @summary Updates a namespace
+   * @throws FetchError<400, types.Error> Bad request
+   * @throws FetchError<401, types.Error> Authentication failed
+   * @throws FetchError<404, types.Error> Not found
+   * @throws FetchError<500, types.Error> Internal server error
+   * @throws FetchError<504, types.Error> Gateway timeout
    */
   patchAppsApp_idNamespacesNamespace_id(
     body: types.NamespacePatch,
     metadata: types.PatchAppsAppIdNamespacesNamespaceIdMetadataParam
-  ): Promise<
-    | FetchResponse<200, types.NamespaceResponse>
-    | FetchResponse<400, types.Error>
-    | FetchResponse<401, types.Error>
-    | FetchResponse<404, types.Error>
-    | FetchResponse<500, types.Error>
-    | FetchResponse<504, types.Error>
-  >;
-  /**
-   * Updates the namespace with the specified ID, for the application with the specified
-   * application ID.
-   *
-   * @summary Updates a namespace
-   */
+  ): Promise<FetchResponse<200, types.NamespaceResponse>>;
   patchAppsApp_idNamespacesNamespace_id(
     metadata: types.PatchAppsAppIdNamespacesNamespaceIdMetadataParam
-  ): Promise<
-    | FetchResponse<200, types.NamespaceResponse>
-    | FetchResponse<400, types.Error>
-    | FetchResponse<401, types.Error>
-    | FetchResponse<404, types.Error>
-    | FetchResponse<500, types.Error>
-    | FetchResponse<504, types.Error>
-  >;
-  /**
-   * Updates the namespace with the specified ID, for the application with the specified
-   * application ID.
-   *
-   * @summary Updates a namespace
-   */
+  ): Promise<FetchResponse<200, types.NamespaceResponse>>;
   patchAppsApp_idNamespacesNamespace_id(
     body?: types.NamespacePatch | types.PatchAppsAppIdNamespacesNamespaceIdMetadataParam,
     metadata?: types.PatchAppsAppIdNamespacesNamespaceIdMetadataParam
-  ): Promise<
-    | FetchResponse<200, types.NamespaceResponse>
-    | FetchResponse<400, types.Error>
-    | FetchResponse<401, types.Error>
-    | FetchResponse<404, types.Error>
-    | FetchResponse<500, types.Error>
-    | FetchResponse<504, types.Error>
-  > {
+  ): Promise<FetchResponse<200, types.NamespaceResponse>> {
     return this.core.fetch('/apps/{app_id}/namespaces/{namespace_id}', 'patch', body, metadata);
   }
 
@@ -326,17 +254,15 @@ class SDK {
    * Lists the queues associated with the specified application ID.
    *
    * @summary Lists queues
+   * @throws FetchError<401, types.Error> Authentication failed
+   * @throws FetchError<404, types.Error> App not found
+   * @throws FetchError<500, types.Error> Internal server error
+   * @throws FetchError<503, types.Error> 503 Service unavailable
+   * @throws FetchError<504, types.Error> Gateway timeout
    */
   getAppsApp_idQueues(
     metadata: types.GetAppsAppIdQueuesMetadataParam
-  ): Promise<
-    | FetchResponse<200, types.GetAppsAppIdQueuesResponse200>
-    | FetchResponse<401, types.Error>
-    | FetchResponse<404, types.Error>
-    | FetchResponse<500, types.Error>
-    | FetchResponse<503, types.Error>
-    | FetchResponse<504, types.Error>
-  > {
+  ): Promise<FetchResponse<200, types.GetAppsAppIdQueuesResponse200>> {
     return this.core.fetch('/apps/{app_id}/queues', 'get', metadata);
   }
 
@@ -345,18 +271,16 @@ class SDK {
    * queue to be created are specified in the request body.
    *
    * @summary Creates a queue
+   * @throws FetchError<400, types.Error> Bad request
+   * @throws FetchError<401, types.Error> Authentication failed
+   * @throws FetchError<404, types.Error> App not found
+   * @throws FetchError<422, types.Error> Invalid request
+   * @throws FetchError<500, types.Error> Internal server error
    */
   postAppsApp_idQueues(
     body: types.Queue,
     metadata: types.PostAppsAppIdQueuesMetadataParam
-  ): Promise<
-    | FetchResponse<201, types.QueueResponse>
-    | FetchResponse<400, types.Error>
-    | FetchResponse<401, types.Error>
-    | FetchResponse<404, types.Error>
-    | FetchResponse<422, types.Error>
-    | FetchResponse<500, types.Error>
-  > {
+  ): Promise<FetchResponse<201, types.QueueResponse>> {
     return this.core.fetch('/apps/{app_id}/queues', 'post', body, metadata);
   }
 
@@ -365,16 +289,15 @@ class SDK {
    * application ID.
    *
    * @summary Deletes a queue
+   * @throws FetchError<400, types.Error> Bad request
+   * @throws FetchError<401, types.Error> Authentication failed
+   * @throws FetchError<404, types.Error> App not found
+   * @throws FetchError<500, types.Error> Internal server error
+   * @throws FetchError<503, types.Error> 503 Service unavailable
    */
   deleteAppsApp_idQueuesQueue_id(
     metadata: types.DeleteAppsAppIdQueuesQueueIdMetadataParam
-  ): Promise<
-    | FetchResponse<400, types.Error>
-    | FetchResponse<401, types.Error>
-    | FetchResponse<404, types.Error>
-    | FetchResponse<500, types.Error>
-    | FetchResponse<503, types.Error>
-  > {
+  ): Promise<FetchResponse<number, unknown>> {
     return this.core.fetch('/apps/{app_id}/queues/{queue_id}', 'delete', metadata);
   }
 
@@ -382,16 +305,14 @@ class SDK {
    * Lists the rules for the application specified by the application ID.
    *
    * @summary Lists Reactor rules
+   * @throws FetchError<401, types.Error> Authentication failed
+   * @throws FetchError<404, types.Error> App not found
+   * @throws FetchError<500, types.Error> Internal server error
+   * @throws FetchError<504, types.Error> Gateway timeout
    */
   getAppsApp_idRules(
     metadata: types.GetAppsAppIdRulesMetadataParam
-  ): Promise<
-    | FetchResponse<200, types.GetAppsAppIdRulesResponse200>
-    | FetchResponse<401, types.Error>
-    | FetchResponse<404, types.Error>
-    | FetchResponse<500, types.Error>
-    | FetchResponse<504, types.Error>
-  > {
+  ): Promise<FetchResponse<200, types.GetAppsAppIdRulesResponse200>> {
     return this.core.fetch('/apps/{app_id}/rules', 'get', metadata);
   }
 
@@ -399,67 +320,38 @@ class SDK {
    * Creates a rule for the application with the specified application ID.
    *
    * @summary Creates a Reactor rule
+   * @throws FetchError<400, types.Error> Bad request
+   * @throws FetchError<401, types.Error> Authentication failed
+   * @throws FetchError<404, types.Error> App not found
+   * @throws FetchError<422, types.Error> Invalid request
+   * @throws FetchError<500, types.Error> Internal server error
+   * @throws FetchError<504, types.Error> Gateway timeout
    */
   postAppsApp_idRules(
     body: types.RulePost,
     metadata: types.PostAppsAppIdRulesMetadataParam
-  ): Promise<
-    | FetchResponse<201, types.RuleResponse>
-    | FetchResponse<400, types.Error>
-    | FetchResponse<401, types.Error>
-    | FetchResponse<404, types.Error>
-    | FetchResponse<422, types.Error>
-    | FetchResponse<500, types.Error>
-    | FetchResponse<504, types.Error>
-  >;
-  /**
-   * Creates a rule for the application with the specified application ID.
-   *
-   * @summary Creates a Reactor rule
-   */
+  ): Promise<FetchResponse<201, types.RuleResponse>>;
   postAppsApp_idRules(
     metadata: types.PostAppsAppIdRulesMetadataParam
-  ): Promise<
-    | FetchResponse<201, types.RuleResponse>
-    | FetchResponse<400, types.Error>
-    | FetchResponse<401, types.Error>
-    | FetchResponse<404, types.Error>
-    | FetchResponse<422, types.Error>
-    | FetchResponse<500, types.Error>
-    | FetchResponse<504, types.Error>
-  >;
-  /**
-   * Creates a rule for the application with the specified application ID.
-   *
-   * @summary Creates a Reactor rule
-   */
+  ): Promise<FetchResponse<201, types.RuleResponse>>;
   postAppsApp_idRules(
     body?: types.RulePost | types.PostAppsAppIdRulesMetadataParam,
     metadata?: types.PostAppsAppIdRulesMetadataParam
-  ): Promise<
-    | FetchResponse<201, types.RuleResponse>
-    | FetchResponse<400, types.Error>
-    | FetchResponse<401, types.Error>
-    | FetchResponse<404, types.Error>
-    | FetchResponse<422, types.Error>
-    | FetchResponse<500, types.Error>
-    | FetchResponse<504, types.Error>
-  > {
+  ): Promise<FetchResponse<201, types.RuleResponse>> {
     return this.core.fetch('/apps/{app_id}/rules', 'post', body, metadata);
   }
 
   /**
    * Deletes a Reactor rule
    *
+   * @throws FetchError<401, types.Error> Authentication failed
+   * @throws FetchError<404, types.Error> App not found
+   * @throws FetchError<500, types.Error> Internal server error
+   * @throws FetchError<504, types.Error> Gateway timeout
    */
   deleteAppsApp_idRulesRule_id(
     metadata: types.DeleteAppsAppIdRulesRuleIdMetadataParam
-  ): Promise<
-    | FetchResponse<401, types.Error>
-    | FetchResponse<404, types.Error>
-    | FetchResponse<500, types.Error>
-    | FetchResponse<504, types.Error>
-  > {
+  ): Promise<FetchResponse<number, unknown>> {
     return this.core.fetch('/apps/{app_id}/rules/{rule_id}', 'delete', metadata);
   }
 
@@ -468,66 +360,38 @@ class SDK {
    * ID.
    *
    * @summary Gets a reactor rule by rule ID
+   * @throws FetchError<401, types.Error> Authentication failed
+   * @throws FetchError<404, types.Error> Not found
+   * @throws FetchError<500, types.Error> Internal server error
+   * @throws FetchError<504, types.Error> Gateway timeout
    */
   getAppsApp_idRulesRule_id(
     metadata: types.GetAppsAppIdRulesRuleIdMetadataParam
-  ): Promise<
-    | FetchResponse<200, types.RuleResponse>
-    | FetchResponse<401, types.Error>
-    | FetchResponse<404, types.Error>
-    | FetchResponse<500, types.Error>
-    | FetchResponse<504, types.Error>
-  > {
+  ): Promise<FetchResponse<200, types.RuleResponse>> {
     return this.core.fetch('/apps/{app_id}/rules/{rule_id}', 'get', metadata);
   }
 
   /**
    * Updates a Reactor rule
    *
+   * @throws FetchError<400, types.Error> Bad request
+   * @throws FetchError<401, types.Error> Authentication failed
+   * @throws FetchError<404, types.Error> App not found
+   * @throws FetchError<422, types.Error> Invalid request
+   * @throws FetchError<500, types.Error> Internal server error
+   * @throws FetchError<504, types.Error> Gateway timeout
    */
   patchAppsApp_idRulesRule_id(
     body: types.RulePatch,
     metadata: types.PatchAppsAppIdRulesRuleIdMetadataParam
-  ): Promise<
-    | FetchResponse<200, types.RuleResponse>
-    | FetchResponse<400, types.Error>
-    | FetchResponse<401, types.Error>
-    | FetchResponse<404, types.Error>
-    | FetchResponse<422, types.Error>
-    | FetchResponse<500, types.Error>
-    | FetchResponse<504, types.Error>
-  >;
-  /**
-   * Updates a Reactor rule
-   *
-   */
+  ): Promise<FetchResponse<200, types.RuleResponse>>;
   patchAppsApp_idRulesRule_id(
     metadata: types.PatchAppsAppIdRulesRuleIdMetadataParam
-  ): Promise<
-    | FetchResponse<200, types.RuleResponse>
-    | FetchResponse<400, types.Error>
-    | FetchResponse<401, types.Error>
-    | FetchResponse<404, types.Error>
-    | FetchResponse<422, types.Error>
-    | FetchResponse<500, types.Error>
-    | FetchResponse<504, types.Error>
-  >;
-  /**
-   * Updates a Reactor rule
-   *
-   */
+  ): Promise<FetchResponse<200, types.RuleResponse>>;
   patchAppsApp_idRulesRule_id(
     body?: types.RulePatch | types.PatchAppsAppIdRulesRuleIdMetadataParam,
     metadata?: types.PatchAppsAppIdRulesRuleIdMetadataParam
-  ): Promise<
-    | FetchResponse<200, types.RuleResponse>
-    | FetchResponse<400, types.Error>
-    | FetchResponse<401, types.Error>
-    | FetchResponse<404, types.Error>
-    | FetchResponse<422, types.Error>
-    | FetchResponse<500, types.Error>
-    | FetchResponse<504, types.Error>
-  > {
+  ): Promise<FetchResponse<200, types.RuleResponse>> {
     return this.core.fetch('/apps/{app_id}/rules/{rule_id}', 'patch', body, metadata);
   }
 
@@ -535,15 +399,12 @@ class SDK {
    * Deletes the application with the specified application ID.
    *
    * @summary Deletes an app
+   * @throws FetchError<401, types.Error> Authentication failed
+   * @throws FetchError<404, types.Error> App not found
+   * @throws FetchError<422, types.Error> Invalid request
+   * @throws FetchError<500, types.Error> Internal server error
    */
-  deleteAppsId(
-    metadata: types.DeleteAppsIdMetadataParam
-  ): Promise<
-    | FetchResponse<401, types.Error>
-    | FetchResponse<404, types.Error>
-    | FetchResponse<422, types.Error>
-    | FetchResponse<500, types.Error>
-  > {
+  deleteAppsId(metadata: types.DeleteAppsIdMetadataParam): Promise<FetchResponse<number, unknown>> {
     return this.core.fetch('/apps/{id}', 'delete', metadata);
   }
 
@@ -551,46 +412,22 @@ class SDK {
    * Updates the application with the specified application ID.
    *
    * @summary Updates an app
+   * @throws FetchError<400, types.Error> Bad request
+   * @throws FetchError<401, types.Error> Authentication failed
+   * @throws FetchError<404, types.Error> App not found
+   * @throws FetchError<500, types.Error> Internal server error
    */
   patchAppsId(
     body: types.AppPatch,
     metadata: types.PatchAppsIdMetadataParam
-  ): Promise<
-    | FetchResponse<200, types.AppResponse>
-    | FetchResponse<400, types.Error>
-    | FetchResponse<401, types.Error>
-    | FetchResponse<404, types.Error>
-    | FetchResponse<500, types.Error>
-  >;
-  /**
-   * Updates the application with the specified application ID.
-   *
-   * @summary Updates an app
-   */
+  ): Promise<FetchResponse<200, types.AppResponse>>;
   patchAppsId(
     metadata: types.PatchAppsIdMetadataParam
-  ): Promise<
-    | FetchResponse<200, types.AppResponse>
-    | FetchResponse<400, types.Error>
-    | FetchResponse<401, types.Error>
-    | FetchResponse<404, types.Error>
-    | FetchResponse<500, types.Error>
-  >;
-  /**
-   * Updates the application with the specified application ID.
-   *
-   * @summary Updates an app
-   */
+  ): Promise<FetchResponse<200, types.AppResponse>>;
   patchAppsId(
     body?: types.AppPatch | types.PatchAppsIdMetadataParam,
     metadata?: types.PatchAppsIdMetadataParam
-  ): Promise<
-    | FetchResponse<200, types.AppResponse>
-    | FetchResponse<400, types.Error>
-    | FetchResponse<401, types.Error>
-    | FetchResponse<404, types.Error>
-    | FetchResponse<500, types.Error>
-  > {
+  ): Promise<FetchResponse<200, types.AppResponse>> {
     return this.core.fetch('/apps/{id}', 'patch', body, metadata);
   }
 
@@ -598,27 +435,25 @@ class SDK {
    * Updates the application's Apple Push Notification service (APNs) information.
    *
    * @summary Updates app's APNs info from a `.p12` file
+   * @throws FetchError<400, types.Error> Bad request
+   * @throws FetchError<401, types.Error> Authentication failed
+   * @throws FetchError<404, types.Error> App not found
+   * @throws FetchError<500, types.Error> Internal server error
    */
   postAppsIdPkcs12(
     body: types.AppPkcs12,
     metadata: types.PostAppsIdPkcs12MetadataParam
-  ): Promise<
-    | FetchResponse<200, types.AppResponse>
-    | FetchResponse<400, types.Error>
-    | FetchResponse<401, types.Error>
-    | FetchResponse<404, types.Error>
-    | FetchResponse<500, types.Error>
-  > {
+  ): Promise<FetchResponse<200, types.AppResponse>> {
     return this.core.fetch('/apps/{id}/pkcs12', 'post', body, metadata);
   }
 
   /**
    * Get token details
    *
+   * @throws FetchError<401, types.Error> Authentication failed
+   * @throws FetchError<500, types.Error> Internal server error
    */
-  getMe(): Promise<
-    FetchResponse<200, types.Me> | FetchResponse<401, types.Error> | FetchResponse<500, types.Error>
-  > {
+  getMe(): Promise<FetchResponse<200, types.Me>> {
     return this.core.fetch('/me', 'get');
   }
 }

--- a/packages/api/test/__fixtures__/sdk/optional-payload/index.ts
+++ b/packages/api/test/__fixtures__/sdk/optional-payload/index.ts
@@ -81,17 +81,9 @@ class SDK {
     body: types.UpdatePetWithFormFormDataParam,
     metadata: types.UpdatePetWithFormMetadataParam
   ): Promise<FetchResponse<number, unknown>>;
-  /**
-   * Updates a pet in the store with form data
-   *
-   */
   updatePetWithForm(
     metadata: types.UpdatePetWithFormMetadataParam
   ): Promise<FetchResponse<number, unknown>>;
-  /**
-   * Updates a pet in the store with form data
-   *
-   */
   updatePetWithForm(
     body?: types.UpdatePetWithFormFormDataParam | types.UpdatePetWithFormMetadataParam,
     metadata?: types.UpdatePetWithFormMetadataParam

--- a/packages/api/test/__fixtures__/sdk/petstore/index.ts
+++ b/packages/api/test/__fixtures__/sdk/petstore/index.ts
@@ -129,17 +129,9 @@ class SDK {
     body: types.UpdatePetWithFormFormDataParam,
     metadata: types.UpdatePetWithFormMetadataParam
   ): Promise<FetchResponse<number, unknown>>;
-  /**
-   * Updates a pet in the store with form data
-   *
-   */
   updatePetWithForm(
     metadata: types.UpdatePetWithFormMetadataParam
   ): Promise<FetchResponse<number, unknown>>;
-  /**
-   * Updates a pet in the store with form data
-   *
-   */
   updatePetWithForm(
     body?: types.UpdatePetWithFormFormDataParam | types.UpdatePetWithFormMetadataParam,
     metadata?: types.UpdatePetWithFormMetadataParam
@@ -163,17 +155,9 @@ class SDK {
     body: types.UploadFileBodyParam,
     metadata: types.UploadFileMetadataParam
   ): Promise<FetchResponse<200, types.ApiResponse>>;
-  /**
-   * Uploads an image
-   *
-   */
   uploadFile(
     metadata: types.UploadFileMetadataParam
   ): Promise<FetchResponse<200, types.ApiResponse>>;
-  /**
-   * Uploads an image
-   *
-   */
   uploadFile(
     body?: types.UploadFileBodyParam | types.UploadFileMetadataParam,
     metadata?: types.UploadFileMetadataParam

--- a/packages/api/test/__fixtures__/sdk/readme/index.ts
+++ b/packages/api/test/__fixtures__/sdk/readme/index.ts
@@ -77,13 +77,11 @@ class SDK {
    * Get an API definition file that's been uploaded to ReadMe.
    *
    * @summary Retrieve an entry from the API Registry
+   * @throws FetchError<404, types.ErrorRegistryNotfound> The registry entry couldn't be found.
    */
   getAPIRegistry(
     metadata: types.GetApiRegistryMetadataParam
-  ): Promise<
-    | FetchResponse<200, types.GetApiRegistryResponse200>
-    | FetchResponse<404, types.ErrorRegistryNotfound>
-  > {
+  ): Promise<FetchResponse<200, types.GetApiRegistryResponse200>> {
     return this.core.fetch('/api-registry/{uuid}', 'get', metadata);
   }
 
@@ -91,16 +89,14 @@ class SDK {
    * Get API specification metadata.
    *
    * @summary Get metadata
+   * @throws FetchError<400, types.ErrorVersionEmpty> No version was supplied.
+   * @throws FetchError<401, types.GetApiSpecificationResponse401> Unauthorized
+   * @throws FetchError<403, types.GetApiSpecificationResponse403> Unauthorized
+   * @throws FetchError<404, types.ErrorVersionNotfound> The version couldn't be found.
    */
   getAPISpecification(
     metadata?: types.GetApiSpecificationMetadataParam
-  ): Promise<
-    | FetchResponse<200, types.GetApiSpecificationResponse200>
-    | FetchResponse<400, types.ErrorVersionEmpty>
-    | FetchResponse<401, types.GetApiSpecificationResponse401>
-    | FetchResponse<403, types.GetApiSpecificationResponse403>
-    | FetchResponse<404, types.ErrorVersionNotfound>
-  > {
+  ): Promise<FetchResponse<200, types.GetApiSpecificationResponse200>> {
     return this.core.fetch('/api-specification', 'get', metadata);
   }
 
@@ -109,16 +105,15 @@ class SDK {
    * https://docs.readme.com/docs/automatically-sync-api-specification-with-github.
    *
    * @summary Upload specification
+   * @throws FetchError<400, types.UploadApiSpecificationResponse400> There was a validation error during upload.
+   * @throws FetchError<401, types.UploadApiSpecificationResponse401> Unauthorized
+   * @throws FetchError<403, types.UploadApiSpecificationResponse403> Unauthorized
+   * @throws FetchError<408, types.ErrorSpecTimeout> The spec upload timed out.
    */
   uploadAPISpecification(
     body: types.UploadApiSpecificationBodyParam,
     metadata?: types.UploadApiSpecificationMetadataParam
-  ): Promise<
-    | FetchResponse<400, types.UploadApiSpecificationResponse400>
-    | FetchResponse<401, types.UploadApiSpecificationResponse401>
-    | FetchResponse<403, types.UploadApiSpecificationResponse403>
-    | FetchResponse<408, types.ErrorSpecTimeout>
-  > {
+  ): Promise<FetchResponse<number, unknown>> {
     return this.core.fetch('/api-specification', 'post', body, metadata);
   }
 
@@ -126,16 +121,15 @@ class SDK {
    * Update an API specification in ReadMe.
    *
    * @summary Update specification
+   * @throws FetchError<400, types.UpdateApiSpecificationResponse400> There was a validation error during upload.
+   * @throws FetchError<401, types.UpdateApiSpecificationResponse401> Unauthorized
+   * @throws FetchError<403, types.UpdateApiSpecificationResponse403> Unauthorized
+   * @throws FetchError<408, types.ErrorSpecTimeout> The spec upload timed out.
    */
   updateAPISpecification(
     body: types.UpdateApiSpecificationBodyParam,
     metadata: types.UpdateApiSpecificationMetadataParam
-  ): Promise<
-    | FetchResponse<400, types.UpdateApiSpecificationResponse400>
-    | FetchResponse<401, types.UpdateApiSpecificationResponse401>
-    | FetchResponse<403, types.UpdateApiSpecificationResponse403>
-    | FetchResponse<408, types.ErrorSpecTimeout>
-  > {
+  ): Promise<FetchResponse<number, unknown>> {
     return this.core.fetch('/api-specification/{id}', 'put', body, metadata);
   }
 
@@ -143,15 +137,14 @@ class SDK {
    * Delete an API specification in ReadMe.
    *
    * @summary Delete specification
+   * @throws FetchError<400, types.ErrorSpecIdInvalid> The spec ID isn't valid.
+   * @throws FetchError<401, types.DeleteApiSpecificationResponse401> Unauthorized
+   * @throws FetchError<403, types.DeleteApiSpecificationResponse403> Unauthorized
+   * @throws FetchError<404, types.ErrorSpecNotfound> The spec couldn't be found.
    */
   deleteAPISpecification(
     metadata: types.DeleteApiSpecificationMetadataParam
-  ): Promise<
-    | FetchResponse<400, types.ErrorSpecIdInvalid>
-    | FetchResponse<401, types.DeleteApiSpecificationResponse401>
-    | FetchResponse<403, types.DeleteApiSpecificationResponse403>
-    | FetchResponse<404, types.ErrorSpecNotfound>
-  > {
+  ): Promise<FetchResponse<number, unknown>> {
     return this.core.fetch('/api-specification/{id}', 'delete', metadata);
   }
 
@@ -189,11 +182,12 @@ class SDK {
    * Create a new category inside of this project.
    *
    * @summary Create category
+   * @throws FetchError<400, types.ErrorCategoryInvalid> The category couldn't be saved.
    */
   createCategory(
     body: types.Category,
     metadata?: types.CreateCategoryMetadataParam
-  ): Promise<FetchResponse<400, types.ErrorCategoryInvalid>> {
+  ): Promise<FetchResponse<number, unknown>> {
     return this.core.fetch('/categories', 'post', body, metadata);
   }
 
@@ -201,10 +195,9 @@ class SDK {
    * Returns the category with this slug.
    *
    * @summary Get category
+   * @throws FetchError<404, types.ErrorCategoryNotfound> The category couldn't be found.
    */
-  getCategory(
-    metadata: types.GetCategoryMetadataParam
-  ): Promise<FetchResponse<404, types.ErrorCategoryNotfound>> {
+  getCategory(metadata: types.GetCategoryMetadataParam): Promise<FetchResponse<number, unknown>> {
     return this.core.fetch('/categories/{slug}', 'get', metadata);
   }
 
@@ -212,13 +205,13 @@ class SDK {
    * Change the properties of a category.
    *
    * @summary Update category
+   * @throws FetchError<400, types.ErrorCategoryInvalid> The category couldn't be saved.
+   * @throws FetchError<404, types.ErrorCategoryNotfound> The category couldn't be found.
    */
   updateCategory(
     body: types.Category,
     metadata: types.UpdateCategoryMetadataParam
-  ): Promise<
-    FetchResponse<400, types.ErrorCategoryInvalid> | FetchResponse<404, types.ErrorCategoryNotfound>
-  > {
+  ): Promise<FetchResponse<number, unknown>> {
     return this.core.fetch('/categories/{slug}', 'put', body, metadata);
   }
 
@@ -228,10 +221,11 @@ class SDK {
    * > This will also delete all of the docs within this category.
    *
    * @summary Delete category
+   * @throws FetchError<404, types.ErrorCategoryNotfound> The category couldn't be found.
    */
   deleteCategory(
     metadata: types.DeleteCategoryMetadataParam
-  ): Promise<FetchResponse<404, types.ErrorCategoryNotfound>> {
+  ): Promise<FetchResponse<number, unknown>> {
     return this.core.fetch('/categories/{slug}', 'delete', metadata);
   }
 
@@ -239,10 +233,11 @@ class SDK {
    * Returns the docs and children docs within this category.
    *
    * @summary Get docs for category
+   * @throws FetchError<404, types.ErrorCategoryNotfound> The category couldn't be found.
    */
   getCategoryDocs(
     metadata: types.GetCategoryDocsMetadataParam
-  ): Promise<FetchResponse<404, types.ErrorCategoryNotfound>> {
+  ): Promise<FetchResponse<number, unknown>> {
     return this.core.fetch('/categories/{slug}/docs', 'get', metadata);
   }
 
@@ -302,14 +297,12 @@ class SDK {
    * Returns a list of custom pages.
    *
    * @summary Get custom pages
+   * @throws FetchError<401, types.GetCustomPagesResponse401> Unauthorized
+   * @throws FetchError<403, types.GetCustomPagesResponse403> Unauthorized
    */
   getCustomPages(
     metadata?: types.GetCustomPagesMetadataParam
-  ): Promise<
-    | FetchResponse<200, types.GetCustomPagesResponse200>
-    | FetchResponse<401, types.GetCustomPagesResponse401>
-    | FetchResponse<403, types.GetCustomPagesResponse403>
-  > {
+  ): Promise<FetchResponse<200, types.GetCustomPagesResponse200>> {
     return this.core.fetch('/custompages', 'get', metadata);
   }
 
@@ -317,14 +310,11 @@ class SDK {
    * Create a new custom page inside of this project.
    *
    * @summary Create custom page
+   * @throws FetchError<400, types.ErrorCustompageInvalid> The page couldn't be saved.
+   * @throws FetchError<401, types.CreateCustomPageResponse401> Unauthorized
+   * @throws FetchError<403, types.CreateCustomPageResponse403> Unauthorized
    */
-  createCustomPage(
-    body: types.CustomPage
-  ): Promise<
-    | FetchResponse<400, types.ErrorCustompageInvalid>
-    | FetchResponse<401, types.CreateCustomPageResponse401>
-    | FetchResponse<403, types.CreateCustomPageResponse403>
-  > {
+  createCustomPage(body: types.CustomPage): Promise<FetchResponse<number, unknown>> {
     return this.core.fetch('/custompages', 'post', body);
   }
 
@@ -332,14 +322,13 @@ class SDK {
    * Returns the custom page with this slug.
    *
    * @summary Get custom page
+   * @throws FetchError<401, types.GetCustomPageResponse401> Unauthorized
+   * @throws FetchError<403, types.GetCustomPageResponse403> Unauthorized
+   * @throws FetchError<404, types.ErrorCustompageNotfound> The custom page couldn't be found.
    */
   getCustomPage(
     metadata: types.GetCustomPageMetadataParam
-  ): Promise<
-    | FetchResponse<401, types.GetCustomPageResponse401>
-    | FetchResponse<403, types.GetCustomPageResponse403>
-    | FetchResponse<404, types.ErrorCustompageNotfound>
-  > {
+  ): Promise<FetchResponse<number, unknown>> {
     return this.core.fetch('/custompages/{slug}', 'get', metadata);
   }
 
@@ -347,16 +336,15 @@ class SDK {
    * Update a custom page with this slug.
    *
    * @summary Update custom page
+   * @throws FetchError<400, types.ErrorCustompageInvalid> The page couldn't be saved.
+   * @throws FetchError<401, types.UpdateCustomPageResponse401> Unauthorized
+   * @throws FetchError<403, types.UpdateCustomPageResponse403> Unauthorized
+   * @throws FetchError<404, types.ErrorCustompageNotfound> The custom page couldn't be found.
    */
   updateCustomPage(
     body: types.CustomPage,
     metadata: types.UpdateCustomPageMetadataParam
-  ): Promise<
-    | FetchResponse<400, types.ErrorCustompageInvalid>
-    | FetchResponse<401, types.UpdateCustomPageResponse401>
-    | FetchResponse<403, types.UpdateCustomPageResponse403>
-    | FetchResponse<404, types.ErrorCustompageNotfound>
-  > {
+  ): Promise<FetchResponse<number, unknown>> {
     return this.core.fetch('/custompages/{slug}', 'put', body, metadata);
   }
 
@@ -364,14 +352,13 @@ class SDK {
    * Delete the custom page with this slug.
    *
    * @summary Delete custom page
+   * @throws FetchError<401, types.DeleteCustomPageResponse401> Unauthorized
+   * @throws FetchError<403, types.DeleteCustomPageResponse403> Unauthorized
+   * @throws FetchError<404, types.ErrorCustompageNotfound> The custom page couldn't be found.
    */
   deleteCustomPage(
     metadata: types.DeleteCustomPageMetadataParam
-  ): Promise<
-    | FetchResponse<401, types.DeleteCustomPageResponse401>
-    | FetchResponse<403, types.DeleteCustomPageResponse403>
-    | FetchResponse<404, types.ErrorCustompageNotfound>
-  > {
+  ): Promise<FetchResponse<number, unknown>> {
     return this.core.fetch('/custompages/{slug}', 'delete', metadata);
   }
 
@@ -379,14 +366,11 @@ class SDK {
    * Returns the doc with this slug.
    *
    * @summary Get doc
+   * @throws FetchError<401, types.GetDocResponse401> Unauthorized
+   * @throws FetchError<403, types.GetDocResponse403> Unauthorized
+   * @throws FetchError<404, types.ErrorDocNotfound> The doc couldn't be found.
    */
-  getDoc(
-    metadata: types.GetDocMetadataParam
-  ): Promise<
-    | FetchResponse<401, types.GetDocResponse401>
-    | FetchResponse<403, types.GetDocResponse403>
-    | FetchResponse<404, types.ErrorDocNotfound>
-  > {
+  getDoc(metadata: types.GetDocMetadataParam): Promise<FetchResponse<number, unknown>> {
     return this.core.fetch('/docs/{slug}', 'get', metadata);
   }
 
@@ -394,16 +378,15 @@ class SDK {
    * Update a doc with this slug.
    *
    * @summary Update doc
+   * @throws FetchError<400, types.ErrorDocInvalid> The doc couldn't be saved.
+   * @throws FetchError<401, types.UpdateDocResponse401> Unauthorized
+   * @throws FetchError<403, types.UpdateDocResponse403> Unauthorized
+   * @throws FetchError<404, types.ErrorDocNotfound> The doc couldn't be found.
    */
   updateDoc(
     body: types.Doc,
     metadata: types.UpdateDocMetadataParam
-  ): Promise<
-    | FetchResponse<400, types.ErrorDocInvalid>
-    | FetchResponse<401, types.UpdateDocResponse401>
-    | FetchResponse<403, types.UpdateDocResponse403>
-    | FetchResponse<404, types.ErrorDocNotfound>
-  > {
+  ): Promise<FetchResponse<number, unknown>> {
     return this.core.fetch('/docs/{slug}', 'put', body, metadata);
   }
 
@@ -411,14 +394,11 @@ class SDK {
    * Delete the doc with this slug.
    *
    * @summary Delete doc
+   * @throws FetchError<401, types.DeleteDocResponse401> Unauthorized
+   * @throws FetchError<403, types.DeleteDocResponse403> Unauthorized
+   * @throws FetchError<404, types.ErrorDocNotfound> The doc couldn't be found.
    */
-  deleteDoc(
-    metadata: types.DeleteDocMetadataParam
-  ): Promise<
-    | FetchResponse<401, types.DeleteDocResponse401>
-    | FetchResponse<403, types.DeleteDocResponse403>
-    | FetchResponse<404, types.ErrorDocNotfound>
-  > {
+  deleteDoc(metadata: types.DeleteDocMetadataParam): Promise<FetchResponse<number, unknown>> {
     return this.core.fetch('/docs/{slug}', 'delete', metadata);
   }
 
@@ -428,14 +408,13 @@ class SDK {
    * return staging.
    *
    * @summary Get production doc
+   * @throws FetchError<401, types.GetProductionDocResponse401> Unauthorized
+   * @throws FetchError<403, types.GetProductionDocResponse403> Unauthorized
+   * @throws FetchError<404, types.ErrorDocNotfound> The doc couldn't be found.
    */
   getProductionDoc(
     metadata: types.GetProductionDocMetadataParam
-  ): Promise<
-    | FetchResponse<401, types.GetProductionDocResponse401>
-    | FetchResponse<403, types.GetProductionDocResponse403>
-    | FetchResponse<404, types.ErrorDocNotfound>
-  > {
+  ): Promise<FetchResponse<number, unknown>> {
     return this.core.fetch('/docs/{slug}/production', 'get', metadata);
   }
 
@@ -443,15 +422,14 @@ class SDK {
    * Create a new doc inside of this project.
    *
    * @summary Create doc
+   * @throws FetchError<400, types.ErrorDocInvalid> The doc couldn't be saved.
+   * @throws FetchError<401, types.CreateDocResponse401> Unauthorized
+   * @throws FetchError<403, types.CreateDocResponse403> Unauthorized
    */
   createDoc(
     body: types.Doc,
     metadata?: types.CreateDocMetadataParam
-  ): Promise<
-    | FetchResponse<400, types.ErrorDocInvalid>
-    | FetchResponse<401, types.CreateDocResponse401>
-    | FetchResponse<403, types.CreateDocResponse403>
-  > {
+  ): Promise<FetchResponse<number, unknown>> {
     return this.core.fetch('/docs', 'post', body, metadata);
   }
 
@@ -459,13 +437,10 @@ class SDK {
    * Returns all docs that match the search.
    *
    * @summary Search docs
+   * @throws FetchError<401, types.SearchDocsResponse401> Unauthorized
+   * @throws FetchError<403, types.SearchDocsResponse403> Unauthorized
    */
-  searchDocs(
-    metadata: types.SearchDocsMetadataParam
-  ): Promise<
-    | FetchResponse<401, types.SearchDocsResponse401>
-    | FetchResponse<403, types.SearchDocsResponse403>
-  > {
+  searchDocs(metadata: types.SearchDocsMetadataParam): Promise<FetchResponse<number, unknown>> {
     return this.core.fetch('/docs/search', 'post', metadata);
   }
 
@@ -473,10 +448,10 @@ class SDK {
    * Returns with all of the error page types for this project.
    *
    * @summary Get errors
+   * @throws FetchError<401, types.GetErrorsResponse401> Unauthorized
+   * @throws FetchError<403, types.GetErrorsResponse403> Unauthorized
    */
-  getErrors(): Promise<
-    FetchResponse<401, types.GetErrorsResponse401> | FetchResponse<403, types.GetErrorsResponse403>
-  > {
+  getErrors(): Promise<FetchResponse<number, unknown>> {
     return this.core.fetch('/errors', 'get');
   }
 
@@ -484,12 +459,10 @@ class SDK {
    * Returns project data for the API key.
    *
    * @summary Get metadata about the current project
+   * @throws FetchError<401, types.GetProjectResponse401> Unauthorized
+   * @throws FetchError<403, types.GetProjectResponse403> Unauthorized
    */
-  getProject(): Promise<
-    | FetchResponse<200, types.CondensedProjectData>
-    | FetchResponse<401, types.GetProjectResponse401>
-    | FetchResponse<403, types.GetProjectResponse403>
-  > {
+  getProject(): Promise<FetchResponse<200, types.CondensedProjectData>> {
     return this.core.fetch('/', 'get');
   }
 
@@ -497,11 +470,10 @@ class SDK {
    * Retrieve a list of versions associated with a project API key.
    *
    * @summary Get versions
+   * @throws FetchError<401, types.GetVersionsResponse401> Unauthorized
+   * @throws FetchError<403, types.GetVersionsResponse403> Unauthorized
    */
-  getVersions(): Promise<
-    | FetchResponse<401, types.GetVersionsResponse401>
-    | FetchResponse<403, types.GetVersionsResponse403>
-  > {
+  getVersions(): Promise<FetchResponse<number, unknown>> {
     return this.core.fetch('/version', 'get');
   }
 
@@ -509,15 +481,12 @@ class SDK {
    * Create a new version.
    *
    * @summary Create version
+   * @throws FetchError<400, types.CreateVersionResponse400> There was a validation error during creation.
+   * @throws FetchError<401, types.CreateVersionResponse401> Unauthorized
+   * @throws FetchError<403, types.CreateVersionResponse403> Unauthorized
+   * @throws FetchError<404, types.ErrorVersionForkNotfound> The version couldn't be found.
    */
-  createVersion(
-    body: types.Version
-  ): Promise<
-    | FetchResponse<400, types.CreateVersionResponse400>
-    | FetchResponse<401, types.CreateVersionResponse401>
-    | FetchResponse<403, types.CreateVersionResponse403>
-    | FetchResponse<404, types.ErrorVersionForkNotfound>
-  > {
+  createVersion(body: types.Version): Promise<FetchResponse<number, unknown>> {
     return this.core.fetch('/version', 'post', body);
   }
 
@@ -525,14 +494,11 @@ class SDK {
    * Returns the version with this version ID.
    *
    * @summary Get version
+   * @throws FetchError<401, types.GetVersionResponse401> Unauthorized
+   * @throws FetchError<403, types.GetVersionResponse403> Unauthorized
+   * @throws FetchError<404, types.ErrorVersionNotfound> The version couldn't be found.
    */
-  getVersion(
-    metadata: types.GetVersionMetadataParam
-  ): Promise<
-    | FetchResponse<401, types.GetVersionResponse401>
-    | FetchResponse<403, types.GetVersionResponse403>
-    | FetchResponse<404, types.ErrorVersionNotfound>
-  > {
+  getVersion(metadata: types.GetVersionMetadataParam): Promise<FetchResponse<number, unknown>> {
     return this.core.fetch('/version/{versionId}', 'get', metadata);
   }
 
@@ -540,16 +506,15 @@ class SDK {
    * Update an existing version.
    *
    * @summary Update version
+   * @throws FetchError<400, types.ErrorVersionCantDemoteStable> A stable version can't be demoted.
+   * @throws FetchError<401, types.UpdateVersionResponse401> Unauthorized
+   * @throws FetchError<403, types.UpdateVersionResponse403> Unauthorized
+   * @throws FetchError<404, types.ErrorVersionNotfound> The version couldn't be found.
    */
   updateVersion(
     body: types.Version,
     metadata: types.UpdateVersionMetadataParam
-  ): Promise<
-    | FetchResponse<400, types.ErrorVersionCantDemoteStable>
-    | FetchResponse<401, types.UpdateVersionResponse401>
-    | FetchResponse<403, types.UpdateVersionResponse403>
-    | FetchResponse<404, types.ErrorVersionNotfound>
-  > {
+  ): Promise<FetchResponse<number, unknown>> {
     return this.core.fetch('/version/{versionId}', 'put', body, metadata);
   }
 
@@ -557,15 +522,14 @@ class SDK {
    * Delete a version
    *
    * @summary Delete version
+   * @throws FetchError<400, types.ErrorVersionCantRemoveStable> A stable version can't be removed.
+   * @throws FetchError<401, types.DeleteVersionResponse401> Unauthorized
+   * @throws FetchError<403, types.DeleteVersionResponse403> Unauthorized
+   * @throws FetchError<404, types.ErrorVersionNotfound> The version couldn't be found.
    */
   deleteVersion(
     metadata: types.DeleteVersionMetadataParam
-  ): Promise<
-    | FetchResponse<400, types.ErrorVersionCantRemoveStable>
-    | FetchResponse<401, types.DeleteVersionResponse401>
-    | FetchResponse<403, types.DeleteVersionResponse403>
-    | FetchResponse<404, types.ErrorVersionNotfound>
-  > {
+  ): Promise<FetchResponse<number, unknown>> {
     return this.core.fetch('/version/{versionId}', 'delete', metadata);
   }
 }


### PR DESCRIPTION
| 🚥 Fixes #612 |
| :---------------- |

## 🧰 Changes

This fixes a problem in codegen where we're documenting 400 and 500 status code families as being possible return types for SDK methods  which is not accurate as when we encounter these status codes we throw a `FetchError`. This is causing codegen's responses for these methods to effectively be typed as `unknown` as noted here[^1].

Unfortunately for us TypeScript doesn't offer any way to document that a method may throw an exception, and what that exception contains, so we need to fallback to a JSDoc `@throws` annotation. Not great but other than completely removing those error response types from the compiled SDK, which I don't want to do, we don't have any other option.

I have also cleaned up another very minor thing in this work with regard to typed method overloads that we're creating for methods that have an optional `body` or `metadata`. In these cases Because the first argument of the method can be either `body` or `metadata` we're creating a typed TS overload[^2] for each alternative. We were adding a docblock to each of these overloads but in actuality IDE Intellisense only ever picks up the docblock from the first method so adding the same docblock not only increases the size of the SDK we're generating but also fills the SDK with documentation that just isn't being used.

## 🧬 QA & Testing

The status code work is pretty well tested here with the SDK fixture snapshots we've got but for the docblock work you can see how the docblock from the first overload of this method is being picked up by Intellisense:

![Screen Shot 2023-07-14 at 10 38 59 AM](https://github.com/readmeio/api/assets/33762/2c4676fb-cfe1-47e8-b9ec-dba65a562190)

For comparison, if we add that docblock to the last method it doesn't get picked up:

![Screen Shot 2023-07-14 at 10 50 16 AM](https://github.com/readmeio/api/assets/33762/2e11a1cc-256a-4fc7-91ba-6e3e07ba7c80)


[^1]: https://github.com/readmeio/api/issues/612#issuecomment-1633949991
[^2]: https://www.typescriptlang.org/docs/handbook/2/functions.html#function-overloads