### PR TITLE
refactor(core): removing `oas` as a dependency on codegen'd SDKs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21961,9 +21961,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.22.2",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.2.tgz",
-      "integrity": "sha512-wvWkphh5WQsJbVk1tbx1l1Ly4yg+XecD+Mq280uBGt9wa5BKSWf4Mhp6GmrkPixhMxmabYY7RbzlwVP32pbGCg==",
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
+      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/packages/api/src/codegen/languages/typescript/index.ts
+++ b/packages/api/src/codegen/languages/typescript/index.ts
@@ -99,11 +99,6 @@ export default class TSGenerator extends CodeGenerator {
         url: 'https://npm.im/json-schema-to-ts',
         version: '^2.9.2',
       },
-      oas: {
-        reason: 'Used within `@readme/api-core` and is also loaded for TypeScript types.',
-        url: 'https://npm.im/oas',
-        version: '^23.0.0',
-      },
     };
 
     this.project = new Project({
@@ -265,7 +260,6 @@ export default class TSGenerator extends CodeGenerator {
         defaultImport: 'type { ConfigOptions, FetchResponse, HTTPMethodRange }',
         moduleSpecifier: '@readme/api-core',
       },
-      { defaultImport: 'Oas', moduleSpecifier: 'oas' },
       { defaultImport: 'APICore', moduleSpecifier: '@readme/api-core' },
       { defaultImport: 'definition', moduleSpecifier: this.specPath },
     ]);
