### PR TITLE
feat: throw error for legacy dynamic `require` users

### DIFF
--- a/packages/api/.gitignore
+++ b/packages/api/.gitignore
@@ -2,3 +2,4 @@
 coverage/
 dist/
 node_modules/
+legacy-require-handler.d.cts

--- a/packages/api/legacy-require-handler.cjs
+++ b/packages/api/legacy-require-handler.cjs
@@ -1,3 +1,4 @@
+// @ts-check
 /* eslint-disable import/no-commonjs */
 
 /**

--- a/packages/api/legacy-require-handler.cjs
+++ b/packages/api/legacy-require-handler.cjs
@@ -1,13 +1,6 @@
 /* eslint-disable import/no-commonjs */
 
 /**
- * You can regenerate the type declarations for this file by running the following:
- * ```sh
- * npx tsc legacy-require-handler.cjs --checkJs --declaration --emitDeclarationOnly
- * ```
- */
-
-/**
  * In `api` v6, this package was a JS library used JavaScript Proxies to dynamically generate SDKs at runtime.
  * This functionality has been sunset in `api` v7 to focus on its CLI, which builds strongly-typed SDKs.
  * This file is here to throw errors for users that attempt to use the legacy library.

--- a/packages/api/legacy-require-handler.cjs
+++ b/packages/api/legacy-require-handler.cjs
@@ -24,5 +24,6 @@ You can read more about this in our docs: TKTK
 
 Try running this command to get started:
 
-npx api@latest install ${input}`);
+npx api@latest install ${input}
+`);
 };

--- a/packages/api/legacy-require-handler.cjs
+++ b/packages/api/legacy-require-handler.cjs
@@ -1,0 +1,28 @@
+/* eslint-disable import/no-commonjs */
+
+/**
+ * You can regenerate the type declarations for this file by running the following:
+ * ```sh
+ * npx tsc legacy-require-handler.cjs --checkJs --declaration --emitDeclarationOnly
+ * ```
+ */
+
+/**
+ * In `api` v6, this package was a JS library used JavaScript Proxies to dynamically generate SDKs at runtime.
+ * This functionality has been sunset in `api` v7 to focus on its CLI, which builds strongly-typed SDKs.
+ * This file is here to throw errors for users that attempt to use the legacy library.
+ *
+ *
+ * @param {unknown} input
+ */
+module.exports = function legacyHandler(input) {
+  throw new Error(`Oops! You're attempting to use a legacy usage pattern that no longer exists.
+
+You can read more about this in our docs: TKTK
+
+\`api\` can now generate strongly-typed SDKs that work in pretty much every JS runtime!
+
+Try running this command to get started:
+
+npx api@latest install ${input}`);
+};

--- a/packages/api/legacy-require-handler.cjs
+++ b/packages/api/legacy-require-handler.cjs
@@ -16,6 +16,12 @@
  * @param {unknown} input
  */
 module.exports = function legacyHandler(input) {
+  let identifier = 'https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/examples/v3.0/petstore.json';
+
+  if (typeof input === 'string') {
+    identifier = input;
+  }
+
   throw new Error(`Oops! You're attempting to use a legacy usage pattern that no longer exists.
 
 You can read more about this in our docs: TKTK
@@ -24,6 +30,6 @@ You can read more about this in our docs: TKTK
 
 Try running this command to get started:
 
-npx api@latest install ${input}
+npx api@latest install ${identifier}
 `);
 };

--- a/packages/api/legacy-require-handler.d.cts
+++ b/packages/api/legacy-require-handler.d.cts
@@ -1,2 +1,0 @@
-declare function _exports(input: unknown): never;
-export = _exports;

--- a/packages/api/legacy-require-handler.d.cts
+++ b/packages/api/legacy-require-handler.d.cts
@@ -1,0 +1,2 @@
+declare function _exports(input: unknown): never;
+export = _exports;

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -6,6 +6,7 @@
   "bin": {
     "api": "bin/api.js"
   },
