### PR TITLE
feat(api): creation of a new `list` command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4724,6 +4724,23 @@
         }
       }
     },
+    "node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/alex": {
       "version": "11.0.1",
       "resolved": "https://registry.npmjs.org/alex/-/alex-11.0.1.tgz",
@@ -22738,6 +22755,7 @@
         "@types/validate-npm-package-name": "^4.0.0",
         "@vitest/coverage-v8": "^0.34.4",
         "ajv": "^8.12.0",
+        "ajv-formats": "^2.1.1",
         "fetch-mock": "^9.11.0",
         "oas-normalize": "^11.0.1",
         "tsup": "^7.2.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -77,6 +77,7 @@
     "@types/validate-npm-package-name": "^4.0.0",
     "@vitest/coverage-v8": "^0.34.4",
     "ajv": "^8.12.0",
+    "ajv-formats": "^2.1.1",
     "fetch-mock": "^9.11.0",
     "oas-normalize": "^11.0.1",
     "tsup": "^7.2.0",

--- a/packages/api/schema.json
+++ b/packages/api/schema.json
@@ -3,18 +3,18 @@
   "title": "api storage lockfile",
   "description": "See https://api.readme.dev/docs",
   "type": "object",
-  "required": ["apis", "version"],
+  "required": ["apis"],
+  "additionalProperties": false,
   "properties": {
+    "$schema": {
+      "type": "string"
+    },
     "apis": {
       "type": "array",
       "description": "The list of installed APIs",
       "items": {
         "$ref": "#/definitions/api"
       }
-    },
-    "version": {
-      "type": "string",
-      "description": "The current `api.json` schema version."
     }
   },
   "definitions": {

--- a/packages/api/schema.json
+++ b/packages/api/schema.json
@@ -20,8 +20,14 @@
   "definitions": {
     "api": {
       "type": "object",
-      "required": ["identifier", "installerVersion", "integrity"],
+      "required": ["createdAt", "identifier", "installerVersion", "integrity"],
       "properties": {
+        "createdAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date that this SDK was installed.",
+          "examples": ["2023-10-19T20:35:39.268Z"]
+        },
         "identifier": {
           "type": "string",
           "description": "A unique identifier of the API. This'll be used to do imports on `@api/<identifier>` and also where the SDK code will be located in `.api/apis/<identifier>`",
@@ -39,6 +45,10 @@
             "sha512-ld+djZk8uRWmzXC+JYla1PTBScg0NjP/8x9vOOKRW+DuJ3NNMRjrpfbY7T77Jgnc87dZZsU49robbQfYe3ukug=="
           ]
         },
+        "private": {
+          "type": "boolean",
+          "description": "Was this SDK installed as a private, unpublished, package to the filesystem?"
+        },
         "source": {
           "type": "string",
           "description": "The original source that was used to generate the SDK with.",
@@ -47,6 +57,12 @@
             "./petstore.json",
             "@developers/v2.0#nysezql0wwo236"
           ]
+        },
+        "updatedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date that this SDK was last rebuilt or updated.",
+          "examples": ["2023-10-19T20:35:39.268Z"]
         }
       }
     }

--- a/packages/api/src/commands/index.ts
+++ b/packages/api/src/commands/index.ts
@@ -1,5 +1,7 @@
 import installCommand from './install.js';
+import listCommand from './list.js';
 
 export default {
   install: installCommand,
+  list: listCommand,
 };

--- a/packages/api/src/commands/list.ts
+++ b/packages/api/src/commands/list.ts
@@ -32,7 +32,7 @@ cmd
 
       logger(`source: ${chalk.grey(api.source)}`);
       logger(`installer version: ${chalk.grey(api.installerVersion)}`);
-      logger(`created at: ${chalk.grey(api.createdAt)}`);
+      logger(`created at: ${chalk.grey(api.createdAt || 'n/a')}`);
       if (api.updatedAt) {
         logger(`updated at: ${chalk.grey(api.updatedAt)}`);
       }

