### PR TITLE
feat(api): improvements to the installation screen

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3535,25 +3535,26 @@
       "dev": true
     },
     "node_modules/@readme/oas-extensions": {
-      "version": "20.0.5",
-      "resolved": "https://registry.npmjs.org/@readme/oas-extensions/-/oas-extensions-20.0.5.tgz",
-      "integrity": "sha512-U+PIo658pvOXz7ti5wyV6zAZB0IU0rUfaqLPTPxC1xssy1eE6v0xC9e3vBmh4c8WaglHTN3kHrM4SfBkyUchFA==",
+      "version": "20.0.6",
+      "resolved": "https://registry.npmjs.org/@readme/oas-extensions/-/oas-extensions-20.0.6.tgz",
+      "integrity": "sha512-iJBcXb3NU+eunjl/U9Q/aKmrODAeesCvdCFPN4qVyUC31bMHPIlKW2WUNyc0itKfZW5M+uuUX+8wOGUgJoMy5Q==",
       "dependencies": {
-        "oas": "^23.0.1"
+        "oas": "^23.0.2"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@readme/oas-to-har": {
-      "version": "23.0.13",
-      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-23.0.13.tgz",
-      "integrity": "sha512-0ADQjN9MP8jGQAWC62Vy1DKKl3zoCdwrg4EZlUnrYTihSn/4WHEqqoKQnigBowyWfPOAhZUUiqRkUjbit512rg==",
+      "version": "23.0.14",
+      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-23.0.14.tgz",
+      "integrity": "sha512-EPlAi4RXSFh5U0RbECT2tofX0aI9ytQly4hiy5DRn+3P95SluFmE96jItdAoV8RP7Xru2XJeh180vl+kjugvNQ==",
       "dependencies": {
         "@readme/data-urls": "^3.0.0",
-        "@readme/oas-extensions": "^20.0.5",
-        "lodash": "^4.17.21",
-        "oas": "^23.0.1",
+        "@readme/oas-extensions": "^20.0.6",
+        "lodash.get": "^4.4.2",
+        "lodash.set": "^4.3.2",
+        "oas": "^23.0.2",
         "qs": "^6.11.2",
         "remove-undefined-objects": "^5.0.0"
       },
@@ -14022,6 +14023,11 @@
       "resolved": "https://registry.npmjs.org/lodash.deburr/-/lodash.deburr-4.1.0.tgz",
       "integrity": "sha512-m/M1U1f3ddMCs6Hq2tAsYThTBDaAKFDX3dwDo97GEYzamXi9SqUpjWi/Rrj/gf3X2n8ktwgZrlP1z6E3v/IExQ=="
     },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
+    },
     "node_modules/lodash.isequal": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
@@ -14062,6 +14068,11 @@
       "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
       "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
       "dev": true
