### PR TITLE
fix(cjs): include get-stream directly in bundle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23064,7 +23064,6 @@
         "caseless": "^0.12.0",
         "datauri": "^4.1.0",
         "fetch-har": "^11.0.1",
-        "get-stream": "^8.0.1",
         "json-schema-to-ts": "^2.9.2",
         "json-schema-traverse": "^1.0.0",
         "lodash.merge": "^4.6.2",
@@ -23078,6 +23077,7 @@
         "@types/lodash.merge": "^4.6.7",
         "@vitest/coverage-v8": "^0.34.4",
         "fetch-mock": "^9.11.0",
+        "get-stream": "^8.0.1",
         "typescript": "^5.2.2",
         "vitest": "^0.34.5"
       },
@@ -23089,6 +23089,7 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
       "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true,
       "engines": {
         "node": ">=16"
       },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -49,7 +49,6 @@
     "caseless": "^0.12.0",
     "datauri": "^4.1.0",
     "fetch-har": "^11.0.1",
-    "get-stream": "^8.0.1",
     "json-schema-to-ts": "^2.9.2",
     "json-schema-traverse": "^1.0.0",
     "lodash.merge": "^4.6.2",
@@ -63,6 +62,7 @@
     "@types/lodash.merge": "^4.6.7",
     "@vitest/coverage-v8": "^0.34.4",
     "fetch-mock": "^9.11.0",
+    "get-stream": "^8.0.1",
     "typescript": "^5.2.2",
     "vitest": "^0.34.5"
   },

--- a/packages/core/src/lib/prepareParams.ts
+++ b/packages/core/src/lib/prepareParams.ts
@@ -9,6 +9,8 @@ import stream from 'node:stream';
 import caseless from 'caseless';
 import DatauriParser from 'datauri/parser.js';
 import datauri from 'datauri/sync.js';
+// `get-stream` is included in our bundle, see `tsup.config.ts`
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { getStreamAsBuffer } from 'get-stream';
 import lodashMerge from 'lodash.merge';
 import removeUndefinedObjects from 'remove-undefined-objects';

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -11,5 +11,9 @@ export default defineConfig((options: Options) => ({
   ...config,
 
   entry: ['src/errors/fetchError.ts', 'src/lib/index.ts', 'src/index.ts'],
+  // `get-stream` is ESM-only and we need to build for CommonJS,
+  // so including it below means that its (tree-shaken!) source code
+  // will be included directly in our dist outputs.
+  noExternal: ['get-stream'],
   silent: !options.watch,
 }));

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -11,9 +11,11 @@ export default defineConfig((options: Options) => ({
   ...config,
 
   entry: ['src/errors/fetchError.ts', 'src/lib/index.ts', 'src/index.ts'],
-  // `get-stream` is ESM-only and we need to build for CommonJS,
-  // so including it below means that its (tree-shaken!) source code
-  // will be included directly in our dist outputs.
-  noExternal: ['get-stream'],
+  noExternal: [
+    // `get-stream` is ESM-only and we need to build for CommonJS,
+    // so including it here means that its (tree-shaken!) source code
+    // will be included directly in our dist outputs.
+    'get-stream',
+  ],
   silent: !options.watch,
 }));


### PR DESCRIPTION
## 🧰 Changes

Seeing the following error when attempting to run a codegen'd SDK via CJS:

```
/Users/kanadg/Code/readmeio/tmp-api-tsup-sandbox/node_modules/@readme/api-core/dist/chunk-TOMHUGQA.cjs:138
var _getstream = require('get-stream');
                 ^

Error [ERR_REQUIRE_ESM]: require() of ES Module /Users/kanadg/Code/readmeio/tmp-api-tsup-sandbox/node_modules/get-stream/source/index.js from /Users/kanadg/Code/readmeio/tmp-api-tsup-sandbox/node_modules/@readme/api-core/dist/chunk-TOMHUGQA.cjs not supported.
Instead change the require of index.js in /Users/kanadg/Code/readmeio/tmp-api-tsup-sandbox/node_modules/@readme/api-core/dist/chunk-TOMHUGQA.cjs to a dynamic import() which is available in all CommonJS modules.
    at Object.<anonymous> (/Users/kanadg/Code/readmeio/tmp-api-tsup-sandbox/node_modules/@readme/api-core/dist/chunk-TOMHUGQA.cjs:138:18)
    at Object.<anonymous> (/Users/kanadg/Code/readmeio/tmp-api-tsup-sandbox/node_modules/@readme/api-core/dist/index.cjs:9:25)
    at Object.<anonymous> (/Users/kanadg/Code/readmeio/tmp-api-tsup-sandbox/.api/apis/transit-new/dist/index.js:2:16)
    at Object.<anonymous> (/Users/kanadg/Code/readmeio/tmp-api-tsup-sandbox/src/index.cjs:1:17) {
  code: 'ERR_REQUIRE_ESM'
}

Node.js v18.18.2
```

This PR makes a slight tweak to our `tsup` config and our dependencies so the `get-stream` code we use is included directly in the bundle.

## 🧬 QA & Testing

I confirmed using our handy dandy [`tmp-api-tsup-sandbox`](https://github.com/readmeio/tmp-api-tsup-sandbox) that I can run CJS code once again.