--- a/packages/api/src/commands/list.ts
+++ b/packages/api/src/commands/list.ts
@@ -34,7 +34,7 @@ cmd
       logger(`installer version: ${chalk.grey(api.installerVersion)}`);
       logger(`created at: ${chalk.grey(api.createdAt)}`);
       if (api.updatedAt) {
-        logger(`updated at: ${chalk.grey(api.createdAt)}`);
+        logger(`updated at: ${chalk.grey(api.updatedAt)}`);
       }
     });
   });

--- a/packages/api/src/commands/list.ts
+++ b/packages/api/src/commands/list.ts
@@ -16,7 +16,7 @@ cmd
     const lockfile = Storage.getLockfile();
 
     if (!lockfile.apis.length) {
-      logger('😔 You do not have any API SDKs installed.');
+      logger('😔 You do not have any SDKs installed.');
       return;
     }
 

--- a/packages/api/src/commands/list.ts
+++ b/packages/api/src/commands/list.ts
@@ -1,0 +1,42 @@
+import chalk from 'chalk';
+import { Command } from 'commander';
+
+import logger from '../logger.js';
+import Storage from '../storage.js';
+
+const cmd = new Command();
+cmd
+  .name('list')
+  .alias('ls')
+  .description('list any installed API SDKs')
+  .action(async () => {
+    // We need to preload the storage system so we can grab the lockfile.
+    Storage.setStorageDir();
+
+    const lockfile = Storage.getLockfile();
+
+    if (!lockfile.apis.length) {
+      logger('😔 You do not have any API SDKs installed.');
+      return;
+    }
+
+    lockfile.apis.forEach((api, i) => {
+      if (i > 0) {
+        logger('');
+      }
+
+      logger(chalk.yellow.underline(api.identifier));
+      if (api.private) {
+        logger(`package name (${chalk.red('private')}): ${chalk.grey(`@api/${api.identifier}`)}`);
+      }
+
+      logger(`source: ${chalk.grey(api.source)}`);
+      logger(`installer version: ${chalk.grey(api.installerVersion)}`);
+      logger(`created at: ${chalk.grey(api.createdAt)}`);
+      if (api.updatedAt) {
+        logger(`updated at: ${chalk.grey(api.createdAt)}`);
+      }
+    });
+  });
+
+export default cmd;

--- a/packages/api/src/storage.ts
+++ b/packages/api/src/storage.ts
@@ -84,7 +84,6 @@ export default class Storage {
 
     return {
       $schema: `https://unpkg.com/api@${majorVersion}/schema.json`,
-      version: '1.0',
       apis: [],
     };
   }
