### PR TITLE
fix(api): run `npm install` with `--ignore-scripts`

### DIFF
--- a/packages/api/src/codegen/languages/typescript/index.ts
+++ b/packages/api/src/codegen/languages/typescript/index.ts
@@ -197,7 +197,7 @@ export default class TSGenerator extends CodeGenerator {
   async compile(storage: Storage, opts: InstallerOptions = {}): Promise<void> {
     const installDir = storage.getIdentifierStorageDir();
 
-    await execa('npm', ['pkg', 'set', 'scripts.prepare=tsup'])
+    await execa('npm', ['pkg', 'set', 'scripts.prepare=tsup'], { cwd: installDir })
       .then(res => handleExecSuccess(res, opts))
       .catch(err => handleExecFailure(err, opts));
 

--- a/packages/api/src/codegen/languages/typescript/index.ts
+++ b/packages/api/src/codegen/languages/typescript/index.ts
@@ -140,7 +140,7 @@ export default class TSGenerator extends CodeGenerator {
   async install(storage: Storage, opts: InstallerOptions = {}): Promise<void> {
     const installDir = storage.getIdentifierStorageDir();
 
-    const npmInstall = ['install', '--save', opts.dryRun ? '--dry-run' : ''].filter(Boolean);
+    const npmInstall = ['install', '--save', '--ignore-scripts', opts.dryRun ? '--dry-run' : ''].filter(Boolean);
 
     // This will install the installed SDK as a dependency within the current working directory,
     // adding `@api/<sdk identifier>` as a dependency there so you can load it with

--- a/packages/test-utils/sdks/alby/package.json
+++ b/packages/test-utils/sdks/alby/package.json
@@ -19,8 +19,7 @@
     "openapi.json"
   ],
   "scripts": {
-    "lint": "tsc --noEmit",
-    "prepare": "tsup"
+    "lint": "tsc --noEmit"
   },
   "dependencies": {
     "@readme/api-core": "file:../../../../../core",

--- a/packages/test-utils/sdks/metrotransit/package.json
+++ b/packages/test-utils/sdks/metrotransit/package.json
@@ -19,8 +19,7 @@
     "openapi.json"
   ],
   "scripts": {
-    "lint": "tsc --noEmit",
-    "prepare": "tsup"
+    "lint": "tsc --noEmit"
   },
   "dependencies": {
     "@readme/api-core": "file:../../../../../core",

--- a/packages/test-utils/sdks/operationid-quirks/package.json
+++ b/packages/test-utils/sdks/operationid-quirks/package.json
@@ -15,8 +15,7 @@
     "openapi.json"
   ],
   "scripts": {
-    "lint": "tsc --noEmit",
-    "prepare": "tsup"
+    "lint": "tsc --noEmit"
   },
   "dependencies": {
     "@readme/api-core": "file:../../../../../core",

--- a/packages/test-utils/sdks/optional-payload/package.json
+++ b/packages/test-utils/sdks/optional-payload/package.json
@@ -19,8 +19,7 @@
     "openapi.json"
   ],
   "scripts": {
-    "lint": "tsc --noEmit",
-    "prepare": "tsup"
+    "lint": "tsc --noEmit"
   },
   "dependencies": {
     "@readme/api-core": "file:../../../../../core",

--- a/packages/test-utils/sdks/petstore/package.json
+++ b/packages/test-utils/sdks/petstore/package.json
@@ -20,8 +20,7 @@
     "openapi.json"
   ],
   "scripts": {
-    "lint": "tsc --noEmit",
-    "prepare": "tsup"
+    "lint": "tsc --noEmit"
   },
   "dependencies": {
     "@readme/api-core": "file:../../../../../core",

--- a/packages/test-utils/sdks/readme/package.json
+++ b/packages/test-utils/sdks/readme/package.json
@@ -19,8 +19,7 @@
     "openapi.json"
   ],
   "scripts": {
-    "lint": "tsc --noEmit",
-    "prepare": "tsup"
+    "lint": "tsc --noEmit"
   },
   "dependencies": {
     "@readme/api-core": "file:../../../../../core",

--- a/packages/test-utils/sdks/response-title-quirks/package.json
+++ b/packages/test-utils/sdks/response-title-quirks/package.json
@@ -19,8 +19,7 @@
     "openapi.json"
   ],
   "scripts": {
-    "lint": "tsc --noEmit",
-    "prepare": "tsup"
+    "lint": "tsc --noEmit"
   },
   "dependencies": {
     "@readme/api-core": "file:../../../../../core",

--- a/packages/test-utils/sdks/simple/package.json
+++ b/packages/test-utils/sdks/simple/package.json
@@ -19,8 +19,7 @@
     "openapi.json"
   ],
   "scripts": {
-    "lint": "tsc --noEmit",
-    "prepare": "tsup"
+    "lint": "tsc --noEmit"
   },
   "dependencies": {
     "@readme/api-core": "file:../../../../../core",

--- a/packages/test-utils/sdks/star-trek/package.json
+++ b/packages/test-utils/sdks/star-trek/package.json
@@ -19,8 +19,7 @@
     "openapi.json"
   ],
   "scripts": {
-    "lint": "tsc --noEmit",
-    "prepare": "tsup"
+    "lint": "tsc --noEmit"
   },
   "dependencies": {
     "@readme/api-core": "file:../../../../../core",


### PR DESCRIPTION
## 🧰 Changes

The `prepare` script that was added to codegen'd `package.json` files in https://github.com/readmeio/api/pull/761 is being executed when we install that SDK resulting us in running the compilation step twice. Because I'd like to keep the dependency installation and SDK dist compilation processes separate we should run `npm install` with the `--ignore-scripts` option.

fixes RM-8243