### PR TITLE
feat(api): adding a `$schema` property to generated `api.json` lockfiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.api/
 dist/
 node_modules/
 **/*.tsbuildinfo

--- a/package-lock.json
+++ b/package-lock.json
@@ -22737,6 +22737,7 @@
         "@types/uslug": "^1.0.2",
         "@types/validate-npm-package-name": "^4.0.0",
         "@vitest/coverage-v8": "^0.34.4",
+        "ajv": "^8.12.0",
         "fetch-mock": "^9.11.0",
         "oas-normalize": "^11.0.1",
         "tsup": "^7.2.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -31,6 +31,10 @@
   "engines": {
     "node": ">=18"
   },
+  "files": [
+    "dist",
+    "schema.json"
+  ],
   "keywords": [
     "api",
     "openapi",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -76,6 +76,7 @@
     "@types/uslug": "^1.0.2",
     "@types/validate-npm-package-name": "^4.0.0",
     "@vitest/coverage-v8": "^0.34.4",
+    "ajv": "^8.12.0",
     "fetch-mock": "^9.11.0",
     "oas-normalize": "^11.0.1",
     "tsup": "^7.2.0",

--- a/packages/api/schema.json
+++ b/packages/api/schema.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "api storage lockfile",
+  "description": "See https://api.readme.dev/docs",
+  "type": "object",
+  "required": ["apis", "version"],
+  "properties": {
+    "apis": {
+      "type": "array",
+      "description": "The list of installed APIs",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/api"
+      }
+    },
+    "version": {
+      "type": "string",
+      "description": "The current `api.json` schema version."
+    }
+  },
+  "definitions": {
+    "api": {
+      "type": "object",
+      "required": ["identifier", "installerVersion", "integrity"],
+      "properties": {
+        "identifier": {
+          "type": "string",
+          "description": "A unique identifier of the API. This'll be used to do imports on `@api/<identifier>` and also where the SDK code will be located in `.api/apis/<identifier>`",
+          "examples": ["petstore"]
+        },
+        "installerVersion": {
+          "type": "string",
+          "description": "The version of `api` that was used to install this SDK.",
+          "examples": ["7.0.0"]
+        },
+        "integrity": {
+          "type": "string",
+          "description": "An integrity hash that will be used to determine on `npx api update` calls if the API has changed since the SDK was last generated.",
+          "examples": [
+            "sha512-ld+djZk8uRWmzXC+JYla1PTBScg0NjP/8x9vOOKRW+DuJ3NNMRjrpfbY7T77Jgnc87dZZsU49robbQfYe3ukug=="
+          ]
+        },
+        "source": {
+          "type": "string",
+          "description": "The original source that was used to generate the SDK with.",
+          "examples": [
+            "https://raw.githubusercontent.com/readmeio/oas-examples/main/3.0/json/petstore-simple.json",
+            "./petstore.json",
+            "@developers/v2.0#nysezql0wwo236"
+          ]
+        }
+      }
+    }
+  },
+  "unevaluatedProperties": false
+}

--- a/packages/api/schema.json
+++ b/packages/api/schema.json
@@ -8,7 +8,6 @@
     "apis": {
       "type": "array",
       "description": "The list of installed APIs",
-      "minItems": 1,
       "items": {
         "$ref": "#/definitions/api"
       }
@@ -51,6 +50,5 @@
         }
       }
     }
-  },
-  "unevaluatedProperties": false
+  }
 }

--- a/packages/api/src/storage.ts
+++ b/packages/api/src/storage.ts
@@ -3,6 +3,7 @@ import type { OASDocument } from 'oas/rmoas.types';
 import fs from 'node:fs';
 import path from 'node:path';
 
+import semver from 'semver';
 import ssri from 'ssri';
 import validateNPMPackageName from 'validate-npm-package-name';
 
@@ -79,7 +80,10 @@ export default class Storage {
   }
 
   static getDefaultLockfile(): Lockfile {
+    const majorVersion = semver.parse(PACKAGE_VERSION)?.major || 'latest';
+
     return {
+      $schema: `https://unpkg.com/api@${majorVersion}/schema.json`,
       version: '1.0',
       apis: [],
     };
@@ -288,7 +292,15 @@ export default class Storage {
   }
 }
 
+/**
+ * @see schema.json
+ */
 interface Lockfile {
+  $schema: string;
+
+  /**
+   * The list of installed APIs.
+   */
   apis: LockfileAPI[];
 
   /**
@@ -298,9 +310,12 @@ interface Lockfile {
   version: '1.0';
 }
 
+/**
+ * @see schema.json
+ */
 interface LockfileAPI {
   /**
-   * A unique identifier of the API. This'll be used to do requires on `@api/<identifier>` and also
+   * A unique identifier of the API. This'll be used to do imports on `@api/<identifier>` and also
    * where the SDK code will be located in `.api/apis/<identifier>`.
    *
    * @example petstore


### PR DESCRIPTION
| 🚥 Resolves RM-8186 |
| :------------------- |

## 🧰 Changes

This adds a new `$schema` property to the `api.json` lockfiles we generate when installing an API.

## 🧬 QA & Testing

Here it is validating:

![Screen Shot 2023-10-19 at 11 54 17 AM](https://github.com/readmeio/api/assets/33762/138a1183-b171-4495-8712-25beb165ac8f)

And what it looks like after instaling an API[^1]:

![Screen Shot 2023-10-19 at 12 04 11 PM](https://github.com/readmeio/api/assets/33762/cf1a3a39-4892-4e29-947e-3805f280dc34)