@@ -298,18 +297,15 @@ export default class Storage {
  * @see schema.json
  */
 interface Lockfile {
+  /**
+   * @since `Lockfile.version: 2.0`
+   */
   $schema: string;
 
   /**
    * The list of installed APIs.
    */
   apis: LockfileAPI[];
-
-  /**
-   * The `api.json` schema version. This will only ever change if we introduce breaking changes to
-   * this store.
-   */
-  version: '1.0';
 }
 
 /**
@@ -319,6 +315,7 @@ interface LockfileAPI {
   /**
    * The date that this SDK was installed.
    *
+   * @since 7.0
    * @example 2023-10-19T20:35:39.268Z
    */
   createdAt: string;
@@ -349,6 +346,7 @@ interface LockfileAPI {
   /**
    * Was this SDK installed as a private, unpublished, package to the filesystem?
    *
+   * @since 7.0
    */
   private?: boolean;
 
@@ -364,6 +362,7 @@ interface LockfileAPI {
   /**
    * The date that this SDK was last rebuilt or updated.
    *
+   * @since 7.0
    * @example 2023-10-19T20:35:39.268Z
    */
   updatedAt?: string;

--- a/packages/api/src/storage.ts
+++ b/packages/api/src/storage.ts
@@ -276,10 +276,12 @@ export default class Storage {
       }
 
       (Storage.lockfile as Lockfile).apis.push({
+        private: true,
         identifier: this.identifier,
         source: this.source,
         integrity: Storage.generateIntegrityHash(spec),
         installerVersion: PACKAGE_VERSION,
+        createdAt: new Date().toISOString(),
       } as LockfileAPI);
 
       fs.writeFileSync(path.join(identifierStorageDir, 'openapi.json'), saved);
@@ -315,6 +317,13 @@ interface Lockfile {
  */
 interface LockfileAPI {
   /**
+   * The date that this SDK was installed.
+   *
+   * @example 2023-10-19T20:35:39.268Z
+   */
+  createdAt: string;
+
+  /**
    * A unique identifier of the API. This'll be used to do imports on `@api/<identifier>` and also
    * where the SDK code will be located in `.api/apis/<identifier>`.
    *
@@ -338,6 +347,12 @@ interface LockfileAPI {
   integrity: string;
 
   /**
+   * Was this SDK installed as a private, unpublished, package to the filesystem?
+   *
+   */
+  private?: boolean;
+
+  /**
    * The original source that was used to generate the SDK with.
    *
    * @example https://raw.githubusercontent.com/readmeio/oas-examples/main/3.0/json/petstore-simple.json
@@ -345,4 +360,11 @@ interface LockfileAPI {
    * @example @developers/v2.0#nysezql0wwo236
    */
   source: string;
+
+  /**
+   * The date that this SDK was last rebuilt or updated.
+   *
+   * @example 2023-10-19T20:35:39.268Z
+   */
+  updatedAt?: string;
 }

--- a/packages/api/test/storage.test.ts
+++ b/packages/api/test/storage.test.ts
@@ -6,6 +6,7 @@ import path from 'node:path';
 
 import { loadSpec } from '@api/test-utils';
 import Ajv from 'ajv';
+import addFormats from 'ajv-formats';
 import fetchMock from 'fetch-mock';
 import uniqueTempDir from 'unique-temp-dir';
 import { describe, beforeAll, beforeEach, afterEach, it, expect } from 'vitest';
@@ -109,6 +110,8 @@ describe('storage', () => {
       // `ajv` has funky types in ESM environments. https://github.com/ajv-validator/ajv/issues/2047
       // eslint-disable-next-line new-cap
       const ajv = new Ajv.default();
+      addFormats.default(ajv);
+
       const source = '@petstore/v1.0#n6kvf10vakpemvplx';
       const storage = new Storage(source, 'petstore');
 
@@ -120,6 +123,7 @@ describe('storage', () => {
       await storage.load();
 
       valid = ajv.validate(lockfileSchema, Storage.getLockfile());
+      expect(ajv.errors).toBeNull();
       expect(valid).toBe(true);
     });
   });
@@ -136,10 +140,12 @@ describe('storage', () => {
       await storage.load();
 
       expect(Storage.isInLockFile({ source })).toStrictEqual({
+        private: true,
         identifier: 'petstore',
         source,
         integrity: 'sha512-otRF5TLMeDczSJlrmWLNDHLfmXg+C98oa/I/X2WWycwngh+a6WsbnjTbfwKGRU5DFbagOn2qX2SRvtBGOBRVGg==',
         installerVersion: PACKAGE_VERSION,
+        createdAt: expect.any(String),
       });
     });
 
@@ -154,10 +160,12 @@ describe('storage', () => {
       await storage.load();
 
       expect(Storage.isInLockFile({ identifier: 'petstore' })).toStrictEqual({
+        private: true,
         identifier: 'petstore',
         source,
         integrity: 'sha512-otRF5TLMeDczSJlrmWLNDHLfmXg+C98oa/I/X2WWycwngh+a6WsbnjTbfwKGRU5DFbagOn2qX2SRvtBGOBRVGg==',
         installerVersion: PACKAGE_VERSION,
+        createdAt: expect.any(String),
       });
     });
   });
@@ -195,10 +203,12 @@ describe('storage', () => {
 
         expect(storage.isInLockfile()).toBe(true);
         expect(storage.getFromLockfile()).toStrictEqual({
+          private: true,
           identifier: 'petstore',
           source: '@petstore/v1.0#n6kvf10vakpemvplx',
           integrity: 'sha512-otRF5TLMeDczSJlrmWLNDHLfmXg+C98oa/I/X2WWycwngh+a6WsbnjTbfwKGRU5DFbagOn2qX2SRvtBGOBRVGg==',
           installerVersion: PACKAGE_VERSION,
+          createdAt: expect.any(String),
         });
       });
 
@@ -229,10 +239,12 @@ describe('storage', () => {
 
         expect(storage.isInLockfile()).toBe(true);
         expect(storage.getFromLockfile()).toStrictEqual({
+          private: true,
           identifier: 'petstore',
           source: '@petstore#n6kvf10vakpemvplx',
           integrity: 'sha512-otRF5TLMeDczSJlrmWLNDHLfmXg+C98oa/I/X2WWycwngh+a6WsbnjTbfwKGRU5DFbagOn2qX2SRvtBGOBRVGg==',
           installerVersion: PACKAGE_VERSION,
+          createdAt: expect.any(String),
         });
       });
 
@@ -269,10 +281,12 @@ describe('storage', () => {
 
         expect(storage.isInLockfile()).toBe(true);
         expect(storage.getFromLockfile()).toStrictEqual({
+          private: true,
           identifier: 'petstore',
           source: 'http://example.com/readme.json',
           integrity: 'sha512-otRF5TLMeDczSJlrmWLNDHLfmXg+C98oa/I/X2WWycwngh+a6WsbnjTbfwKGRU5DFbagOn2qX2SRvtBGOBRVGg==',
           installerVersion: PACKAGE_VERSION,
+          createdAt: expect.any(String),
         });
       });
 
@@ -297,10 +311,12 @@ describe('storage', () => {
         expect(storage.getAPIDefinition().paths['/api-specification'].get.parameters).toBeDereferenced();
         expect(storage.isInLockfile()).toBe(true);
         expect(storage.getFromLockfile()).toStrictEqual({
+          private: true,
           identifier: 'readme-yaml',
           source: 'http://example.com/readme.yaml',
           integrity: 'sha512-rcaq4j4BzMyR9n3kLRTDLbOg37QdNywj2e3whoK/J/6PNlHrLATvysfJVHq+kMBf+gkukUwxayCwbN0wZj8ysg==',
           installerVersion: PACKAGE_VERSION,
+          createdAt: expect.any(String),
         });
       });
     });
