### PR TITLE
fix: add caret to package.json dep

### DIFF
--- a/packages/api/src/codegen/languages/typescript/index.ts
+++ b/packages/api/src/codegen/languages/typescript/index.ts
@@ -95,7 +95,7 @@ export default class TSGenerator extends CodeGenerator {
           process.env.NODE_ENV === 'test'
             ? // eslint-disable-next-line unicorn/prefer-module
               `file:${path.relative(__dirname, path.dirname(require.resolve('@readme/api-core/package.json')))}`
-            : corePkg.version,
+            : `^${corePkg.version}`,
       },
       tsup: {
         dependencyType: 'development',


### PR DESCRIPTION
## 🧰 Changes

We should presumably make it this:

```json
"@readme/api-core": "^7.0.0-beta.0"
```

instead of this:

```json
"@readme/api-core": "7.0.0-beta.0"
```
