### PR TITLE
refactor(api): minor refactors to how some internal language classes are used

### DIFF
--- a/packages/api/src/codegen/codegenerator.ts
+++ b/packages/api/src/codegen/codegenerator.ts
@@ -16,7 +16,7 @@ export interface InstallerOptions {
   logger?: (msg: string) => void;
 }
 
-export default abstract class CodeGeneratorLanguage {
+export default abstract class CodeGenerator {
   spec: Oas;
 
   specPath: string;
@@ -55,9 +55,9 @@ export default abstract class CodeGeneratorLanguage {
     }
   }
 
-  abstract generator(): Promise<Record<string, string>>;
+  abstract compile(): Promise<Record<string, string>>;
 
-  abstract installer(storage: Storage, opts?: InstallerOptions): Promise<void>;
+  abstract install(storage: Storage, opts?: InstallerOptions): Promise<void>;
 
   hasRequiredPackages() {
     return Boolean(Object.keys(this.requiredPackages));

--- a/packages/api/src/codegen/factory.ts
+++ b/packages/api/src/codegen/factory.ts
@@ -1,16 +1,16 @@
-import type CodeGeneratorLanguage from './language.js';
+import type CodeGenerator from './codegenerator.js';
 import type Oas from 'oas';
 
-import TSGenerator from './languages/typescript.js';
+import TSGenerator from './languages/typescript/index.js';
 
 export type SupportedLanguages = 'js' | 'js-cjs' | 'js-esm' | 'ts';
 
-export default function codegen(
+export default function codegenFactory(
   language: SupportedLanguages,
   spec: Oas,
   specPath: string,
   identifier: string,
-): CodeGeneratorLanguage {
+): CodeGenerator {
   switch (language) {
     case 'js':
       throw new TypeError('An export format of CommonJS or ECMAScript is required for JavaScript compilation.');

--- a/packages/api/src/commands/install.ts
+++ b/packages/api/src/commands/install.ts
@@ -1,11 +1,11 @@
-import type { SupportedLanguages } from '../codegen/index.js';
+import type { SupportedLanguages } from '../codegen/factory.js';
 
 import { Command, Option } from 'commander';
 import figures from 'figures';
 import Oas from 'oas';
 import ora from 'ora';
 
-import codegen from '../codegen/index.js';
+import codegenFactory from '../codegen/factory.js';
 import Fetcher from '../fetcher.js';
 import promptTerminal from '../lib/prompt.js';
 import logger from '../logger.js';
@@ -120,9 +120,9 @@ cmd
 
     // @todo look for a prettier config and if we find one ask them if we should use it
     spinner = ora('Generating your SDK').start();
-    const generator = codegen(language, oas, './openapi.json', identifier);
+    const generator = codegenFactory(language, oas, './openapi.json', identifier);
     const sdkSource = await generator
-      .generator()
+      .compile()
       .then(res => {
         spinner.succeed(spinner.text);
         return res;
@@ -170,7 +170,7 @@ cmd
 
       spinner = ora('Installing required packages').start();
       try {
-        await generator.installer(storage);
+        await generator.install(storage);
         spinner.succeed(spinner.text);
       } catch (err) {
         // @todo cleanup installed files

--- a/packages/api/test/codegen/languages/typescript/smoketest.test.ts
+++ b/packages/api/test/codegen/languages/typescript/smoketest.test.ts
@@ -20,7 +20,7 @@ import Oas from 'oas';
 import OASNormalize from 'oas-normalize';
 import { describe, it, expect } from 'vitest';
 
-import TSGenerator from '../../../../src/codegen/languages/typescript.js';
+import TSGenerator from '../../../../src/codegen/languages/typescript/index.js';
 
 // These APIs don't have any schemas so they should only be generating an `index.ts`.
 const APIS_WITHOUT_SCHEMAS = ['poemist.com'];
@@ -70,7 +70,7 @@ describe('typescript smoketest', () => {
       await oas.dereference({ preserveRefAsJSONSchemaTitle: true });
 
       const ts = new TSGenerator(oas, './path/not/needed.json', name);
-      const res = await ts.generator();
+      const res = await ts.compile();
 
       if (APIS_WITHOUT_SCHEMAS.includes(name)) {
         expect(Object.keys(res)).toStrictEqual(['index.ts']);


### PR DESCRIPTION
## 🧰 Changes

This is all some very minor internal API refactoring that spawned out of the ESM overhauls in https://github.com/readmeio/api/pull/754 that I decided to extract into a targeted changeset.