### PR TITLE
fix(core): funky type issues with the main export exporting multiple things

### DIFF
--- a/packages/api/src/codegen/languages/typescript/index.ts
+++ b/packages/api/src/codegen/languages/typescript/index.ts
@@ -236,7 +236,7 @@ export default class TSGenerator extends CodeGenerator {
       sdkSource
         .getImportDeclarations()
         .find(id => id.getText().includes('HTTPMethodRange'))
-        ?.replaceWithText("import type { ConfigOptions, FetchResponse } from '@readme/api-core';");
+        ?.replaceWithText("import type { ConfigOptions, FetchResponse } from '@readme/api-core/types';");
     }
 
     return [

--- a/packages/api/src/codegen/languages/typescript/index.ts
+++ b/packages/api/src/codegen/languages/typescript/index.ts
@@ -279,7 +279,7 @@ export default class TSGenerator extends CodeGenerator {
       {
         // `HTTPMethodRange` will be conditionally removed later if it ends up not being used.
         defaultImport: 'type { ConfigOptions, FetchResponse, HTTPMethodRange }',
-        moduleSpecifier: '@readme/api-core',
+        moduleSpecifier: '@readme/api-core/types',
       },
       { defaultImport: 'APICore', moduleSpecifier: '@readme/api-core' },
       { defaultImport: 'definition', moduleSpecifier: this.specPath },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,6 +17,10 @@
       "require": "./dist/lib/index.cjs",
       "import": "./dist/lib/index.js"
     },
+    "./types": {
+      "require": "./dist/types.d.cts",
+      "import": "./dist/types.d.ts"
+    },
     "./package.json": "./package.json"
   },
   "main": "dist/index.cjs",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,8 +18,8 @@
       "import": "./dist/lib/index.js"
     },
     "./types": {
-      "require": "./dist/types.d.cts",
-      "import": "./dist/types.d.ts"
+      "require": "./dist/types.d.cjs",
+      "import": "./dist/types.d.js"
     },
     "./package.json": "./package.json"
   },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,4 @@
+import type { ConfigOptions } from './types.js';
 import type { Har } from 'har-format';
 import type Operation from 'oas/operation';
 import type { HttpMethods, OASDocument } from 'oas/rmoas.types';
@@ -8,28 +9,6 @@ import Oas from 'oas';
 
 import FetchError from './errors/fetchError.js';
 import { parseResponse, prepareAuth, prepareParams, prepareServer } from './lib/index.js';
