### PR TITLE
refactor(api): refactor core to handle HAR generation for code snippets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22734,7 +22734,6 @@
       "license": "MIT",
       "dependencies": {
         "@readme/api-core": "file:../core",
-        "@readme/oas-to-har": "^23.0.14",
         "@readme/openapi-parser": "^2.4.0",
         "chalk": "^5.3.0",
         "commander": "^11.1.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -44,7 +44,6 @@
   ],
   "dependencies": {
     "@readme/api-core": "file:../core",
-    "@readme/oas-to-har": "^23.0.14",
     "@readme/openapi-parser": "^2.4.0",
     "chalk": "^5.3.0",
     "commander": "^11.1.0",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 import type { ConfigOptions } from './types.js';
+import type { AuthForHAR, DataForHAR } from '@readme/oas-to-har/lib/types';
 import type { Har } from 'har-format';
 import type Operation from 'oas/operation';
 import type { HttpMethods, OASDocument } from 'oas/rmoas.types';
@@ -66,6 +67,15 @@ export default class APICore {
     return this.fetchOperation<HTTPStatus>(operation, body, metadata);
   }
 
+  /**
+   * Retrieve a HAR for a given HTTP request.
+   *
+   * @internal
+   */
+  getHARForRequest(operation: Operation, data: DataForHAR, auth: AuthForHAR) {
+    return oasToHar(this.spec, operation, data, auth);
+  }
+
   async fetchOperation<HTTPStatus extends number = number>(
     operation: Operation,
     body?: unknown,
@@ -84,8 +94,7 @@ export default class APICore {
         }
       }
 
-      // @ts-expect-error `this.auth` typing is off. FIXME
-      const har = oasToHar(this.spec, operation, data, prepareAuth(this.auth, operation));
+      const har = this.getHARForRequest(operation, data, prepareAuth(this.auth, operation));
 
       let timeoutSignal: NodeJS.Timeout;
       const init: RequestInit = {};

--- a/packages/core/src/lib/prepareAuth.ts
+++ b/packages/core/src/lib/prepareAuth.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-underscore-dangle */
+import type { AuthForHAR } from '@readme/oas-to-har/lib/types';
 import type Operation from 'oas/operation';
 import type { KeyedSecuritySchemeObject } from 'oas/rmoas.types';
 
@@ -7,15 +8,7 @@ export default function prepareAuth(authKey: (number | string)[], operation: Ope
     return {};
   }
 
-  const preparedAuth: Record<
-    string,
-    | string
-    | number
-    | {
-        pass: string | number;
-        user: string | number;
-      }
-  > = {};
+  const preparedAuth: AuthForHAR = {};
 
   const security = operation.getSecurity();
   if (security.length === 0) {
@@ -61,8 +54,8 @@ export default function prepareAuth(authKey: (number | string)[], operation: Ope
 
     const scheme = schemes.shift() as KeyedSecuritySchemeObject;
     preparedAuth[scheme._key] = {
-      user: authKey[0],
-      pass: authKey.length === 2 ? authKey[1] : '',
+      user: String(authKey[0]),
+      pass: authKey.length === 2 ? String(authKey[1]) : '',
     };
 
     return preparedAuth;
@@ -82,8 +75,8 @@ export default function prepareAuth(authKey: (number | string)[], operation: Ope
     case 'http':
       if (scheme.scheme === 'basic') {
         preparedAuth[scheme._key] = {
-          user: authKey[0],
-          pass: authKey.length === 2 ? authKey[1] : '',
+          user: String(authKey[0]),
+          pass: authKey.length === 2 ? String(authKey[1]) : '',
         };
       } else if (scheme.scheme === 'bearer') {
         preparedAuth[scheme._key] = authKey[0];


### PR DESCRIPTION
## 🧰 Changes

Slightly refactors the work I did in https://github.com/readmeio/api/pull/783 to remove our dependency on `@readme/oas-to-har` in `api`. Because we already depend on this library in core it's easier to have a method for generating a HAR object from the spec we're using there instead of having `oas-to-har` as a full dependency in `api`.

Proof that this all still works:

![Screen Shot 2023-10-24 at 2 49 24 PM](https://github.com/readmeio/api/assets/33762/66edc0bc-6e76-4057-98c5-ad7fa4e20d55)