@@ -273,16 +267,12 @@ export default class TSGenerator extends CodeGenerator {
     // @todo add TOS, License, info.* to a docblock at the top of the SDK.
     this.sdk = sourceFile.addClass({
       name: 'SDK',
-      properties: [
-        { name: 'spec', type: 'Oas' },
-        { name: 'core', type: 'APICore' },
-      ],
+      properties: [{ name: 'core', type: 'APICore' }],
     });
 
     this.sdk.addConstructor({
       statements: writer => {
-        writer.writeLine('this.spec = Oas.init(definition);');
-        writer.write('this.core = new APICore(this.spec, ').quote(this.userAgent).write(');');
+        writer.write('this.core = new APICore(definition, ').quote(this.userAgent).write(');');
         return writer;
       },
     });

--- a/packages/api/test/__fixtures__/sdk/alby/package.json
+++ b/packages/api/test/__fixtures__/sdk/alby/package.json
@@ -16,8 +16,7 @@
   },
   "dependencies": {
     "@readme/api-core": "file:../../../../../core",
-    "json-schema-to-ts": "^2.9.2",
-    "oas": "^23.0.0"
+    "json-schema-to-ts": "^2.9.2"
   },
   "tsup": {
     "cjsInterop": true,

--- a/packages/api/test/__fixtures__/sdk/alby/src/index.ts
+++ b/packages/api/test/__fixtures__/sdk/alby/src/index.ts
@@ -1,16 +1,13 @@
 import type * as types from './types';
 import type { ConfigOptions, FetchResponse } from '@readme/api-core';
-import Oas from 'oas';
 import APICore from '@readme/api-core';
 import definition from '@api/test-utils/definitions/alby.json';
 
 class SDK {
-  spec: Oas;
   core: APICore;
 
   constructor() {
-    this.spec = Oas.init(definition);
-    this.core = new APICore(this.spec, 'alby/1.0.14 (api/<<package version>>)');
+    this.core = new APICore(definition, 'alby/1.0.14 (api/<<package version>>)');
   }
 
   /**

--- a/packages/api/test/__fixtures__/sdk/operationid-quirks/package.json
+++ b/packages/api/test/__fixtures__/sdk/operationid-quirks/package.json
@@ -12,8 +12,7 @@
   },
   "dependencies": {
     "@readme/api-core": "file:../../../../../core",
-    "json-schema-to-ts": "^2.9.2",
-    "oas": "^23.0.0"
+    "json-schema-to-ts": "^2.9.2"
   },
   "tsup": {
     "cjsInterop": true,

--- a/packages/api/test/__fixtures__/sdk/operationid-quirks/src/index.ts
+++ b/packages/api/test/__fixtures__/sdk/operationid-quirks/src/index.ts
@@ -1,15 +1,12 @@
 import type { ConfigOptions, FetchResponse } from '@readme/api-core';
-import Oas from 'oas';
 import APICore from '@readme/api-core';
 import definition from '@api/test-utils/definitions/operationid-quirks.json';
 
 class SDK {
-  spec: Oas;
   core: APICore;
 
   constructor() {
-    this.spec = Oas.init(definition);
-    this.core = new APICore(this.spec, 'operationid-quirks/1.0.0 (api/<<package version>>)');
+    this.core = new APICore(definition, 'operationid-quirks/1.0.0 (api/<<package version>>)');
   }
 
   /**

--- a/packages/api/test/__fixtures__/sdk/optional-payload/package.json
+++ b/packages/api/test/__fixtures__/sdk/optional-payload/package.json
@@ -16,8 +16,7 @@
   },
   "dependencies": {
     "@readme/api-core": "file:../../../../../core",
-    "json-schema-to-ts": "^2.9.2",
-    "oas": "^23.0.0"
+    "json-schema-to-ts": "^2.9.2"
   },
   "tsup": {
     "cjsInterop": true,

--- a/packages/api/test/__fixtures__/sdk/optional-payload/src/index.ts
+++ b/packages/api/test/__fixtures__/sdk/optional-payload/src/index.ts
@@ -1,16 +1,13 @@
 import type * as types from './types';
 import type { ConfigOptions, FetchResponse } from '@readme/api-core';
-import Oas from 'oas';
 import APICore from '@readme/api-core';
 import definition from '@api/test-utils/definitions/optional-payload.json';
 
 class SDK {
-  spec: Oas;
   core: APICore;
 
   constructor() {
-    this.spec = Oas.init(definition);
-    this.core = new APICore(this.spec, 'optional-payload/1.0.0 (api/<<package version>>)');
+    this.core = new APICore(definition, 'optional-payload/1.0.0 (api/<<package version>>)');
   }
 
   /**

--- a/packages/api/test/__fixtures__/sdk/petstore/package.json
+++ b/packages/api/test/__fixtures__/sdk/petstore/package.json
@@ -16,8 +16,7 @@
   },
   "dependencies": {
     "@readme/api-core": "file:../../../../../core",
-    "json-schema-to-ts": "^2.9.2",
-    "oas": "^23.0.0"
+    "json-schema-to-ts": "^2.9.2"
   },
   "tsup": {
     "cjsInterop": true,

--- a/packages/api/test/__fixtures__/sdk/petstore/src/index.ts
+++ b/packages/api/test/__fixtures__/sdk/petstore/src/index.ts
@@ -1,16 +1,13 @@
 import type * as types from './types';
 import type { ConfigOptions, FetchResponse } from '@readme/api-core';
-import Oas from 'oas';
 import APICore from '@readme/api-core';
 import definition from '@readme/oas-examples/3.0/json/petstore.json';
 
 class SDK {
-  spec: Oas;
   core: APICore;
 
   constructor() {
-    this.spec = Oas.init(definition);
-    this.core = new APICore(this.spec, 'petstore/1.0.0 (api/<<package version>>)');
+    this.core = new APICore(definition, 'petstore/1.0.0 (api/<<package version>>)');
   }
 
   /**

--- a/packages/api/test/__fixtures__/sdk/readme/package.json
+++ b/packages/api/test/__fixtures__/sdk/readme/package.json
@@ -16,8 +16,7 @@
   },
   "dependencies": {
     "@readme/api-core": "file:../../../../../core",
-    "json-schema-to-ts": "^2.9.2",
-    "oas": "^23.0.0"
+    "json-schema-to-ts": "^2.9.2"
   },
   "tsup": {
     "cjsInterop": true,

--- a/packages/api/test/__fixtures__/sdk/readme/src/index.ts
+++ b/packages/api/test/__fixtures__/sdk/readme/src/index.ts
@@ -1,16 +1,13 @@
 import type * as types from './types';
 import type { ConfigOptions, FetchResponse } from '@readme/api-core';
-import Oas from 'oas';
 import APICore from '@readme/api-core';
 import definition from '@readme/oas-examples/3.0/json/readme.json';
 
 class SDK {
-  spec: Oas;
   core: APICore;
 
   constructor() {
-    this.spec = Oas.init(definition);
-    this.core = new APICore(this.spec, 'readme/4.355.0 (api/<<package version>>)');
+    this.core = new APICore(definition, 'readme/4.355.0 (api/<<package version>>)');
   }
 
   /**

--- a/packages/api/test/__fixtures__/sdk/response-title-quirks/package.json
+++ b/packages/api/test/__fixtures__/sdk/response-title-quirks/package.json
@@ -16,8 +16,7 @@
   },
   "dependencies": {
     "@readme/api-core": "file:../../../../../core",
-    "json-schema-to-ts": "^2.9.2",
-    "oas": "^23.0.0"
+    "json-schema-to-ts": "^2.9.2"
   },
   "tsup": {
     "cjsInterop": true,

--- a/packages/api/test/__fixtures__/sdk/response-title-quirks/src/index.ts
+++ b/packages/api/test/__fixtures__/sdk/response-title-quirks/src/index.ts
@@ -1,16 +1,13 @@
 import type * as types from './types';
 import type { ConfigOptions, FetchResponse, HTTPMethodRange } from '@readme/api-core';
-import Oas from 'oas';
 import APICore from '@readme/api-core';
 import definition from '@api/test-utils/definitions/response-title-quirks.json';
 
 class SDK {
-  spec: Oas;
   core: APICore;
 
   constructor() {
-    this.spec = Oas.init(definition);
-    this.core = new APICore(this.spec, 'response-title-quirks/1.0.0 (api/<<package version>>)');
+    this.core = new APICore(definition, 'response-title-quirks/1.0.0 (api/<<package version>>)');
   }
 
   /**

--- a/packages/api/test/__fixtures__/sdk/simple/package.json
+++ b/packages/api/test/__fixtures__/sdk/simple/package.json
@@ -16,8 +16,7 @@
   },
   "dependencies": {
     "@readme/api-core": "file:../../../../../core",
-    "json-schema-to-ts": "^2.9.2",
-    "oas": "^23.0.0"
+    "json-schema-to-ts": "^2.9.2"
   },
   "tsup": {
     "cjsInterop": true,

--- a/packages/api/test/__fixtures__/sdk/simple/src/index.ts
+++ b/packages/api/test/__fixtures__/sdk/simple/src/index.ts
@@ -1,16 +1,13 @@
 import type * as types from './types';
 import type { ConfigOptions, FetchResponse } from '@readme/api-core';
-import Oas from 'oas';
 import APICore from '@readme/api-core';
 import definition from '@api/test-utils/definitions/simple.json';
 
 class SDK {
-  spec: Oas;
   core: APICore;
 
   constructor() {
-    this.spec = Oas.init(definition);
-    this.core = new APICore(this.spec, 'simple/1.0.0 (api/<<package version>>)');
+    this.core = new APICore(definition, 'simple/1.0.0 (api/<<package version>>)');
   }
 
   /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,10 +1,10 @@
 import type { Har } from 'har-format';
-import type Oas from 'oas';
 import type Operation from 'oas/operation';
-import type { HttpMethods } from 'oas/rmoas.types';
+import type { HttpMethods, OASDocument } from 'oas/rmoas.types';
 
 import oasToHar from '@readme/oas-to-har';
 import fetchHar from 'fetch-har';
+import Oas from 'oas';
 
 import FetchError from './errors/fetchError.js';
 import { parseResponse, prepareAuth, prepareParams, prepareServer } from './lib/index.js';
@@ -47,8 +47,8 @@ export default class APICore {
 
   private userAgent!: string;
 
-  constructor(spec?: Oas, userAgent?: string) {
-    if (spec) this.spec = spec;
+  constructor(definition?: Record<string, unknown> | OASDocument, userAgent?: string) {
+    if (definition) this.spec = Oas.init(definition);
     if (userAgent) this.userAgent = userAgent;
   }
 

--- a/packages/core/test/index.test.ts
+++ b/packages/core/test/index.test.ts
@@ -3,7 +3,6 @@ import assert from 'node:assert';
 import { loadSpec, responses as mockResponse } from '@api/test-utils';
 import datauri from 'datauri';
 import fetchMock from 'fetch-mock';
-import Oas from 'oas';
 import { describe, beforeEach, afterEach, it, expect } from 'vitest';
 
 import FetchError from '../src/errors/fetchError.js';
@@ -24,29 +23,21 @@ describe('APICore', () => {
   };
 
   beforeEach(async () => {
-    fileUploads = await loadSpec('@readme/oas-examples/3.0/json/file-uploads.json')
-      .then(Oas.init)
-      .then(oas => new APICore(oas));
+    fileUploads = await loadSpec('@readme/oas-examples/3.0/json/file-uploads.json').then(spec => new APICore(spec));
 
-    parametersStyle = await loadSpec('@readme/oas-examples/3.1/json/parameters-style.json')
-      .then(Oas.init)
-      .then(oas => new APICore(oas));
+    parametersStyle = await loadSpec('@readme/oas-examples/3.1/json/parameters-style.json').then(
+      spec => new APICore(spec),
+    );
 
-    petstore = await loadSpec('@readme/oas-examples/3.0/json/petstore-expanded.json')
-      .then(Oas.init)
-      .then(oas => new APICore(oas));
+    petstore = await loadSpec('@readme/oas-examples/3.0/json/petstore-expanded.json').then(spec => new APICore(spec));
 
-    readme = await loadSpec('@readme/oas-examples/3.0/json/readme.json')
-      .then(Oas.init)
-      .then(oas => new APICore(oas));
+    readme = await loadSpec('@readme/oas-examples/3.0/json/readme.json').then(spec => new APICore(spec));
 
-    security = await loadSpec('@readme/oas-examples/3.0/json/security.json')
-      .then(Oas.init)
-      .then(oas => new APICore(oas));
+    security = await loadSpec('@readme/oas-examples/3.0/json/security.json').then(spec => new APICore(spec));
 
-    serverVariables = await loadSpec('@readme/oas-examples/3.0/json/server-variables.json')
-      .then(Oas.init)
-      .then(oas => new APICore(oas));
+    serverVariables = await loadSpec('@readme/oas-examples/3.0/json/server-variables.json').then(
+      spec => new APICore(spec),
+    );
   });
 
   afterEach(() => {
@@ -139,26 +130,24 @@ describe('APICore', () => {
         let queryEncoding: APICore;
 
         beforeEach(() => {
-          queryEncoding = new APICore(
-            Oas.init({
-              servers: [{ url: 'https://httpbin.org/' }],
-              paths: {
-                '/anything': {
-                  get: {
-                    operationId: 'getAnything',
-                    parameters: [
-                      { name: 'stringPound', in: 'query', schema: { type: 'string' } },
-                      { name: 'stringPound2', in: 'query', schema: { type: 'string' } },
-                      { name: 'stringHash', in: 'query', schema: { type: 'string' } },
-                      { name: 'stringArray', in: 'query', schema: { type: 'string' } },
-                      { name: 'stringWeird', in: 'query', schema: { type: 'string' } },
-                      { name: 'array', in: 'query', schema: { type: 'array', items: { type: 'string' } } },
-                    ],
-                  },
+          queryEncoding = new APICore({
+            servers: [{ url: 'https://httpbin.org/' }],
+            paths: {
+              '/anything': {
+                get: {
+                  operationId: 'getAnything',
+                  parameters: [
+                    { name: 'stringPound', in: 'query', schema: { type: 'string' } },
+                    { name: 'stringPound2', in: 'query', schema: { type: 'string' } },
+                    { name: 'stringHash', in: 'query', schema: { type: 'string' } },
+                    { name: 'stringArray', in: 'query', schema: { type: 'string' } },
+                    { name: 'stringWeird', in: 'query', schema: { type: 'string' } },
+                    { name: 'array', in: 'query', schema: { type: 'array', items: { type: 'string' } } },
+                  ],
                 },
               },
-            }),
-          );
+            },
+          });
         });
 
         it('should encode query parameters', async () => {
@@ -214,8 +203,7 @@ describe('APICore', () => {
               spec.servers[0].url = '{scheme}://httpbin.org/anything';
               return spec;
             })
-            .then(Oas.init)
-            .then(oas => new APICore(oas));
+            .then(spec => new APICore(spec));
 
           fetchMock.post('https://httpbin.org/anything/v1/oa_citations/records', mockResponse.all);
 
@@ -372,9 +360,7 @@ describe('APICore', () => {
       let petstoreTimeout: APICore;
 
       beforeEach(async () => {
-        petstoreTimeout = await loadSpec('@readme/oas-examples/3.0/json/petstore.json')
-          .then(Oas.init)
-          .then(oas => new APICore(oas));
+        petstoreTimeout = await loadSpec('@readme/oas-examples/3.0/json/petstore.json').then(spec => new APICore(spec));
       });
 
       afterEach(() => {


### PR DESCRIPTION
## 🧰 Changes

Because `oas` is only used in codegen'd SDKs to do `Oas.init()` and supply an instance of `oas` to `@readme/api-core` we can lessen some steps, and a hard dependency on `oas` here by refactoring `@readme/api-core` to instead accept an API definition as its first argument.