@@ -317,10 +333,12 @@ describe('storage', () => {
         expect(storage.getAPIDefinition().paths['/api-specification'].get.parameters).toBeDereferenced();
         expect(storage.isInLockfile()).toBe(true);
         expect(storage.getFromLockfile()).toStrictEqual({
+          private: true,
           identifier: 'readme',
           source: file,
           integrity: 'sha512-rcaq4j4BzMyR9n3kLRTDLbOg37QdNywj2e3whoK/J/6PNlHrLATvysfJVHq+kMBf+gkukUwxayCwbN0wZj8ysg==',
           installerVersion: PACKAGE_VERSION,
+          createdAt: expect.any(String),
         });
       });
 
@@ -339,10 +357,12 @@ describe('storage', () => {
         });
 
         expect(storage.getFromLockfile()).toStrictEqual({
+          private: true,
           identifier: 'relative-path',
           source: file,
           integrity: 'sha512-Ey83iRY4tY7JCCUI03eqfNb8YsxKlBdLILXcLDBbxZ1a2X/YfTspCTA8mLp6aaG9gRSyNMhI1hmtSlduWZw8RA==',
           installerVersion: PACKAGE_VERSION,
+          createdAt: expect.any(String),
         });
       });
 
@@ -357,10 +377,12 @@ describe('storage', () => {
         expect(storage.getAPIDefinition().paths['/api-specification'].get.parameters).toBeDereferenced();
         expect(storage.isInLockfile()).toBe(true);
         expect(storage.getFromLockfile()).toStrictEqual({
+          private: true,
           identifier: 'readme-yaml',
           source: file,
           integrity: 'sha512-rcaq4j4BzMyR9n3kLRTDLbOg37QdNywj2e3whoK/J/6PNlHrLATvysfJVHq+kMBf+gkukUwxayCwbN0wZj8ysg==',
           installerVersion: PACKAGE_VERSION,
+          createdAt: expect.any(String),
         });
       });
     });
