### PR TITLE
fix(httpsnippet-client-api): retain casing for non-reserved headers

### DIFF
--- a/packages/httpsnippet-client-api/src/index.ts
+++ b/packages/httpsnippet-client-api/src/index.ts
@@ -274,9 +274,14 @@ const client: Client<APIOptions> = {
         }
 
         // If we haven't used our header anywhere else, or we've deleted it from the payload
-        // because it'll be handled internally by `api` then we should add the lowercased version
-        // of our header into the generated code snippet.
-        requestHeaders[headerLower] = headers[header];
+        // because it'll be handled internally by `api` then we should add it into our code snippet.
+        if (['accept', 'content-type'].includes(headerLower)) {
+          requestHeaders[headerLower] = headers[header];
+        } else {
+          // Non-reserved headers retain their casing because we want to generate a snippet that
+          // matches the TS types that are created during codegeneration.
+          requestHeaders[header] = headers[header];
+        }
       });
 
       if (Object.keys(requestHeaders).length > 0) {

--- a/packages/httpsnippet-client-api/test/__datasets__/headers/index.ts
+++ b/packages/httpsnippet-client-api/test/__datasets__/headers/index.ts
@@ -17,8 +17,12 @@ const mock: SnippetMock = {
         value: 'Bar',
       },
       {
-        name: 'X-Bar',
+        name: 'x-bar',
         value: 'foo',
+      },
+      {
+        name: 'reqKey',
+        value: 'baz',
       },
     ],
     headersSize: 0,

--- a/packages/httpsnippet-client-api/test/__datasets__/headers/openapi.json
+++ b/packages/httpsnippet-client-api/test/__datasets__/headers/openapi.json
@@ -26,6 +26,14 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "reqKey",
+            "in": "header",
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
           }
         ],
         "responses": {

--- a/packages/httpsnippet-client-api/test/__datasets__/headers/output.js
+++ b/packages/httpsnippet-client-api/test/__datasets__/headers/output.js
@@ -1,5 +1,5 @@
 import sdk from '@api/headers';
 
-sdk.getAnything({'x-foo': 'Bar', 'x-bar': 'foo'})
+sdk.getAnything({'x-foo': 'Bar', 'x-bar': 'foo', reqKey: 'baz'})
   .then(({ data }) => console.log(data))
   .catch(err => console.error(err));


### PR DESCRIPTION
| 🚥 Resolves RM-8153 |
| :------------------- |

## 🧰 Changes

This fixes a quirk in `httpsnippet-client-api` where even though HTTP headers are case-insensitive the TS types we generate for `api` are not and we are currently lowercasing all non-reserved header names we add into code snippets.

![image](https://github.com/readmeio/api/assets/33762/0e077dd0-b2ab-4bc1-ade8-96bc40925041)
