### PR TITLE
refactor(snippets): moving the library over to be an HTTPSnippet plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3512,9 +3512,9 @@
       "integrity": "sha512-/dBh9qw3QhJYqlGwt2I+KUP/lQ6nytdCx3aq+GpMUhibLHF3O7fwoowNcTwlbnwtyJ+TJYTIIrp3oVUlRNx3fA=="
     },
     "node_modules/@readme/httpsnippet": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@readme/httpsnippet/-/httpsnippet-8.0.1.tgz",
-      "integrity": "sha512-gqD8hRlQcyemWNFPtSqOAWrEqXyDfCgi0dK0+dANhgaACCW6OTHWwZFLXOBcYY8g408Ndus80ZCAZSfWZEvBOA==",
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/@readme/httpsnippet/-/httpsnippet-8.1.2.tgz",
+      "integrity": "sha512-76q+ZuKP4O3vPT2ST1SKGCjRV0bAutGMAynHkdZOkFK+mVmiblodUtq+un3XIbYEbDKKu0ffkFekiCjXmFaH+w==",
       "peer": true,
       "dependencies": {
         "formdata-to-string": "^2.0.0",
@@ -23450,7 +23450,7 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "@readme/httpsnippet": ">=8",
+        "@readme/httpsnippet": ">=8.1.2",
         "oas": "^23.0.0"
       }
     },

--- a/packages/api/src/lib/suggestedOperations.ts
+++ b/packages/api/src/lib/suggestedOperations.ts
@@ -3,7 +3,7 @@ import type Oas from 'oas';
 import type Operation from 'oas/operation';
 
 import APICore from '@readme/api-core';
-import client from 'httpsnippet-client-api';
+import apiSnippetPlugin from 'httpsnippet-client-api';
 import { Webhook } from 'oas/operation';
 
 /**
@@ -96,7 +96,7 @@ export async function buildCodeSnippetForOperation(oas: Oas, operation: Operatio
     return false;
   }
 
-  const snippet = client.convert(
+  const snippet = apiSnippetPlugin.client.convert(
     {
       ...har,
       cookiesObj: har.cookies.reduce((acc, { name, value }) => ({ ...acc, [name]: value }), {}),
@@ -114,9 +114,11 @@ export async function buildCodeSnippetForOperation(oas: Oas, operation: Operatio
       uriObj: {} as never,
     },
     {
-      apiDefinition: oas.getDefinition(),
-      apiDefinitionUri: opts.identifier,
-      identifier: opts.identifier,
+      api: {
+        definition: oas.getDefinition(),
+        identifier: opts.identifier,
+        registryURI: opts.identifier,
+      },
     },
   );
 

--- a/packages/httpsnippet-client-api/README.md
+++ b/packages/httpsnippet-client-api/README.md
@@ -15,10 +15,10 @@ npm install --save httpsnippet-client-api
 ## Usage
 
 ```js
-import { HTTPSnippet, addTargetClient } from 'httpsnippet';
-import client = require('httpsnippet-client-api');
+import { HTTPSnippet, addClientPlugin } from 'httpsnippet';
+import apiClientPlugin from 'httpsnippet-client-api';
 
-addTargetClient('node', client);
+addClientPlugin('node', apiClientPlugin);
 
 const har = {
   "log": {
@@ -42,10 +42,12 @@ const har = {
 }
 
 const snippet = new HTTPSnippet(har);
-const code = snippet.convert('node', 'api', {
-  apiDefinitionUri: 'https://api.example.com/openapi.json'
-  apiDefinition: {
-    /* an OpenAPI definition object */
+const code = await snippet.convert('node', 'api', {
+  api: {
+    definition: {
+      /* an OpenAPI definition object */
+    }
+    registryURI: '@example/v2.0#17273l2glm9fq4l5'
   }
 });
 