+    },
+    "node_modules/lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg=="
     },
     "node_modules/lodash.setwith": {
       "version": "4.3.2",
@@ -16908,9 +16919,9 @@
       }
     },
     "node_modules/oas": {
-      "version": "23.0.1",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-23.0.1.tgz",
-      "integrity": "sha512-R3mcbr90nFQQLHSbrGCZYF5ufFo8rIYvkW7JG7VGLzjMA9SuQhAzyzgw0A/+pvg4kR01HJZfb24ts+/y/HoYsQ==",
+      "version": "23.0.2",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-23.0.2.tgz",
+      "integrity": "sha512-bGyNsCjzCqdg1ORmNNbOq0dPMbDeIl7iLBXOAlUW2i3XRLZEGW6jMBy0uNZ0QgYEooEZvdV4K1HlNnnQtLyvjw==",
       "dependencies": {
         "@readme/json-schema-ref-parser": "^1.2.0",
         "@types/json-schema": "^7.0.11",
@@ -22718,11 +22729,13 @@
       "license": "MIT",
       "dependencies": {
         "@readme/api-core": "file:../core",
+        "@readme/oas-to-har": "^23.0.14",
         "@readme/openapi-parser": "^2.4.0",
         "chalk": "^5.3.0",
         "commander": "^11.1.0",
         "execa": "^8.0.1",
         "figures": "^5.0.0",
+        "httpsnippet-client-api": "file:../httpsnippet-client-api",
         "js-yaml": "^4.1.0",
         "lodash.camelcase": "^4.3.0",
         "lodash.deburr": "^4.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19099,6 +19099,11 @@
         "node": ">=0.10.5"
       }
     },
+    "node_modules/reserved2": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/reserved2/-/reserved2-0.1.5.tgz",
+      "integrity": "sha512-f6KwU3XdknMNBCCl0KAFNGtkuUeVyZJckXXcwls8iKJdQBdaQK8rBjT8iVWS3qH/nce6nymRtN2fIoGl8kbzLw=="
+    },
     "node_modules/resolve": {
       "version": "1.22.6",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.6.tgz",
@@ -23133,7 +23138,9 @@
       "version": "7.0.0-beta.0",
       "license": "MIT",
       "dependencies": {
+        "camelcase": "^8.0.0",
         "content-type": "^1.0.5",
+        "reserved2": "^0.1.5",
         "stringify-object": "^5.0.0"
       },
       "devDependencies": {
@@ -23151,6 +23158,17 @@
       "peerDependencies": {
         "@readme/httpsnippet": ">=8",
         "oas": "^23.0.0"
+      }
+    },
+    "packages/httpsnippet-client-api/node_modules/camelcase": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-8.0.0.tgz",
+      "integrity": "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "packages/httpsnippet-client-api/node_modules/is-obj": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -44,11 +44,13 @@
   ],
   "dependencies": {
     "@readme/api-core": "file:../core",
+    "@readme/oas-to-har": "^23.0.14",
     "@readme/openapi-parser": "^2.4.0",
     "chalk": "^5.3.0",
     "commander": "^11.1.0",
     "execa": "^8.0.1",
     "figures": "^5.0.0",
+    "httpsnippet-client-api": "file:../httpsnippet-client-api",
     "js-yaml": "^4.1.0",
     "lodash.camelcase": "^4.3.0",
     "lodash.deburr": "^4.1.0",

--- a/packages/api/src/lib/suggestedOperations.ts
+++ b/packages/api/src/lib/suggestedOperations.ts
@@ -1,0 +1,118 @@
+import type { AuthForHAR } from '@readme/oas-to-har/lib/types';
+import type Oas from 'oas';
+import type Operation from 'oas/operation';
+
+import oasToHar from '@readme/oas-to-har';
+import client from 'httpsnippet-client-api';
+import { Webhook } from 'oas/operation';
+
+/**
+ * Return a list of suggested and "good first issue" types of endpoints that we can build a post-SDK
+ * code generation code snippet around to demo the power of `api`.
+ *
+ * The criteria for a suggested endpoint are the following:
+ *  - GET request
+ *  - Has no required query or body parameters
+ *  - Endpoint has not been deprecated
+ *
+ * @param oas
+ */
+export function getSuggestedOperation(oas: Oas) {
+  const suggested: Operation[] = [];
+
+  Object.values(oas.getPaths()).forEach(path => {
+    Object.values(path).forEach(operation => {
+      // We don't really support webhooks with this library so if this operation is one we shouldn't
+      // return it as a recommended operation.
+      if (operation instanceof Webhook) {
+        return;
+      }
+
+      if (operation.isDeprecated()) {
+        return;
+      }
+
+      if (operation.method.toLowerCase() === 'get') {
+        const hasRequiredParameters = operation.hasRequiredParameters();
+        const hasRequiredRequestBody = operation.hasRequiredRequestBody();
+
+        // If the criteria matches, push it into a recommended array
+        if (!hasRequiredParameters && !hasRequiredRequestBody) {
+          suggested.push(operation);
+        }
+      }
+    });
+  });
+
+  if (suggested.length) {
+    return suggested[0];
+  }
+
+  return false;
+}
+
+/**
+ * Generate an example code snippet for a given (suggested) operation. We'll show this to users
+ * post-codegeneration so they can see how to use the SDK we created for them.
+ *
+ */
+export async function buildCodeSnippetForOperation(oas: Oas, operation: Operation, opts: { identifier: string }) {
+  // If this endpoint has authentication on it then we should try to flesh out some placeholder
+  // values in the `.auth()` SDK method for them so they can see how to use auth.
+  let auth: AuthForHAR = {};
+  const hasAuth = !!operation.getSecurity()?.length;
+  if (hasAuth) {
+    operation.getSecurityWithTypes().forEach(schemes => {
+      if (!schemes) return;
+      schemes.filter(Boolean).forEach(scheme => {
+        if (!scheme) return;
+
+        // eslint-disable-next-line no-underscore-dangle
+        const schemeName = scheme.security._key;
+        if (scheme?.type === 'Basic') {
+          auth[schemeName] = { user: 'username', pass: 'password' };
+        } else {
+          auth[schemeName] = 'token';
+        }
+      });
+    });
+
+    auth = oas.getAuth(auth) as AuthForHAR;
+  }
+
+  // We're pulling in `@reamde/oas-to-har` and `httpsnippet-client-api` here instead of using
+  // `@readme/oas-to-snippet`, which would handle both, because we don't need the entire
+  // `oas-to-snippet` for what we're doing here. All we want to do is generate a very simple code
+  // example for `api` snippets and because we're controlling which kinds of endpoints we're
+  // generating this for the HAR dataset we're working with here is mostly a fully known object.
+  const har = oasToHar(oas, operation, undefined, auth)?.log?.entries?.[0]?.request;
+  if (!har) {
+    return false;
+  }
+
+  const snippet = client.convert(
+    {
+      ...har,
+      cookiesObj: har.cookies.reduce((acc, { name, value }) => ({ ...acc, [name]: value }), {}),
+      fullUrl: har.url,
+      headersObj: har.headers.reduce((acc, { name, value }) => ({ ...acc, [name]: value }), {}),
+      postData: {
+        mimeType: 'application/json',
+        text: '',
+      },
+      queryObj: har.queryString.reduce((acc, { name, value }) => ({ ...acc, [name]: value }), {}),
+      url: har.url,
+
+      // These aren't used in `httpsnippet-client-api` so we don't need to bother hooking them up.
+      allHeaders: {} as never,
+      uriObj: {} as never,
+    },
+    {
+      apiDefinition: oas.getDefinition(),
+      apiDefinitionUri: opts.identifier,
+      identifier: opts.identifier,
+    },
+  );
+
+  return snippet;
+}

--- a/packages/api/test/lib/__snapshots__/suggestedOperations.test.ts.snap
+++ b/packages/api/test/lib/__snapshots__/suggestedOperations.test.ts.snap
@@ -1,0 +1,10 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`#buildCodeSnippetForOperation > should construct a code snippet for a given operation 1`] = `
+"import petstore from '@api/petstore';
+
+petstore.auth('token');
+petstore.findPetsByStatus()
+  .then(({ data }) => console.log(data))
+  .catch(err => console.error(err));"
+`;