@@ -389,10 +411,12 @@ describe('storage', () => {
 
       expect(storage.isInLockfile()).toBe(true);
       expect(storage.getFromLockfile()).toStrictEqual({
+        private: true,
         identifier: 'petstore-simple',
         source: file,
         integrity: 'sha512-otRF5TLMeDczSJlrmWLNDHLfmXg+C98oa/I/X2WWycwngh+a6WsbnjTbfwKGRU5DFbagOn2qX2SRvtBGOBRVGg==',
         installerVersion: PACKAGE_VERSION,
+        createdAt: expect.any(String),
       });
     });
 
@@ -406,10 +430,12 @@ describe('storage', () => {
 
       expect(storage.isInLockfile()).toBe(true);
       expect(storage.getFromLockfile()).toStrictEqual({
+        private: true,
         identifier: 'circular',
         source: file,
         integrity: 'sha512-bxLv3OTzVucsauZih1VCprHQ7/e0iB/yzeuWdp1E1iq8o3MOYFAig+aMUkTqD71BNf/1/6B7NTkyjJXfrXgumA==',
         installerVersion: PACKAGE_VERSION,
+        createdAt: expect.any(String),
       });
     });
 
@@ -423,10 +449,12 @@ describe('storage', () => {
 
       expect(storage.isInLockfile()).toBe(true);
       expect(storage.getFromLockfile()).toStrictEqual({
+        private: true,
         identifier: 'petstore',
         source: file,
         integrity: 'sha512-P1xkfSiktRFJUZdN90JslLk8FOecNZFypZOnDqh/Xcgw69iiO17dHXwaV6ENqnYGwxd1t4hwXpaXq/4V5AY3NQ==',
         installerVersion: PACKAGE_VERSION,
+        createdAt: expect.any(String),
       });
     });
   });


### PR DESCRIPTION
| 🚥 Resolves RM-4124 |
| :------------------- |

## 🧰 Changes

This introduces a new `list` command for listing out any API SDKs that you may have installed.

```
Usage: api list|ls [options]

list any installed API SDKs

Options:
  -h, --help  display help for command
```

Additionally I've also added a couple new things into the lockfile:

* [x] `private`: We'll use this later in an NPM publishing flow but this'll tell us (and the user) that when they ran `npx api install <uri>` they chose to not publish it and only install it as a private package.
* [x] `createdAt`: ISO date for everyone to know when an API SDK was originally generated + installed.
* [x] `updatedAt`: Currently unused but this will be factored into the coming `rebuild` command and will keep track of when an API SDK was regenerated or otherwise updated.

We're also removing `version` from the lockfile in favor of the recently added `$schema` property. Having two versioned fields in the lockfile felt like too much complexity.

Here's what it all looks like:

![Screen Shot 2023-10-19 at 1 55 17 PM](https://github.com/readmeio/api/assets/33762/d6e75c45-47d6-4233-97fd-4a70fddb8b27)

And if you don't have any APIs installed:

![Screen Shot 2023-10-19 at 1 55 27 PM](https://github.com/readmeio/api/assets/33762/03d62506-0be8-4e34-8a7e-f1d3a2649827)