@@ -55,10 +57,34 @@ console.log(code);
 Results in the following:
 
 ```js
-const sdk = require('api')('https://api.example.com/openapi.json');
+import sdk from '@api/example';
 
 sdk.auth('a5a220e');
 sdk
+  .put('/apiKey')
+  .then(({ data }}) => console.log(data))
+  .catch(err => console.error(err));
+```
+
+We also support supplying a shorter `identifier` option that will take over the imported package and the variable that is created.
+
+```js
+const code = await snippet.convert('node', 'api', {
+  api: {
+    definition: {
+      /* an OpenAPI definition object */
+    }
+    identifier: 'example',
+    registryURI: '@example/v2.0#17273l2glm9fq4l5'
+  }
+});
+```
+
+```js
+import example from 'example';
+
+example.auth('a5a220e');
+example
   .put('/apiKey')
   .then(({ data }}) => console.log(data))
   .catch(err => console.error(err));

--- a/packages/httpsnippet-client-api/package.json
+++ b/packages/httpsnippet-client-api/package.json
@@ -42,7 +42,7 @@
     "stringify-object": "^5.0.0"
   },
   "peerDependencies": {
-    "@readme/httpsnippet": ">=8",
+    "@readme/httpsnippet": ">=8.1.2",
     "oas": "^23.0.0"
   },
   "devDependencies": {

--- a/packages/httpsnippet-client-api/test/index.test.ts
+++ b/packages/httpsnippet-client-api/test/index.test.ts
@@ -1,17 +1,17 @@
 import type { HarRequest, Request } from '@readme/httpsnippet';
-import type { Client } from '@readme/httpsnippet/targets';
+import type { ClientPlugin } from '@readme/httpsnippet/targets';
 import type { OASDocument } from 'oas/rmoas.types';
 
 import { readdirSync } from 'node:fs';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 
-import { HTTPSnippet, addTargetClient } from '@readme/httpsnippet';
+import { HTTPSnippet, addClientPlugin } from '@readme/httpsnippet';
 import readme from '@readme/oas-examples/3.0/json/readme.json';
 import openapiParser from '@readme/openapi-parser';
 import { describe, beforeEach, expect, it } from 'vitest';
 
-import client from '../src/index.js';
+import plugin from '../src/index.js';
 
 const DATASETS_DIR = path.join(__dirname, '__datasets__');
 const SNIPPETS = readdirSync(DATASETS_DIR);
@@ -28,7 +28,7 @@ function getSnippetDataset(snippet): Promise<SnippetMock> {
 describe('httpsnippet-client-api', () => {
   beforeEach(() => {
     try {
-      addTargetClient('node', client as Client);
+      addClientPlugin(plugin as ClientPlugin);
     } catch (err) {
       if (err.message !== 'The supplied custom target client already exists, please use a different key') {
         throw err;
@@ -37,36 +37,54 @@ describe('httpsnippet-client-api', () => {
   });
 
   it('should have info', () => {
-    expect(client).toHaveProperty('info');
-    expect(client.info).toStrictEqual({
+    expect(plugin).toHaveProperty('target', 'node');
+    expect(plugin.client).toHaveProperty('info');
+    expect(plugin.client.info).toStrictEqual({
       key: 'api',
       title: 'API',
       link: 'https://npm.im/api',
       description: 'Automatic SDK generation from an OpenAPI definition.',
       extname: '.js',
+      installation: 'npx api install {packageName}',
     });
   });
 
-  it('should error if no apiDefinitionUri was supplied', async () => {
+  it('should error if no `api` config was supplied', async () => {
     const { har } = await getSnippetDataset('petstore');
     const snippet = new HTTPSnippet(har);
 
-    await expect(snippet.convert('node', 'api')).rejects.toThrow(/must have an `apiDefinitionUri` option supplied/);
+    await expect(snippet.convert('node', 'api')).rejects.toThrow(/must have an `api` config supplied/);
+    await expect(snippet.convert('node', 'api', {})).rejects.toThrow(/must have an `api` config supplied/);
   });
 
-  it('should error if no apiDefinition was supplied', async () => {
+  it('should error if no `api.definition` was supplied', async () => {
     const { har } = await getSnippetDataset('petstore');
     const snippet = new HTTPSnippet(har);
 
     await expect(
       snippet.convert('node', 'api', {
-        apiDefinitionUri: '@developers/v2.0#17273l2glm9fq4l5',
+        api: {
+          registryURI: '@developers/v2.0#17273l2glm9fq4l5',
+        },
       }),
-    ).rejects.toThrow(/must have an `apiDefinition` option supplied/);
+    ).rejects.toThrow(/must have an `api.definition` option supplied/);
+  });
+
+  it('should error if no `api.registryURI` was supplied', async () => {
+    const { har } = await getSnippetDataset('petstore');
+    const snippet = new HTTPSnippet(har);
+
+    await expect(
+      snippet.convert('node', 'api', {
+        api: {
+          definition: readme,
+        },
+      }),
+    ).rejects.toThrow(/must have an `api.registryURI` option supplied/);
   });
 
   // This test should fail because the url in the HAR is missing `/v1` in the path.
-  it('should error if no matching operation was found in the apiDefinition', async () => {
+  it('should error if no matching operation was found in the supplied API definition', async () => {
     const har = {
       httpVersion: 'HTTP/1.1',
       method: 'GET',
@@ -81,8 +99,10 @@ describe('httpsnippet-client-api', () => {
 
     await expect(
       snippet.convert('node', 'api', {
-        apiDefinitionUri: '@developers/v2.0#17273l2glm9fq4l5',
-        apiDefinition: readme,
+        api: {
+          definition: readme,
+          registryURI: '@developers/v2.0#17273l2glm9fq4l5',
+        },
       }),
     ).rejects.toThrow(/unable to locate a matching operation/i);
   });
@@ -104,8 +124,10 @@ describe('httpsnippet-client-api', () => {
         const expected = await fs.readFile(path.join(DATASETS_DIR, snippet, 'output.js'), 'utf-8');
 
         const code = await new HTTPSnippet(mock.har).convert('node', 'api', {
-          apiDefinitionUri: `@${snippet}/v2.0#17273l2glm9fq4l5`,
-          apiDefinition: mock.definition,
+          api: {
+            definition: mock.definition,
+            registryURI: `@${snippet}/v2.0#17273l2glm9fq4l5`,
+          },
         });
 
         expect(`${code}\n`).toStrictEqual(expected);