--- a/packages/api/test/lib/suggestedOperations.test.ts
+++ b/packages/api/test/lib/suggestedOperations.test.ts
@@ -1,0 +1,66 @@
+import { loadSpec } from '@api/test-utils';
+import Oas from 'oas';
+import Operation from 'oas/operation';
+import { describe, it, expect } from 'vitest';
+
+import { getSuggestedOperation, buildCodeSnippetForOperation } from '../../src/lib/suggestedOperations.js';
+
+describe('#getSuggestedOperation', () => {
+  it('should retrieve a suggested operation', async () => {
+    const spec = await loadSpec('@readme/oas-examples/3.0/json/readme.json').then(Oas.init);
+    await spec.dereference();
+
+    const suggested = getSuggestedOperation(spec);
+
+    expect(suggested).toBeInstanceOf(Operation);
+    expect((suggested as Operation).getOperationId()).toBe('getAPISpecification');
+  });
+
+  it('should not retrieve an operation from a spec thats only comprised of webhooks', async () => {
+    const spec = await loadSpec('@readme/oas-examples/3.1/json/webhooks.json').then(Oas.init);
+    await spec.dereference();
+
+    const suggested = getSuggestedOperation(spec);
+    expect(suggested).toBe(false);
+  });
+});
+
+describe('#buildCodeSnippetForOperation', () => {
+  it('should construct a code snippet for a given operation', async () => {
+    const spec = await loadSpec('@readme/oas-examples/3.0/json/petstore.json').then(Oas.init);
+    await spec.dereference();
+
+    const operation = spec.operation('/pet/findByStatus', 'get');
+    const snippet = await buildCodeSnippetForOperation(spec, operation, {
+      identifier: 'petstore',
+    });
+
+    expect(snippet).toMatchSnapshot();
+  });
+
+  describe('should prefill in example auth auth tokens for endpoints that have auth', () => {
+    it('basic auth', async () => {
+      const spec = await loadSpec('@readme/oas-examples/3.0/json/readme.json').then(Oas.init);
+      await spec.dereference();
+
+      const operation = spec.operation('/api-specification', 'get');
+      const snippet = await buildCodeSnippetForOperation(spec, operation, {
+        identifier: 'readme',
+      });
+
+      expect(snippet).toContain(".auth('username', 'password')");
+    });
+
+    it('query auth', async () => {
+      const spec = await loadSpec('@readme/oas-examples/3.0/json/security.json').then(Oas.init);
+      await spec.dereference();
+
+      const operation = spec.operation('/anything/apiKey', 'get');
+      const snippet = await buildCodeSnippetForOperation(spec, operation, {
+        identifier: 'security',
+      });
+
+      expect(snippet).toContain(".auth('token')");
+    });
+  });
+});

