### PR TITLE
refactor: remove `make-dir` as a dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13624,6 +13624,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
       "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
       "dependencies": {
         "semver": "^7.5.3"
       },
@@ -21630,7 +21631,6 @@
         "lodash.deburr": "^4.1.0",
         "lodash.setwith": "^4.3.2",
         "lodash.startcase": "^4.4.0",
-        "make-dir": "^4.0.0",
         "oas": "^22.0.0",
         "ora": "^5.4.1",
         "prompts": "^2.4.2",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -47,7 +47,6 @@
     "lodash.deburr": "^4.1.0",
     "lodash.setwith": "^4.3.2",
     "lodash.startcase": "^4.4.0",
-    "make-dir": "^4.0.0",
     "oas": "^22.0.0",
     "ora": "^5.4.1",
     "prompts": "^2.4.2",

--- a/packages/api/src/storage.ts
+++ b/packages/api/src/storage.ts
@@ -3,7 +3,6 @@ import type { OASDocument } from 'oas/rmoas.types';
 import fs from 'node:fs';
 import path from 'node:path';
 
-import makeDir from 'make-dir';
 import ssri from 'ssri';
 import validateNPMPackageName from 'validate-npm-package-name';
 
@@ -59,7 +58,7 @@ export default class Storage {
 
     Storage.dir = makeDir.sync(path.join(process.cwd(), '.api'));
 
-    makeDir.sync(Storage.getAPIsDir());
+    fs.mkdirSync(Storage.getAPIsDir(), { recursive: true });
   }
 
   /**

--- a/packages/api/src/storage.ts
+++ b/packages/api/src/storage.ts
@@ -56,7 +56,7 @@ export default class Storage {
       return;
     }
 
-    Storage.dir = makeDir.sync(path.join(process.cwd(), '.api'));
+    Storage.dir = fs.mkdirSync(path.join(process.cwd(), '.api'), { recursive: true }) as string;
 
     fs.mkdirSync(Storage.getAPIsDir(), { recursive: true });
   }


### PR DESCRIPTION
## 🧰 Changes

`make-dir` isn't needed a we can call` fs.makeDirSync` instead.