-
-export interface ConfigOptions {
-  /**
-   * Override the default `fetch` request timeout of 30 seconds. This number should be represented
-   * in milliseconds.
-   */
-  timeout?: number;
-}
-
-export interface FetchResponse<HTTPStatus, Data> {
-  data: Data;
-  headers: Headers;
-  res: Response;
-  status: HTTPStatus;
-}
-
-// https://stackoverflow.com/a/39495173
-type Enumerate<N extends number, Acc extends number[] = []> = Acc['length'] extends N
-  ? Acc[number]
-  : Enumerate<N, [...Acc, Acc['length']]>;
-
-export type HTTPMethodRange<F extends number, T extends number> = Exclude<Enumerate<T>, Enumerate<F>>;
 
 export default class APICore {
   spec!: Oas;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,0 +1,23 @@
+export interface ConfigOptions {
+  /**
+   * Override the default `fetch` request timeout of 30 seconds. This number should be represented
+   * in milliseconds.
+   */
+  timeout?: number;
+}
+
+/**
+ * @see {@link https://stackoverflow.com/a/39495173}
+ */
+type Enumerate<N extends number, Acc extends number[] = []> = Acc['length'] extends N
+  ? Acc[number]
+  : Enumerate<N, [...Acc, Acc['length']]>;
+
+export type HTTPMethodRange<F extends number, T extends number> = Exclude<Enumerate<T>, Enumerate<F>>;
+
+export interface FetchResponse<HTTPStatus, Data> {
+  data: Data;
+  headers: Headers;
+  res: Response;
+  status: HTTPStatus;
+}

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -10,7 +10,7 @@ export default defineConfig((options: Options) => ({
   ...options,
   ...config,
 
-  entry: ['src/errors/fetchError.ts', 'src/lib/index.ts', 'src/index.ts'],
+  entry: ['src/errors/fetchError.ts', 'src/lib/index.ts', 'src/index.ts', 'src/types.ts'],
   noExternal: [
     // `get-stream` is ESM-only and we need to build for CommonJS,
     // so including it here means that its (tree-shaken!) source code

--- a/packages/test-utils/sdks/alby/src/index.ts
+++ b/packages/test-utils/sdks/alby/src/index.ts
@@ -1,5 +1,5 @@
 import type * as types from './types';
-import type { ConfigOptions, FetchResponse } from '@readme/api-core';
+import type { ConfigOptions, FetchResponse } from '@readme/api-core/types';
 import APICore from '@readme/api-core';
 import definition from '@api/test-utils/definitions/alby.json';
 

--- a/packages/test-utils/sdks/metrotransit/src/index.ts
+++ b/packages/test-utils/sdks/metrotransit/src/index.ts
@@ -1,5 +1,5 @@
 import type * as types from './types';
-import type { ConfigOptions, FetchResponse } from '@readme/api-core';
+import type { ConfigOptions, FetchResponse } from '@readme/api-core/types';
 import APICore from '@readme/api-core';
 import definition from '@api/test-utils/definitions/metrotransit.json';
 

--- a/packages/test-utils/sdks/operationid-quirks/src/index.ts
+++ b/packages/test-utils/sdks/operationid-quirks/src/index.ts
@@ -1,4 +1,4 @@
-import type { ConfigOptions, FetchResponse } from '@readme/api-core';
+import type { ConfigOptions, FetchResponse } from '@readme/api-core/types';
 import APICore from '@readme/api-core';
 import definition from '@api/test-utils/definitions/operationid-quirks.json';
 

--- a/packages/test-utils/sdks/optional-payload/src/index.ts
+++ b/packages/test-utils/sdks/optional-payload/src/index.ts
@@ -1,5 +1,5 @@
 import type * as types from './types';
-import type { ConfigOptions, FetchResponse } from '@readme/api-core';
+import type { ConfigOptions, FetchResponse } from '@readme/api-core/types';
 import APICore from '@readme/api-core';
 import definition from '@api/test-utils/definitions/optional-payload.json';
 

--- a/packages/test-utils/sdks/petstore/src/index.ts
+++ b/packages/test-utils/sdks/petstore/src/index.ts
@@ -1,5 +1,5 @@
 import type * as types from './types';
-import type { ConfigOptions, FetchResponse } from '@readme/api-core';
+import type { ConfigOptions, FetchResponse } from '@readme/api-core/types';
 import APICore from '@readme/api-core';
 import definition from '@readme/oas-examples/3.0/json/petstore.json';
 

--- a/packages/test-utils/sdks/readme/src/index.ts
+++ b/packages/test-utils/sdks/readme/src/index.ts
@@ -1,5 +1,5 @@
 import type * as types from './types';
-import type { ConfigOptions, FetchResponse } from '@readme/api-core';
+import type { ConfigOptions, FetchResponse } from '@readme/api-core/types';
 import APICore from '@readme/api-core';
 import definition from '@readme/oas-examples/3.0/json/readme.json';
 

--- a/packages/test-utils/sdks/response-title-quirks/src/index.ts
+++ b/packages/test-utils/sdks/response-title-quirks/src/index.ts
@@ -1,5 +1,5 @@
 import type * as types from './types';
-import type { ConfigOptions, FetchResponse, HTTPMethodRange } from '@readme/api-core';
+import type { ConfigOptions, FetchResponse, HTTPMethodRange } from '@readme/api-core/types';
 import APICore from '@readme/api-core';
 import definition from '@api/test-utils/definitions/response-title-quirks.json';
 

--- a/packages/test-utils/sdks/simple/src/index.ts
+++ b/packages/test-utils/sdks/simple/src/index.ts
@@ -1,5 +1,5 @@
 import type * as types from './types';
-import type { ConfigOptions, FetchResponse } from '@readme/api-core';
+import type { ConfigOptions, FetchResponse } from '@readme/api-core/types';
 import APICore from '@readme/api-core';
 import definition from '@api/test-utils/definitions/simple.json';
 

--- a/packages/test-utils/sdks/star-trek/src/index.ts
+++ b/packages/test-utils/sdks/star-trek/src/index.ts
@@ -1,5 +1,5 @@
 import type * as types from './types';
-import type { ConfigOptions, FetchResponse } from '@readme/api-core';
+import type { ConfigOptions, FetchResponse } from '@readme/api-core/types';
 import APICore from '@readme/api-core';
 import definition from '@readme/oas-examples/3.0/json/star-trek.json';
 


### PR DESCRIPTION
## 🧰 Changes

We've got a weird issue in the `api@next` dist where the `json-schema-to-ts` refactor I did in https://github.com/readmeio/api/pull/764 is mucking up some types. I'm not totally sure why!

`.cjs`, `.mts`, and `.ts` generated SDK:

![cleanshot_2023-10-20_at_15 12 36_2x_360](https://github.com/readmeio/api/assets/33762/b4e92751-e6b6-4deb-b6d8-a0bece40ebe6)

However a `.mjs` and `.js` file have the types completely different:

![cleanshot_2023-10-20_at_15 13 14_2x](https://github.com/readmeio/api/assets/33762/487778ac-4309-4f63-b58d-0b380366ad04)

While debugging why this was happening I noticed that `attw` was reporting that the types for `core` were all messed up:

![before](https://github.com/readmeio/api/assets/33762/e10353b4-5b64-4251-b041-04ad1eb3ee4d)

After refactoring `ConfigOptions`, `FetchResponse` and `HTTPMethodRange` types into a new `@readme/api-core/types` file `attw` is now happy:

![after](https://github.com/readmeio/api/assets/33762/58745fc4-2ea9-4591-b1d1-629c06472580)