### PR TITLE
fix(api): storage dir not being set properly

### DIFF
--- a/packages/api/src/storage.ts
+++ b/packages/api/src/storage.ts
@@ -56,8 +56,9 @@ export default class Storage {
       return;
     }
 
-    Storage.dir = fs.mkdirSync(path.join(process.cwd(), '.api'), { recursive: true }) as string;
+    Storage.dir = path.join(process.cwd(), '.api');
 
+    fs.mkdirSync(Storage.dir, { recursive: true });
     fs.mkdirSync(Storage.getAPIsDir(), { recursive: true });
   }
 

--- a/packages/api/test/storage.test.ts
+++ b/packages/api/test/storage.test.ts
@@ -33,6 +33,20 @@ describe('storage', () => {
     fetchMock.restore();
   });
 
+  describe('#setStorageDir', () => {
+    it('should create and set a storage dir if one is neither supplied or already exists', async () => {
+      Storage.dir = '';
+
+      Storage.setStorageDir();
+
+      expect(Storage.dir).toContain('/.api');
+      expect(Storage.getAPIsDir()).toContain('/.api/api');
+
+      await expect(fs.stat(Storage.dir)).resolves.toHaveProperty('uid');
+      await expect(fs.stat(Storage.getAPIsDir())).resolves.toHaveProperty('uid');
+    });
+  });
+
   describe('#generateIntegrityHash', () => {
     it('should generate an integrity hash for an API definition', () => {
       expect(Storage.generateIntegrityHash(petstoreSimple as OASDocument)).toBe(


### PR DESCRIPTION
## 🧰 Changes

Fixes a condition introduced in https://github.com/readmeio/api/pull/746 where `Storage.dir` would not get set properly when we create a new `.api/` directory.