### PR TITLE
feat: migrate `api` and `core` to ESM

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "devDependencies": {
         "@commitlint/cli": "^17.6.6",
         "@commitlint/config-conventional": "^17.7.0",
-        "@readme/eslint-config": "^12.2.1",
+        "@readme/eslint-config": "^13.0.1",
+        "@tsconfig/node18": "^18.2.2",
         "alex": "^11.0.1",
         "conventional-changelog-cli": "^4.1.0",
         "eslint": "^8.48.0",
@@ -3295,9 +3296,9 @@
       }
     },
     "node_modules/@readme/eslint-config": {
-      "version": "12.2.1",
-      "resolved": "https://registry.npmjs.org/@readme/eslint-config/-/eslint-config-12.2.1.tgz",
-      "integrity": "sha512-tkYhhH8BTkdH4CFuMSWSby+Z4+XscROyC6/rGHSV1Y3dmJuj35FjhwTCR/nsiOLDVDBkKuJY3v0G5oCSxfgtkQ==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@readme/eslint-config/-/eslint-config-13.0.1.tgz",
+      "integrity": "sha512-sfcW8R1ed2xX/2Cedfrd/YeLsvwflSGWXS/e+IoJbCjIphuFybj5isW60UJyfQAlT3Rv/DU5CtNUBc6ZsxG05g==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^6.2.1",
@@ -3315,6 +3316,7 @@
         "eslint-plugin-prettier": "^5.0.0",
         "eslint-plugin-react": "^7.33.1",
         "eslint-plugin-react-hooks": "^4.6.0",
+        "eslint-plugin-require-extensions": "^0.1.3",
         "eslint-plugin-testing-library": "^6.0.1",
         "eslint-plugin-typescript-sort-keys": "^3.0.0",
         "eslint-plugin-unicorn": "^48.0.1",
@@ -3323,7 +3325,7 @@
         "lodash.merge": "^4.6.2"
       },
       "engines": {
-        "node": ">=14.18"
+        "node": ">=18"
       },
       "peerDependencies": {
         "eslint": "^8.0.0",
@@ -3369,17 +3371,6 @@
       "integrity": "sha512-qFBl1HJVHOW9x+9k6Egi9zr0wHXitqsZnSjAiBExDFIH6aS9vLEkKehDdVnntcjnYi6HzmIG5Z/iDZb7q56P8g==",
       "dev": true
     },
-    "node_modules/@readme/oas-extensions": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/@readme/oas-extensions/-/oas-extensions-17.0.1.tgz",
-      "integrity": "sha512-PCU7WLz8TkbdxsiE4eQGvJYDYZQPiyLhXme3SvLboSmH+8G6AJPJ5OymzSAdlf5sXpSSoD2q3dTIou3Cb2DirQ==",
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "oas": "^20.0.0"
-      }
-    },
     "node_modules/@readme/oas-to-har": {
       "version": "20.1.1",
       "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-20.1.1.tgz",
@@ -3393,6 +3384,45 @@
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@readme/oas-to-har/node_modules/@readme/oas-extensions": {
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/@readme/oas-extensions/-/oas-extensions-17.0.1.tgz",
+      "integrity": "sha512-PCU7WLz8TkbdxsiE4eQGvJYDYZQPiyLhXme3SvLboSmH+8G6AJPJ5OymzSAdlf5sXpSSoD2q3dTIou3Cb2DirQ==",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "oas": "^20.0.0"
+      }
+    },
+    "node_modules/@readme/oas-to-har/node_modules/oas": {
+      "version": "20.10.3",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-20.10.3.tgz",
+      "integrity": "sha512-dBxDuwn2ssggPMOqEKEzT4sjCqbkol8JozuWrpwD7chcmbKbverj5vpk2kmsczeyguFkLcKUOMcqUUimf9h+IQ==",
+      "dependencies": {
+        "@readme/json-schema-ref-parser": "^1.2.0",
+        "@types/json-schema": "^7.0.11",
+        "json-schema-merge-allof": "^0.8.1",
+        "jsonpath-plus": "^7.2.0",
+        "jsonpointer": "^5.0.0",
+        "memoizee": "^0.4.14",
+        "oas-normalize": "^8.4.0",
+        "openapi-types": "^12.1.1",
+        "path-to-regexp": "^6.2.0",
+        "remove-undefined-objects": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@readme/oas-to-har/node_modules/oas/node_modules/remove-undefined-objects": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/remove-undefined-objects/-/remove-undefined-objects-3.0.0.tgz",
+      "integrity": "sha512-nxG1yYfc/Jxi+bNCBiqKhxVJPE+QvziIOKbD+Dxc93Uisz92v/ZYpo4WR0TJuf+dk2xE8lW2WPJsA3mDFzXy8w==",
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/@readme/oas-to-har/node_modules/remove-undefined-objects": {
@@ -3690,6 +3720,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node18": {
+      "version": "18.2.2",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node18/-/node18-18.2.2.tgz",
+      "integrity": "sha512-d6McJeGsuoRlwWZmVIeE8CUA27lu6jLjvv1JzqmpsytOYYbVi1tHZEnwCNVOXnj4pyLvneZlFlpXUK+X9wBWyw==",
       "dev": true
     },
     "node_modules/@tufjs/canonical-json": {
@@ -4087,12 +4123,6 @@
       "dev": true,
       "optional": true,
       "peer": true
-    },
-    "node_modules/@types/stringify-object": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/stringify-object/-/stringify-object-4.0.2.tgz",
-      "integrity": "sha512-8ZJwc0CTd9oA09Ug+kmlM1KeIctDTCmLUq77VqKveIdyyCw/kowfKBiJaNq8e4F73UBquRE4xsnHGmRq7sVOBA==",
-      "dev": true
     },
     "node_modules/@types/supports-color": {
       "version": "8.1.1",
@@ -9297,6 +9327,18 @@
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-plugin-require-extensions": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-require-extensions/-/eslint-plugin-require-extensions-0.1.3.tgz",
+      "integrity": "sha512-T3c1PZ9PIdI3hjV8LdunfYI8gj017UQjzAnCrxuo3wAjneDbTPHdE3oNWInOjMA+z/aBkUtlW5vC0YepYMZIug==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "eslint": "*"
       }
     },
     "node_modules/eslint-plugin-testing-library": {
@@ -16850,9 +16892,9 @@
       }
     },
     "node_modules/oas": {
-      "version": "20.10.3",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-20.10.3.tgz",
-      "integrity": "sha512-dBxDuwn2ssggPMOqEKEzT4sjCqbkol8JozuWrpwD7chcmbKbverj5vpk2kmsczeyguFkLcKUOMcqUUimf9h+IQ==",
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-21.1.1.tgz",
+      "integrity": "sha512-d4qHiZIlySPPEsToEKg6P9sju6vq+MjycjrFC2lrrwWRble+c60qjpenoPY0bopqi7VStZ6AQpLa9hVDeBScyQ==",
       "dependencies": {
         "@readme/json-schema-ref-parser": "^1.2.0",
         "@types/json-schema": "^7.0.11",
@@ -16860,13 +16902,13 @@
         "jsonpath-plus": "^7.2.0",
         "jsonpointer": "^5.0.0",
         "memoizee": "^0.4.14",
-        "oas-normalize": "^8.4.0",
+        "oas-normalize": "^9.0.0",
         "openapi-types": "^12.1.1",
         "path-to-regexp": "^6.2.0",
-        "remove-undefined-objects": "^3.0.0"
+        "remove-undefined-objects": "^4.0.2"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/oas-kit-common": {
@@ -16948,6 +16990,60 @@
       },
       "funding": {
         "url": "https://github.com/Mermade/oas-kit?sponsor=1"
+      }
+    },
+    "node_modules/oas/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/oas/node_modules/oas-normalize": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-9.0.0.tgz",
+      "integrity": "sha512-6G4uRemkP3YAr73lzJve0F9sbUnn88G5uCkuMSyIMnB4ml6Y6eRL7zpaE/0Oj0IU7zgCw8dszB2HpYOd/kM9rQ==",
+      "dependencies": {
+        "@readme/openapi-parser": "^2.5.0",
+        "@readme/postman-to-openapi": "^4.1.0",
+        "js-yaml": "^4.1.0",
+        "node-fetch": "^2.7.0",
+        "openapi-types": "^12.1.3",
+        "swagger2openapi": "^7.0.8"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/oas/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/oas/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/oas/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/object-assign": {
@@ -18747,9 +18843,9 @@
       }
     },
     "node_modules/remove-undefined-objects": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/remove-undefined-objects/-/remove-undefined-objects-3.0.0.tgz",
