### PR TITLE
feat(api): exposing `openapi.json` to codegen'd `package.json` files

### DIFF
--- a/packages/api/src/codegen/languages/typescript/index.ts
+++ b/packages/api/src/codegen/languages/typescript/index.ts
@@ -483,7 +483,7 @@ sdk.server('https://eu.api.example.com/v14');`),
             }
           : {}),
       },
-      files: ['dist'],
+      files: ['dist', 'openapi.json'],
       scripts: {
         prepare: 'tsup',
       },

--- a/packages/test-utils/sdks/alby/package.json
+++ b/packages/test-utils/sdks/alby/package.json
@@ -15,7 +15,8 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "openapi.json"
   ],
   "scripts": {
     "prepare": "tsup"

--- a/packages/test-utils/sdks/metrotransit/package.json
+++ b/packages/test-utils/sdks/metrotransit/package.json
@@ -15,7 +15,8 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "openapi.json"
   ],
   "scripts": {
     "prepare": "tsup"

--- a/packages/test-utils/sdks/operationid-quirks/package.json
+++ b/packages/test-utils/sdks/operationid-quirks/package.json
@@ -11,7 +11,8 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "openapi.json"
   ],
   "scripts": {
     "prepare": "tsup"

--- a/packages/test-utils/sdks/optional-payload/package.json
+++ b/packages/test-utils/sdks/optional-payload/package.json
@@ -15,7 +15,8 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "openapi.json"
   ],
   "scripts": {
     "prepare": "tsup"

--- a/packages/test-utils/sdks/petstore/package.json
+++ b/packages/test-utils/sdks/petstore/package.json
@@ -15,7 +15,8 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "openapi.json"
   ],
   "scripts": {
     "prepare": "tsup"

--- a/packages/test-utils/sdks/readme/package.json
+++ b/packages/test-utils/sdks/readme/package.json
@@ -15,7 +15,8 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "openapi.json"
   ],
   "scripts": {
     "prepare": "tsup"

--- a/packages/test-utils/sdks/response-title-quirks/package.json
+++ b/packages/test-utils/sdks/response-title-quirks/package.json
@@ -15,7 +15,8 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "openapi.json"
   ],
   "scripts": {
     "prepare": "tsup"

--- a/packages/test-utils/sdks/simple/package.json
+++ b/packages/test-utils/sdks/simple/package.json
@@ -15,7 +15,8 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "openapi.json"
   ],
   "scripts": {
     "prepare": "tsup"

--- a/packages/test-utils/sdks/star-trek/package.json
+++ b/packages/test-utils/sdks/star-trek/package.json
@@ -15,7 +15,8 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "openapi.json"
   ],
   "scripts": {
     "prepare": "tsup"


### PR DESCRIPTION
| 🚥 Resolves RM-8187 |
| :------------------- |

## 🧰 Changes

For users who want to publish codegen'd SDKs to NPM I've added the `openapi.json` file that we add into them into the `files` array in `package.json`.