@@ -117,9 +139,11 @@ describe('httpsnippet-client-api', () => {
         const mock = await getSnippetDataset('petstore');
 
         const code = await new HTTPSnippet(mock.har).convert('node', 'api', {
-          apiDefinitionUri: '@developers/v2.0#17273l2glm9fq4l5',
-          identifier: 'developers',
-          apiDefinition: mock.definition,
+          api: {
+            definition: mock.definition,
+            identifier: 'developers',
+            registryURI: '@developers/v2.0#17273l2glm9fq4l5',
+          },
         });
 
         expect(code).toStrictEqual(`import developers from '@api/developers';
@@ -134,9 +158,11 @@ developers.findPetsByStatus({status: 'available', accept: 'application/xml'})
         const mock = await getSnippetDataset('petstore');
 
         const code = await new HTTPSnippet(mock.har).convert('node', 'api', {
-          apiDefinitionUri: '@metro-transit/v2.0#17273l2glm9fq4l5',
-          identifier: 'metro-transit',
-          apiDefinition: mock.definition,
+          api: {
+            definition: mock.definition,
+            identifier: 'metro-transit',
+            registryURI: '@metro-transit/v2.0#17273l2glm9fq4l5',
+          },
         });
 
         expect(code).toStrictEqual(`import metroTransit from '@api/metro-transit';


### PR DESCRIPTION
## 🧰 Changes

With the work I did in https://github.com/readmeio/httpsnippet/releases/tag/8.1.0 this slightly refactors[^1] `httpsnippet-client-api` to now be a proper new HTTPSnippet plugin so it can now be installed as a one-liner:

```js
import { HTTPSnippet, addClientPlugin } from '@readme/httpsnippet';
import plugin from 'httpsnippet-client-api';

addClientPlugin(plugin);
```

Previously the way it was installed was as such:

```js
import { HTTPSnippet, addTargetClient } from '@readme/httpsnippet';
import plugin from 'httpsnippet-client-api';

addTargetClient('node', plugin);
```

This plugin refactor allows us to move the target that we're targeting, `node`, directly onto the client plugin. This refactor, and the addition of an `installation` message on the client will allow us to do some fun stuff in `@readme/oas-to-snippet` and accept plugins from outside sources.

[^1]: Very much a breaking change refactor but because we're still in beta land with this work I'm not going to bother versioning this to another major.