-      "integrity": "sha512-nxG1yYfc/Jxi+bNCBiqKhxVJPE+QvziIOKbD+Dxc93Uisz92v/ZYpo4WR0TJuf+dk2xE8lW2WPJsA3mDFzXy8w==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/remove-undefined-objects/-/remove-undefined-objects-4.0.2.tgz",
+      "integrity": "sha512-6Nh52HADM60lhewwWU30ujMzTjYJk4M5q/LhRYLAacP0hTbzjVWiBVlV84U5RsQA4wDKLwkL0r0qJvti2hRLeQ==",
       "engines": {
         "node": ">=16"
       }
@@ -22111,7 +22207,7 @@
         "lodash.setwith": "^4.3.2",
         "lodash.startcase": "^4.4.0",
         "make-dir": "^3.1.0",
-        "oas": "^20.4.0",
+        "oas": "^21.1.1",
         "ora": "^5.4.1",
         "prompts": "^2.4.2",
         "semver": "^7.3.8",
@@ -22166,8 +22262,8 @@
         "get-stream": "^6.0.1",
         "json-schema-traverse": "^1.0.0",
         "lodash.merge": "^4.6.2",
-        "oas": "^20.10.3",
-        "remove-undefined-objects": "^3.0.0"
+        "oas": "^21.1.1",
+        "remove-undefined-objects": "^4.0.2"
       },
       "devDependencies": {
         "@api/test-utils": "file:../test-utils",
@@ -22199,7 +22295,7 @@
         "@readme/oas-examples": "^5.12.0",
         "@readme/openapi-parser": "^2.5.0",
         "@types/content-type": "^1.1.6",
-        "@types/stringify-object": "^4.0.2",
+        "@types/stringify-object": "^3.3.1",
         "@vitest/coverage-v8": "^0.34.4",
         "typescript": "^5.2.2",
         "vitest": "^0.34.1"
@@ -22209,8 +22305,14 @@
       },
       "peerDependencies": {
         "@readme/httpsnippet": ">=4",
-        "oas": "^20.0.0"
+        "oas": "^21.1.1"
       }