--- a/packages/httpsnippet-client-api/package.json
+++ b/packages/httpsnippet-client-api/package.json
@@ -36,7 +36,9 @@
     "node": ">=18"
   },
   "dependencies": {
+    "camelcase": "^8.0.0",
     "content-type": "^1.0.5",
+    "reserved2": "^0.1.5",
     "stringify-object": "^5.0.0"
   },
   "peerDependencies": {

--- a/packages/httpsnippet-client-api/src/index.ts
+++ b/packages/httpsnippet-client-api/src/index.ts
@@ -4,9 +4,11 @@ import type Operation from 'oas/operation';
 import type { HttpMethods, OASDocument } from 'oas/rmoas.types';
 
 import { CodeBuilder } from '@readme/httpsnippet/helpers/code-builder';
+import camelCase from 'camelcase';
 import contentType from 'content-type';
 import Oas from 'oas';
 import { matchesMimeType } from 'oas/utils';
+import { isReservedOrBuiltinsLC } from 'reserved2';
 import stringifyObject from 'stringify-object';
 
 /**
@@ -146,7 +148,13 @@ const client: Client<APIOptions> = {
     let sdkVariable: string;
     if (opts.identifier) {
       sdkPackageName = opts.identifier;
-      sdkVariable = opts.identifier;
+
+      sdkVariable = camelCase(opts.identifier);
+      if (isReservedOrBuiltinsLC(sdkVariable)) {
+        // If this identifier is a reserved JS word then we should prefix it with an underscore so
+        // this snippet can be valid code.
+        sdkVariable = `_${sdkVariable}`;
+      }
     } else {
       sdkPackageName = getProjectPrefixFromRegistryUUID(opts.apiDefinitionUri);
       sdkVariable = 'sdk';

--- a/packages/httpsnippet-client-api/test/index.test.ts
+++ b/packages/httpsnippet-client-api/test/index.test.ts
@@ -113,7 +113,7 @@ describe('httpsnippet-client-api', () => {
     });
 
     it('should support custom SDK variable names', async () => {
-      const mock = await getSnippetDataset('short');
+      const mock = await getSnippetDataset('petstore');
 
       const code = await new HTTPSnippet(mock.har).convert('node', 'api', {
         apiDefinitionUri: '@developers/v2.0#17273l2glm9fq4l5',
@@ -123,7 +123,8 @@ describe('httpsnippet-client-api', () => {
 
       expect(code).toStrictEqual(`import developers from '@api/developers';
 
-developers.getAnything()
+developers.auth('123');
+developers.findPetsByStatus({status: 'available', accept: 'application/xml'})
   .then(({ data }) => console.log(data))
   .catch(err => console.error(err));`);
     });

--- a/packages/httpsnippet-client-api/test/index.test.ts
+++ b/packages/httpsnippet-client-api/test/index.test.ts
@@ -112,21 +112,40 @@ describe('httpsnippet-client-api', () => {
       });
     });
 
-    it('should support custom SDK variable names', async () => {
-      const mock = await getSnippetDataset('petstore');
+    describe('custom variable names', () => {
+      it('should support custom SDK variable names', async () => {
+        const mock = await getSnippetDataset('petstore');
 
-      const code = await new HTTPSnippet(mock.har).convert('node', 'api', {
-        apiDefinitionUri: '@developers/v2.0#17273l2glm9fq4l5',
-        identifier: 'developers',
-        apiDefinition: mock.definition,
-      });
+        const code = await new HTTPSnippet(mock.har).convert('node', 'api', {
+          apiDefinitionUri: '@developers/v2.0#17273l2glm9fq4l5',
+          identifier: 'developers',
+          apiDefinition: mock.definition,
+        });
 
-      expect(code).toStrictEqual(`import developers from '@api/developers';
+        expect(code).toStrictEqual(`import developers from '@api/developers';
 
 developers.auth('123');
 developers.findPetsByStatus({status: 'available', accept: 'application/xml'})
   .then(({ data }) => console.log(data))
   .catch(err => console.error(err));`);
+      });
+
+      it('should make an unsafe variable name safe', async () => {
+        const mock = await getSnippetDataset('petstore');
+
+        const code = await new HTTPSnippet(mock.har).convert('node', 'api', {
+          apiDefinitionUri: '@metro-transit/v2.0#17273l2glm9fq4l5',
+          identifier: 'metro-transit',
+          apiDefinition: mock.definition,
+        });
+
+        expect(code).toStrictEqual(`import metroTransit from '@api/metro-transit';
+
+metroTransit.auth('123');
+metroTransit.findPetsByStatus({status: 'available', accept: 'application/xml'})
+  .then(({ data }) => console.log(data))
+  .catch(err => console.error(err));`);
+      });
     });
   });
 });


### PR DESCRIPTION
| 🚥 Resolves RM-8185 |
| :------------------- |

## 🧰 Changes

This work is some QOL improvements to the post-installation screen where we'll now, using a very simple algorithm to determine the best endpoint for a demo[^1], show a code example to folks so they can immediately get started with their newly generated SDK. Here's what it looks like:

![Screen Shot 2023-10-23 at 5 02 24 PM](https://github.com/readmeio/api/assets/33762/ea7d4407-7dd0-4aef-a4c5-b6ec943e84e0)

And in the case of us not being able to find a good endpoint to demo[^2] we just won't show a code example:

![Screen Shot 2023-10-23 at 5 02 43 PM](https://github.com/readmeio/api/assets/33762/09a5c0f2-397b-4f21-b51d-759d4409bd8a)

[^1]: With the exception of us being able to handle auth examples, this algorithm is the same that powers the "recommended" API endpoint section of ReadMe Realtime configuration.
[^2]: In this case this API definition was only comprised endpoints with path parameters.