+  "main": "legacy-require-handler.cjs",
   "scripts": {
     "attw": "attw --pack --format table-flipped",
     "build": "tsc",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -10,10 +10,12 @@
   "scripts": {
     "attw": "attw --pack --format table-flipped",
     "build": "tsc",
+    "build:legacy-handler": "tsc legacy-require-handler.cjs --checkJs --declaration --emitDeclarationOnly",
     "build:versioned-files": "NODE_OPTIONS=--no-warnings node --loader ts-node/esm bin/buildVersionedFiles.ts",
     "debug:bin": "NODE_OPTIONS=--no-warnings node --loader ts-node/esm src/bin.ts",
     "lint:types": "tsc --noEmit",
     "prebuild": "rm -rf dist/ && npm run build:versioned-files",
+    "postbuild": "npm run build:legacy-handler",
     "prepack": "npm run build",
     "test": "vitest run --coverage",
     "test:smoke": "vitest --config=vitest-smoketest.config.ts",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -35,6 +35,7 @@
   },
   "files": [
     "dist",
+    "legacy-require-handler.**",
     "schema.json"
   ],
   "keywords": [

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -10,14 +10,14 @@
   "scripts": {
     "attw": "attw --pack --format table-flipped",
     "build": "tsc",
-    "build:versionedfiles": "NODE_OPTIONS=--no-warnings node --loader ts-node/esm bin/buildVersionedFiles.ts",
+    "build:versioned-files": "NODE_OPTIONS=--no-warnings node --loader ts-node/esm bin/buildVersionedFiles.ts",
     "debug:bin": "NODE_OPTIONS=--no-warnings node --loader ts-node/esm src/bin.ts",
     "lint:types": "tsc --noEmit",
-    "prebuild": "rm -rf dist/ && npm run build:versionedfiles",
+    "prebuild": "rm -rf dist/ && npm run build:versioned-files",
     "prepack": "npm run build",
     "test": "vitest run --coverage",
     "test:smoke": "vitest --config=vitest-smoketest.config.ts",
-    "version": "npm run build:versionedfiles && git add schema.json src/packageInfo.ts"
+    "version": "npm run build:versioned-files && git add schema.json src/packageInfo.ts"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
| 🚥 Resolves RM-8241 |
| :------------------- |

## 🧰 Changes

If users were to try and use the `const sdk = require("api")("url");` pattern that has since been removed from `api` v7, they'll see a confusing error like this:

```
node:internal/modules/cjs/loader:1080
  throw err;
  ^

Error: Cannot find module 'api'
Require stack:
- /Users/kanadg/Code/readmeio/tmp-api-tsup-sandbox/src/legacy-require.js
    at Module._resolveFilename (node:internal/modules/cjs/loader:1077:15)
    at Module._load (node:internal/modules/cjs/loader:922:27)
    at Module.require (node:internal/modules/cjs/loader:1143:19)
    at require (node:internal/modules/cjs/helpers:119:18)
    at Object.<anonymous> (/Users/kanadg/Code/readmeio/tmp-api-tsup-sandbox/src/legacy-require.js:1:17)
    at Module._compile (node:internal/modules/cjs/loader:1256:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1310:10)
    at Module.load (node:internal/modules/cjs/loader:1119:32)
    at Module._load (node:internal/modules/cjs/loader:960:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:86:12) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/Users/kanadg/Code/readmeio/tmp-api-tsup-sandbox/src/legacy-require.js'
  ]
}

Node.js v18.18.2
```

This improves the error so it now looks like this:

```
/Users/kanadg/Code/readmeio/api/packages/api/legacy-require-handler.cjs:19
  throw new Error(`Oops! You're attempting to use a legacy usage pattern that no longer exists.
  ^

Error: Oops! You're attempting to use a legacy usage pattern that no longer exists.

You can read more about this in our docs: TKTK

`api` can now generate strongly-typed SDKs that work in pretty much every JS runtime!

Try running this command to get started:

npx api@latest install @metrotransit/v1.0#2w2je3tolbchzuph

    at legacyHandler (/Users/kanadg/Code/readmeio/api/packages/api/legacy-require-handler.cjs:19:9)
    at Object.<anonymous> (/Users/kanadg/Code/readmeio/tmp-api-tsup-sandbox/src/legacy-require.js:1:31)
    at Module._compile (node:internal/modules/cjs/loader:1256:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1310:10)
    at Module.load (node:internal/modules/cjs/loader:1119:32)
    at Module._load (node:internal/modules/cjs/loader:960:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:86:12)
    at node:internal/main/run_main_module:23:47

Node.js v18.18.2
```

I also added a little type declaration file so TS users will see this:

![CleanShot 2023-10-26 at 10 51 51@2x](https://github.com/readmeio/api/assets/8854718/7eeb8fd5-6f24-4f69-86e2-071d6480ea7e)



## 🧬 QA & Testing

Provide as much information as you can on how to test what you've done.