+    },
+    "packages/httpsnippet-client-api/node_modules/@types/stringify-object": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/stringify-object/-/stringify-object-3.3.1.tgz",
+      "integrity": "sha512-bpCBW0O+QrMLNFBY/+rkZtGzcYRmc2aTD8qYHOMNUmednqETfEZtFcGEA11l9xqbIeiT1PgXG0eq3zqayVzZSQ==",
+      "dev": true
     },
     "packages/test-utils": {
       "name": "@api/test-utils",
@@ -22223,7 +22325,7 @@
       },
       "devDependencies": {
         "@types/caseless": "^0.12.3",
-        "oas": "^20.10.3",
+        "oas": "^21.1.1",
         "typescript": "^5.2.2"
       }
     }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
   "devDependencies": {
     "@commitlint/cli": "^17.6.6",
     "@commitlint/config-conventional": "^17.7.0",
-    "@readme/eslint-config": "^12.2.1",
+    "@readme/eslint-config": "^13.0.1",
+    "@tsconfig/node18": "^18.2.2",
     "alex": "^11.0.1",
     "conventional-changelog-cli": "^4.1.0",
     "eslint": "^8.48.0",

--- a/packages/api/.eslintrc
+++ b/packages/api/.eslintrc
@@ -1,4 +1,5 @@
 {
+  "extends": ["@readme/eslint-config/esm"],
   "overrides": [
     {
       "files": ["bin/api"],

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -20,6 +20,7 @@
     "url": "https://github.com/readmeio/api.git",
     "directory": "packages/api"
   },
+  "type": "module",
   "homepage": "https://api.readme.dev",
   "bugs": {
     "url": "https://github.com/readmeio/api/issues"
@@ -48,7 +49,7 @@
     "lodash.setwith": "^4.3.2",
     "lodash.startcase": "^4.4.0",
     "make-dir": "^3.1.0",
-    "oas": "^20.4.0",
+    "oas": "^21.1.1",
     "ora": "^5.4.1",
     "prompts": "^2.4.2",
     "semver": "^7.3.8",

--- a/packages/api/src/bin.ts
+++ b/packages/api/src/bin.ts
@@ -1,7 +1,7 @@
 import { Command } from 'commander';
 
-import commands from './commands';
-import * as pkg from './packageInfo';
+import commands from './commands/index.js';
+import * as pkg from './packageInfo.js';
 
 (async () => {
   const program = new Command();

--- a/packages/api/src/codegen/index.ts
+++ b/packages/api/src/codegen/index.ts
@@ -1,7 +1,7 @@
-import type CodeGeneratorLanguage from './language';
+import type CodeGeneratorLanguage from './language.js';
 import type Oas from 'oas';
 
-import TSGenerator from './languages/typescript';
+import TSGenerator from './languages/typescript.js';
 
 export type SupportedLanguages = 'js' | 'js-cjs' | 'js-esm' | 'ts';
 

--- a/packages/api/src/codegen/language.ts
+++ b/packages/api/src/codegen/language.ts
@@ -1,7 +1,7 @@
-import type Storage from '../storage';
+import type Storage from '../storage.js';
 import type Oas from 'oas';
 
-import { PACKAGE_NAME, PACKAGE_VERSION } from '../packageInfo';
+import { PACKAGE_NAME, PACKAGE_VERSION } from '../packageInfo.js';
 
 export interface InstallerOptions {
   /**

--- a/packages/api/src/codegen/languages/typescript.ts
+++ b/packages/api/src/codegen/languages/typescript.ts
@@ -1,8 +1,8 @@
-import type Storage from '../../storage';
-import type { InstallerOptions } from '../language';
+import type Storage from '../../storage.js';
+import type { InstallerOptions } from '../language.js';
 import type Oas from 'oas';
 import type { Operation } from 'oas';
-import type { HttpMethods, SchemaObject } from 'oas/dist/rmoas.types';
+import type { HttpMethods, SchemaObject } from 'oas/rmoas.types';
 import type { SemVer } from 'semver';
 import type {
   ClassDeclaration,
@@ -21,10 +21,10 @@ import setWith from 'lodash.setwith';
 import semver from 'semver';
 import { IndentationText, Project, QuoteKind, ScriptTarget, VariableDeclarationKind } from 'ts-morph';
 
-import logger from '../../logger';
-import CodeGeneratorLanguage from '../language';
+import logger from '../../logger.js';
+import CodeGeneratorLanguage from '../language.js';
 
-import { docblockEscape, generateTypeName, wordWrap } from './typescript/util';
+import { docblockEscape, generateTypeName, wordWrap } from './typescript/util.js';
 
 export interface TSGeneratorOptions {
   compilerTarget?: 'cjs' | 'esm';

--- a/packages/api/src/commands/index.ts
+++ b/packages/api/src/commands/index.ts
@@ -1,4 +1,4 @@
-import installCommand from './install';
+import installCommand from './install.js';
 
 export default {
   install: installCommand,

--- a/packages/api/src/commands/install.ts
+++ b/packages/api/src/commands/install.ts
@@ -1,15 +1,15 @@
-import type { SupportedLanguages } from '../codegen';
+import type { SupportedLanguages } from '../codegen/index.js';
 
 import { Command, Option } from 'commander';
 import figures from 'figures';
 import Oas from 'oas';
 import ora from 'ora';
 
-import codegen from '../codegen';
-import Fetcher from '../fetcher';
-import promptTerminal from '../lib/prompt';
-import logger from '../logger';
-import Storage from '../storage';
+import codegen from '../codegen/index.js';
+import Fetcher from '../fetcher.js';
+import promptTerminal from '../lib/prompt.js';
+import logger from '../logger.js';
+import Storage from '../storage.js';
 
 // @todo log logs to `.api/.logs` and have `.logs` ignored
 const cmd = new Command();

--- a/packages/api/src/fetcher.ts
+++ b/packages/api/src/fetcher.ts
@@ -1,4 +1,4 @@
-import type { OASDocument } from 'oas/dist/rmoas.types';
+import type { OASDocument } from 'oas/rmoas.types';
 
 import fs from 'node:fs';
 import path from 'node:path';

--- a/packages/api/src/storage.ts
+++ b/packages/api/src/storage.ts
@@ -1,4 +1,4 @@
-import type { OASDocument } from 'oas/dist/rmoas.types';
+import type { OASDocument } from 'oas/rmoas.types';
 
 import fs from 'node:fs';
 import path from 'node:path';
@@ -7,8 +7,8 @@ import makeDir from 'make-dir';
 import ssri from 'ssri';
 import validateNPMPackageName from 'validate-npm-package-name';
 
-import Fetcher from './fetcher';
-import { PACKAGE_VERSION } from './packageInfo';
+import Fetcher from './fetcher.js';
+import { PACKAGE_VERSION } from './packageInfo.js';
 
 export default class Storage {
   static dir: string;

--- a/packages/api/test/codegen/languages/typescript.test.ts
+++ b/packages/api/test/codegen/languages/typescript.test.ts
@@ -1,4 +1,4 @@
-import type { TSGeneratorOptions } from '../../../src/codegen/languages/typescript';
+import type { TSGeneratorOptions } from '../../../src/codegen/languages/typescript.js';
 
 import fs from 'node:fs/promises';
 import path from 'node:path';
@@ -10,9 +10,9 @@ import Oas from 'oas';
 import uniqueTempDir from 'unique-temp-dir';
 import { describe, beforeEach, afterEach, it, expect, vi } from 'vitest';
 
-import TSGenerator from '../../../src/codegen/languages/typescript';
-import * as packageInfo from '../../../src/packageInfo';
-import Storage from '../../../src/storage';
+import TSGenerator from '../../../src/codegen/languages/typescript.js';
+import * as packageInfo from '../../../src/packageInfo.js';
+import Storage from '../../../src/storage.js';
 
 function assertSDKFixture(file: string, fixture: string, opts: TSGeneratorOptions = {}) {
   return async () => {
@@ -172,7 +172,7 @@ describe('typescript', () => {
       });
 
       it('should be able to make an API request (TS)', async () => {
-        const sdk = await import('../../__fixtures__/sdk/simple-ts').then(r => r.default);
+        const sdk = await import('../../__fixtures__/sdk/simple-ts/index.js').then(r => r.default);
         fetchMock.get('http://petstore.swagger.io/v2/pet/findByStatus?status=available', mockResponse.searchParams);
 
         await sdk.findPetsByStatus({ status: ['available'] }).then(({ data, status, headers, res }) => {
@@ -184,7 +184,7 @@ describe('typescript', () => {
       });
 
       it('should be able to make an API request with an `accept` header`', async () => {
-        const sdk = await import('../../__fixtures__/sdk/simple-ts').then(r => r.default);
+        const sdk = await import('../../__fixtures__/sdk/simple-ts/index.js').then(r => r.default);
         fetchMock.get('http://petstore.swagger.io/v2/pet/findByStatus?status=available', mockResponse.headers);
 
         await sdk
@@ -198,7 +198,7 @@ describe('typescript', () => {
       });
 
       it('should be able to make an API request (JS + CommonJS)', async () => {
-        const sdk = await import('../../__fixtures__/sdk/simple-js-cjs').then(r => r.default);
+        const sdk = await import('../../__fixtures__/sdk/simple-js-cjs/index.js').then(r => r.default);
         fetchMock.get('http://petstore.swagger.io/v2/pet/findByStatus?status=available', mockResponse.searchParams);
 
         await sdk.findPetsByStatus({ status: ['available'] }).then(({ data, status, headers, res }) => {
@@ -210,7 +210,7 @@ describe('typescript', () => {
       });
 
       it('should be able to make an API request (JS + ESM)', async () => {
-        const sdk = await import('../../__fixtures__/sdk/simple-js-esm').then(r => r.default);
+        const sdk = await import('../../__fixtures__/sdk/simple-js-esm/index.js').then(r => r.default);
         fetchMock.get('http://petstore.swagger.io/v2/pet/findByStatus?status=available', mockResponse.searchParams);
 
         await sdk.findPetsByStatus({ status: ['available'] }).then(({ data, status, headers, res }) => {

--- a/packages/api/test/codegen/languages/typescript/smoketest.test.ts
+++ b/packages/api/test/codegen/languages/typescript/smoketest.test.ts
@@ -20,7 +20,7 @@ import Oas from 'oas';
 import OASNormalize from 'oas-normalize';
 import { describe, it, expect } from 'vitest';
 
-import TSGenerator from '../../../../src/codegen/languages/typescript';
+import TSGenerator from '../../../../src/codegen/languages/typescript.js';
 
 // These APIs don't have any schemas so they should only be generating an `index.ts`.
 const APIS_WITHOUT_SCHEMAS = ['poemist.com'];

--- a/packages/api/test/codegen/languages/typescript/utils.test.ts
+++ b/packages/api/test/codegen/languages/typescript/utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
-import { docblockEscape, generateTypeName, wordWrap } from '../../../../src/codegen/languages/typescript/util';
+import { docblockEscape, generateTypeName, wordWrap } from '../../../../src/codegen/languages/typescript/util.js';
 
 describe('ts codegen utils', () => {
   describe('#docblockEscape', () => {

--- a/packages/api/test/fetcher.test.ts
+++ b/packages/api/test/fetcher.test.ts
@@ -5,7 +5,7 @@ import loadSpec from '@api/test-utils/load-spec';
 import fetchMock from 'fetch-mock';
 import { describe, beforeAll, it, expect } from 'vitest';
 
-import Fetcher from '../src/fetcher';
+import Fetcher from '../src/fetcher.js';
 
 let readmeSpec;
 

--- a/packages/api/test/storage.test.ts
+++ b/packages/api/test/storage.test.ts
@@ -1,4 +1,4 @@
-import type { OASDocument } from 'oas/dist/rmoas.types';
+import type { OASDocument } from 'oas/rmoas.types';
 
 import assert from 'node:assert';
 import fs from 'node:fs/promises';
@@ -9,8 +9,8 @@ import fetchMock from 'fetch-mock';
 import uniqueTempDir from 'unique-temp-dir';
 import { describe, beforeAll, beforeEach, afterEach, it, expect } from 'vitest';
 
-import { PACKAGE_VERSION } from '../src/packageInfo';
-import Storage from '../src/storage';
+import { PACKAGE_VERSION } from '../src/packageInfo.js';
+import Storage from '../src/storage.js';
 
 let petstoreSimple;
 

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -1,13 +1,9 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "allowJs": true,
-    "baseUrl": "./src",
-    "declaration": true,
     "esModuleInterop": true,
-    "lib": ["DOM", "DOM.Iterable", "ES2020"],
-    "noImplicitAny": true,
+    "lib": ["DOM", "DOM.Iterable", "ES2023"],
     "outDir": "dist/",
-    "strict": true,
     "useUnknownInCatchVariables": false
   },
   "include": ["./src/**/*"]

--- a/packages/core/.eslintrc
+++ b/packages/core/.eslintrc
@@ -1,4 +1,5 @@
 {
+  "extends": ["@readme/eslint-config/esm"],
   "rules": {
     "no-restricted-imports": [
       "error",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,6 +4,7 @@
   "description": "The magic behind `api` 🧙",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "type": "module",
   "scripts": {
     "build": "tsc",
     "lint:types": "tsc --noEmit",
@@ -33,8 +34,8 @@
     "get-stream": "^6.0.1",
     "json-schema-traverse": "^1.0.0",
     "lodash.merge": "^4.6.2",
-    "oas": "^20.10.3",
-    "remove-undefined-objects": "^3.0.0"
+    "oas": "^21.1.1",
+    "remove-undefined-objects": "^4.0.2"
   },
   "devDependencies": {
     "@api/test-utils": "file:../test-utils",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,17 +1,17 @@
 import type { Har } from 'har-format';
 import type Oas from 'oas';
 import type { Operation } from 'oas';
-import type { HttpMethods } from 'oas/dist/rmoas.types';
+import type { HttpMethods } from 'oas/rmoas.types';
 
 import oasToHar from '@readme/oas-to-har';
 import fetchHar from 'fetch-har';
 
-import FetchError from './errors/fetchError';
-import getJSONSchemaDefaults from './lib/getJSONSchemaDefaults';
-import parseResponse from './lib/parseResponse';
-import prepareAuth from './lib/prepareAuth';
-import prepareParams from './lib/prepareParams';
-import prepareServer from './lib/prepareServer';
+import FetchError from './errors/fetchError.js';
+import getJSONSchemaDefaults from './lib/getJSONSchemaDefaults.js';
+import parseResponse from './lib/parseResponse.js';
+import prepareAuth from './lib/prepareAuth.js';
+import prepareParams from './lib/prepareParams.js';
+import prepareServer from './lib/prepareServer.js';
 
 export interface ConfigOptions {
   /**
@@ -122,6 +122,7 @@ export default class APICore {
         init.signal = controller.signal;
       }
 
+      // @ts-expect-error the call signature doesn't align with the type. FIXME
       return fetchHar(har as Har, {
         files: data.files || {},
         init,

--- a/packages/core/src/lib/getJSONSchemaDefaults.ts
+++ b/packages/core/src/lib/getJSONSchemaDefaults.ts
@@ -1,5 +1,5 @@
-import type { SchemaWrapper } from 'oas/dist/operation/get-parameters-as-json-schema';
-import type { SchemaObject } from 'oas/dist/rmoas.types';
+import type { SchemaWrapper } from 'oas/operation/get-parameters-as-json-schema';
+import type { SchemaObject } from 'oas/rmoas.types';
 
 import traverse from 'json-schema-traverse';
 

--- a/packages/core/src/lib/prepareAuth.ts
+++ b/packages/core/src/lib/prepareAuth.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-underscore-dangle */
 import type { Operation } from 'oas';
-import type { KeyedSecuritySchemeObject } from 'oas/dist/rmoas.types';
+import type { KeyedSecuritySchemeObject } from 'oas/rmoas.types';
 
 export default function prepareAuth(authKey: (number | string)[], operation: Operation) {
   if (authKey.length === 0) {

--- a/packages/core/src/lib/prepareParams.ts
+++ b/packages/core/src/lib/prepareParams.ts
@@ -1,19 +1,19 @@
 import type { ReadStream } from 'node:fs';
 import type { Operation } from 'oas';
-import type { ParameterObject, SchemaObject } from 'oas/dist/rmoas.types';
+import type { ParameterObject, SchemaObject } from 'oas/rmoas.types';
 
 import fs from 'node:fs';
 import path from 'node:path';
 import stream from 'node:stream';
 
 import caseless from 'caseless';
-import DatauriParser from 'datauri/parser';
-import datauri from 'datauri/sync';
+import DatauriParser from 'datauri/parser.js';
+import datauri from 'datauri/sync.js';
 import getStream from 'get-stream';
 import lodashMerge from 'lodash.merge';
 import removeUndefinedObjects from 'remove-undefined-objects';
 
-import getJSONSchemaDefaults from './getJSONSchemaDefaults';
+import getJSONSchemaDefaults from './getJSONSchemaDefaults.js';
 
 // These headers are normally only defined by the OpenAPI definition but we allow the user to
 // manually supply them in their `metadata` parameter if they wish.

--- a/packages/core/test/index.test.ts
+++ b/packages/core/test/index.test.ts
@@ -7,8 +7,8 @@ import fetchMock from 'fetch-mock';
 import Oas from 'oas';
 import { describe, beforeEach, afterEach, it, expect } from 'vitest';
 
-import APICore from '../src';
-import FetchError from '../src/errors/fetchError';
+import FetchError from '../src/errors/fetchError.js';
+import APICore from '../src/index.js';
 
 describe('APICore', () => {
   let fileUploads: APICore;

--- a/packages/core/test/lib/getJSONSchemaDefaults.test.ts
+++ b/packages/core/test/lib/getJSONSchemaDefaults.test.ts
@@ -2,7 +2,7 @@ import loadSpec from '@api/test-utils/load-spec';
 import Oas from 'oas';
 import { describe, it, expect } from 'vitest';
 
-import getJSONSchemaDefaults from '../../src/lib/getJSONSchemaDefaults';
+import getJSONSchemaDefaults from '../../src/lib/getJSONSchemaDefaults.js';
 
 describe('#getJSONSchemaDefaults()', () => {
   it('should get defaults off an operation', async () => {

--- a/packages/core/test/lib/parseResponse.test.ts
+++ b/packages/core/test/lib/parseResponse.test.ts
@@ -1,6 +1,6 @@
 import { describe, beforeEach, it, expect } from 'vitest';
 
-import parseResponse from '../../src/lib/parseResponse';
+import parseResponse from '../../src/lib/parseResponse.js';
 
 const responseBody = JSON.stringify({
   id: 9205436248879918000,

--- a/packages/core/test/lib/prepareAuth.test.ts
+++ b/packages/core/test/lib/prepareAuth.test.ts
@@ -1,10 +1,10 @@
-import type { OASDocument } from 'oas/dist/rmoas.types';
+import type { OASDocument } from 'oas/rmoas.types';
 
 import loadSpec from '@api/test-utils/load-spec';
 import Oas from 'oas';
 import { describe, beforeAll, it, expect } from 'vitest';
 
-import prepareAuth from '../../src/lib/prepareAuth';
+import prepareAuth from '../../src/lib/prepareAuth.js';
 
 let oas: Oas;
 

--- a/packages/core/test/lib/prepareParams.test.ts
+++ b/packages/core/test/lib/prepareParams.test.ts
@@ -5,7 +5,7 @@ import loadSpec from '@api/test-utils/load-spec';
 import Oas from 'oas';
 import { describe, beforeEach, it, expect } from 'vitest';
 
-import prepareParams from '../../src/lib/prepareParams';
+import prepareParams from '../../src/lib/prepareParams.js';
 
 describe('#prepareParams', () => {
   let fileUploads: Oas;

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,13 +1,8 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "allowJs": true,
-    "baseUrl": "./src",
-    "declaration": true,
-    "esModuleInterop": true,
-    "lib": ["DOM", "DOM.Iterable", "ES2020"],
-    "noImplicitAny": true,
-    "outDir": "dist/",
-    "strict": true
+    "lib": ["DOM", "DOM.Iterable", "ES2023"],
+    "outDir": "dist/"
   },
   "include": ["./src/**/*"]
 }

--- a/packages/httpsnippet-client-api/package.json
+++ b/packages/httpsnippet-client-api/package.json
@@ -30,13 +30,13 @@
   },
   "peerDependencies": {
     "@readme/httpsnippet": ">=4",
-    "oas": "^20.0.0"
+    "oas": "^21.1.1"
   },
   "devDependencies": {
     "@readme/oas-examples": "^5.12.0",
     "@readme/openapi-parser": "^2.5.0",
     "@types/content-type": "^1.1.6",
-    "@types/stringify-object": "^4.0.2",
+    "@types/stringify-object": "^3.3.1",
     "@vitest/coverage-v8": "^0.34.4",
     "typescript": "^5.2.2",
     "vitest": "^0.34.1"

--- a/packages/httpsnippet-client-api/src/index.ts
+++ b/packages/httpsnippet-client-api/src/index.ts
@@ -1,7 +1,7 @@
 import type { ReducedHelperObject } from '@readme/httpsnippet/dist/helpers/reducer';
 import type { Client } from '@readme/httpsnippet/dist/targets/targets';
 import type { Operation } from 'oas';
-import type { HttpMethods, OASDocument } from 'oas/dist/rmoas.types';
+import type { HttpMethods, OASDocument } from 'oas/rmoas.types';
 
 import { CodeBuilder } from '@readme/httpsnippet/dist/helpers/code-builder';
 import contentType from 'content-type';

--- a/packages/httpsnippet-client-api/test/__datasets__/application-form-encoded/index.ts
+++ b/packages/httpsnippet-client-api/test/__datasets__/application-form-encoded/index.ts
@@ -1,5 +1,5 @@
 import type { SnippetMock } from '../../index.test';
-import type { OASDocument } from 'oas/dist/rmoas.types';
+import type { OASDocument } from 'oas/rmoas.types';
 
 import definition from './openapi.json';
 

--- a/packages/httpsnippet-client-api/test/__datasets__/application-json/index.ts
+++ b/packages/httpsnippet-client-api/test/__datasets__/application-json/index.ts
@@ -1,5 +1,5 @@
 import type { SnippetMock } from '../../index.test';
-import type { OASDocument } from 'oas/dist/rmoas.types';
+import type { OASDocument } from 'oas/rmoas.types';
 
 import definition from './openapi.json';
 

--- a/packages/httpsnippet-client-api/test/__datasets__/auth-apikey-cookie/index.ts
+++ b/packages/httpsnippet-client-api/test/__datasets__/auth-apikey-cookie/index.ts
@@ -1,5 +1,5 @@
 import type { SnippetMock } from '../../index.test';
-import type { OASDocument } from 'oas/dist/rmoas.types';
+import type { OASDocument } from 'oas/rmoas.types';
 
 import definition from '@readme/oas-examples/3.0/json/security.json';
 

--- a/packages/httpsnippet-client-api/test/__datasets__/auth-apikey-header/index.ts
+++ b/packages/httpsnippet-client-api/test/__datasets__/auth-apikey-header/index.ts
@@ -1,5 +1,5 @@
 import type { SnippetMock } from '../../index.test';
-import type { OASDocument } from 'oas/dist/rmoas.types';
+import type { OASDocument } from 'oas/rmoas.types';
 
 import definition from '@readme/oas-examples/3.0/json/security.json';
 

--- a/packages/httpsnippet-client-api/test/__datasets__/auth-basic-full/index.ts
+++ b/packages/httpsnippet-client-api/test/__datasets__/auth-basic-full/index.ts
@@ -1,5 +1,5 @@
 import type { SnippetMock } from '../../index.test';
-import type { OASDocument } from 'oas/dist/rmoas.types';
+import type { OASDocument } from 'oas/rmoas.types';
 
 import definition from '@readme/oas-examples/3.0/json/readme.json';
 

--- a/packages/httpsnippet-client-api/test/__datasets__/auth-basic-password-only/index.ts
+++ b/packages/httpsnippet-client-api/test/__datasets__/auth-basic-password-only/index.ts
@@ -1,5 +1,5 @@
 import type { SnippetMock } from '../../index.test';
-import type { OASDocument } from 'oas/dist/rmoas.types';
+import type { OASDocument } from 'oas/rmoas.types';
 
 import definition from '@readme/oas-examples/3.0/json/readme.json';
 

--- a/packages/httpsnippet-client-api/test/__datasets__/auth-basic-username-only/index.ts
+++ b/packages/httpsnippet-client-api/test/__datasets__/auth-basic-username-only/index.ts
@@ -1,5 +1,5 @@
 import type { SnippetMock } from '../../index.test';
-import type { OASDocument } from 'oas/dist/rmoas.types';
+import type { OASDocument } from 'oas/rmoas.types';
 
 import definition from '@readme/oas-examples/3.0/json/readme.json';
 

--- a/packages/httpsnippet-client-api/test/__datasets__/auth-bearer/index.ts
+++ b/packages/httpsnippet-client-api/test/__datasets__/auth-bearer/index.ts
@@ -1,5 +1,5 @@
 import type { SnippetMock } from '../../index.test';
-import type { OASDocument } from 'oas/dist/rmoas.types';
+import type { OASDocument } from 'oas/rmoas.types';
 
 import definition from '@readme/oas-examples/3.0/json/security.json';
 

--- a/packages/httpsnippet-client-api/test/__datasets__/auth-query/index.ts
+++ b/packages/httpsnippet-client-api/test/__datasets__/auth-query/index.ts
@@ -1,5 +1,5 @@
 import type { SnippetMock } from '../../index.test';
-import type { OASDocument } from 'oas/dist/rmoas.types';
+import type { OASDocument } from 'oas/rmoas.types';
 
 import definition from '@readme/oas-examples/3.0/json/security.json';
 

--- a/packages/httpsnippet-client-api/test/__datasets__/cookies/index.ts
+++ b/packages/httpsnippet-client-api/test/__datasets__/cookies/index.ts
@@ -1,5 +1,5 @@
 import type { SnippetMock } from '../../index.test';
-import type { OASDocument } from 'oas/dist/rmoas.types';
+import type { OASDocument } from 'oas/rmoas.types';
 
 import definition from './openapi.json';
 

--- a/packages/httpsnippet-client-api/test/__datasets__/full-many-query-params/index.ts
+++ b/packages/httpsnippet-client-api/test/__datasets__/full-many-query-params/index.ts
@@ -1,5 +1,5 @@
 import type { SnippetMock } from '../../index.test';
-import type { OASDocument } from 'oas/dist/rmoas.types';
+import type { OASDocument } from 'oas/rmoas.types';
 
 import definition from './openapi.json';
 

--- a/packages/httpsnippet-client-api/test/__datasets__/full/index.ts
+++ b/packages/httpsnippet-client-api/test/__datasets__/full/index.ts
@@ -1,5 +1,5 @@
 import type { SnippetMock } from '../../index.test';
-import type { OASDocument } from 'oas/dist/rmoas.types';
+import type { OASDocument } from 'oas/rmoas.types';
 
 import definition from './openapi.json';
 

--- a/packages/httpsnippet-client-api/test/__datasets__/headers/index.ts
+++ b/packages/httpsnippet-client-api/test/__datasets__/headers/index.ts
@@ -1,5 +1,5 @@
 import type { SnippetMock } from '../../index.test';
-import type { OASDocument } from 'oas/dist/rmoas.types';
+import type { OASDocument } from 'oas/rmoas.types';
 
 import definition from './openapi.json';
 

--- a/packages/httpsnippet-client-api/test/__datasets__/http-insecure/index.ts
+++ b/packages/httpsnippet-client-api/test/__datasets__/http-insecure/index.ts
@@ -1,5 +1,5 @@
 import type { SnippetMock } from '../../index.test';
-import type { OASDocument } from 'oas/dist/rmoas.types';
+import type { OASDocument } from 'oas/rmoas.types';
 
 import definition from './openapi.json';
 

--- a/packages/httpsnippet-client-api/test/__datasets__/issue-128/index.ts
+++ b/packages/httpsnippet-client-api/test/__datasets__/issue-128/index.ts
@@ -1,5 +1,5 @@
 import type { SnippetMock } from '../../index.test';
-import type { OASDocument } from 'oas/dist/rmoas.types';
+import type { OASDocument } from 'oas/rmoas.types';
 
 import definition from './openapi.json';
 

--- a/packages/httpsnippet-client-api/test/__datasets__/issue-76/index.ts
+++ b/packages/httpsnippet-client-api/test/__datasets__/issue-76/index.ts
@@ -1,5 +1,5 @@
 import type { SnippetMock } from '../../index.test';
-import type { OASDocument } from 'oas/dist/rmoas.types';
+import type { OASDocument } from 'oas/rmoas.types';
 
 import definition from './openapi.json';
 

--- a/packages/httpsnippet-client-api/test/__datasets__/issue-78-operationid/index.ts
+++ b/packages/httpsnippet-client-api/test/__datasets__/issue-78-operationid/index.ts
@@ -1,5 +1,5 @@
 import type { SnippetMock } from '../../index.test';
-import type { OASDocument } from 'oas/dist/rmoas.types';
+import type { OASDocument } from 'oas/rmoas.types';
 
 import definition from './openapi.json';
 

--- a/packages/httpsnippet-client-api/test/__datasets__/issue-78/index.ts
+++ b/packages/httpsnippet-client-api/test/__datasets__/issue-78/index.ts
@@ -1,5 +1,5 @@
 import type { SnippetMock } from '../../index.test';
-import type { OASDocument } from 'oas/dist/rmoas.types';
+import type { OASDocument } from 'oas/rmoas.types';
 
 import definition from './openapi.json';
 

--- a/packages/httpsnippet-client-api/test/__datasets__/jsonObj-multiline/index.ts
+++ b/packages/httpsnippet-client-api/test/__datasets__/jsonObj-multiline/index.ts
@@ -1,5 +1,5 @@
 import type { SnippetMock } from '../../index.test';
-import type { OASDocument } from 'oas/dist/rmoas.types';
+import type { OASDocument } from 'oas/rmoas.types';
 
 import definition from './openapi.json';
 

--- a/packages/httpsnippet-client-api/test/__datasets__/jsonObj-null-value/index.ts
+++ b/packages/httpsnippet-client-api/test/__datasets__/jsonObj-null-value/index.ts
@@ -1,5 +1,5 @@
 import type { SnippetMock } from '../../index.test';
-import type { OASDocument } from 'oas/dist/rmoas.types';
+import type { OASDocument } from 'oas/rmoas.types';
 
 import definition from './openapi.json';
 

--- a/packages/httpsnippet-client-api/test/__datasets__/multipart-data/index.ts
+++ b/packages/httpsnippet-client-api/test/__datasets__/multipart-data/index.ts
@@ -1,5 +1,5 @@
 import type { SnippetMock } from '../../index.test';
-import type { OASDocument } from 'oas/dist/rmoas.types';
+import type { OASDocument } from 'oas/rmoas.types';
 
 import definition from './openapi.json';
 

--- a/packages/httpsnippet-client-api/test/__datasets__/multipart-file/index.ts
+++ b/packages/httpsnippet-client-api/test/__datasets__/multipart-file/index.ts
@@ -1,5 +1,5 @@
 import type { SnippetMock } from '../../index.test';
-import type { OASDocument } from 'oas/dist/rmoas.types';
+import type { OASDocument } from 'oas/rmoas.types';
 
 import definition from './openapi.json';
 

--- a/packages/httpsnippet-client-api/test/__datasets__/multipart-form-data-no-params/index.ts
+++ b/packages/httpsnippet-client-api/test/__datasets__/multipart-form-data-no-params/index.ts
@@ -1,5 +1,5 @@
 import type { SnippetMock } from '../../index.test';
-import type { OASDocument } from 'oas/dist/rmoas.types';
+import type { OASDocument } from 'oas/rmoas.types';
 
 import definition from './openapi.json';
 

--- a/packages/httpsnippet-client-api/test/__datasets__/multipart-form-data/index.ts
+++ b/packages/httpsnippet-client-api/test/__datasets__/multipart-form-data/index.ts
@@ -1,5 +1,5 @@
 import type { SnippetMock } from '../../index.test';
-import type { OASDocument } from 'oas/dist/rmoas.types';
+import type { OASDocument } from 'oas/rmoas.types';
 
 import definition from './openapi.json';
 

--- a/packages/httpsnippet-client-api/test/__datasets__/operationid-non-alphanumerical/index.ts
+++ b/packages/httpsnippet-client-api/test/__datasets__/operationid-non-alphanumerical/index.ts
@@ -1,5 +1,5 @@
 import type { SnippetMock } from '../../index.test';
-import type { OASDocument } from 'oas/dist/rmoas.types';
+import type { OASDocument } from 'oas/rmoas.types';
 
 import definition from './openapi.json';
 

--- a/packages/httpsnippet-client-api/test/__datasets__/operationid-with-underscores/index.ts
+++ b/packages/httpsnippet-client-api/test/__datasets__/operationid-with-underscores/index.ts
@@ -1,5 +1,5 @@
 import type { SnippetMock } from '../../index.test';
-import type { OASDocument } from 'oas/dist/rmoas.types';
+import type { OASDocument } from 'oas/rmoas.types';
 
 import definition from './openapi.json';
 

--- a/packages/httpsnippet-client-api/test/__datasets__/parameter-special-characters/index.ts
+++ b/packages/httpsnippet-client-api/test/__datasets__/parameter-special-characters/index.ts
@@ -1,5 +1,5 @@
 import type { SnippetMock } from '../../index.test';
-import type { OASDocument } from 'oas/dist/rmoas.types';
+import type { OASDocument } from 'oas/rmoas.types';
 
 import definition from './openapi.json';
 

--- a/packages/httpsnippet-client-api/test/__datasets__/petstore/index.ts
+++ b/packages/httpsnippet-client-api/test/__datasets__/petstore/index.ts
@@ -1,5 +1,5 @@
 import type { SnippetMock } from '../../index.test';
-import type { OASDocument } from 'oas/dist/rmoas.types';
+import type { OASDocument } from 'oas/rmoas.types';
 
 import definition from '@readme/oas-examples/3.0/json/petstore.json';
 

--- a/packages/httpsnippet-client-api/test/__datasets__/query/index.ts
+++ b/packages/httpsnippet-client-api/test/__datasets__/query/index.ts
@@ -1,5 +1,5 @@
 import type { SnippetMock } from '../../index.test';
-import type { OASDocument } from 'oas/dist/rmoas.types';
+import type { OASDocument } from 'oas/rmoas.types';
 
 import definition from './openapi.json';
 

--- a/packages/httpsnippet-client-api/test/__datasets__/short/index.ts
+++ b/packages/httpsnippet-client-api/test/__datasets__/short/index.ts
@@ -1,5 +1,5 @@
 import type { SnippetMock } from '../../index.test';
-import type { OASDocument } from 'oas/dist/rmoas.types';
+import type { OASDocument } from 'oas/rmoas.types';
 
 import definition from './openapi.json';
 

--- a/packages/httpsnippet-client-api/test/__datasets__/text-plain/index.ts
+++ b/packages/httpsnippet-client-api/test/__datasets__/text-plain/index.ts
@@ -1,5 +1,5 @@
 import type { SnippetMock } from '../../index.test';
-import type { OASDocument } from 'oas/dist/rmoas.types';
+import type { OASDocument } from 'oas/rmoas.types';
 
 import definition from './openapi.json';
 

--- a/packages/httpsnippet-client-api/test/index.test.ts
+++ b/packages/httpsnippet-client-api/test/index.test.ts
@@ -1,6 +1,6 @@
 import type { HarRequest, Request } from '@readme/httpsnippet';
 import type { Client } from '@readme/httpsnippet/dist/targets/targets';
-import type { OASDocument } from 'oas/dist/rmoas.types';
+import type { OASDocument } from 'oas/rmoas.types';
 
 import { readdirSync } from 'node:fs';
 import fs from 'node:fs/promises';

--- a/packages/httpsnippet-client-api/tsconfig.json
+++ b/packages/httpsnippet-client-api/tsconfig.json
@@ -1,13 +1,8 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "allowJs": true,
-    "baseUrl": "./src",
-    "declaration": true,
-    "esModuleInterop": true,
-    "lib": ["DOM", "ES2020"],
-    "noImplicitAny": true,
+    "lib": ["DOM", "ES2023"],
     "outDir": "dist/",
-    "strict": true
   },
   "include": ["./src/**/*"]
 }

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@types/caseless": "^0.12.3",
-    "oas": "^20.10.3",
+    "oas": "^21.1.1",
     "typescript": "^5.2.2"
   },
   "prettier": "@readme/eslint-config/prettier"

--- a/packages/test-utils/tsconfig.json
+++ b/packages/test-utils/tsconfig.json
@@ -1,12 +1,8 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "allowJs": true,
-    "baseUrl": "./src",
-    "declaration": true,
-    "esModuleInterop": true,
-    "noEmit": true,
-    "noImplicitAny": true,
-    "strict": true
+    "lib": ["DOM", "ES2023"],
+    "noEmit": true
   },
   "include": ["./**/*"]
 }

--- a/packages/test-utils/vitest.matchers.ts
+++ b/packages/test-utils/vitest.matchers.ts
@@ -1,4 +1,4 @@
-import type { ParameterObject } from 'oas/dist/rmoas.types';
+import type { ParameterObject } from 'oas/rmoas.types';
 
 import caseless from 'caseless';
 import { expect } from 'vitest';

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,13 @@
+{
+  "extends": "@tsconfig/node18/tsconfig.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "baseUrl": "./src",
+    "declaration": true,
+    // per [this guide](https://www.totaltypescript.com/tsconfig-cheat-sheet#building-for-a-library-in-a-monorepo),
+    // the following flags are recommended for monorepos.
+    "composite": true,
+    "declarationMap": true,
+    "sourceMap": true
+  }
+}


### PR DESCRIPTION
| 🚥 Resolves RM-7989 |
| :------------------- |

## 🧰 Changes

This _very much (in-progress)_ PR migrates the `api` and `core` subpackages over to ESM. TKTK

## 🧬 QA & Testing

Provide as much information as you can on how to test what you've done.
