### PR TITLE
feat(codegen): expose `package.json` in `exports` object

### DIFF
--- a/packages/api/src/codegen/languages/typescript/index.ts
+++ b/packages/api/src/codegen/languages/typescript/index.ts
@@ -621,6 +621,7 @@ dist/
               },
             }
           : {}),
+        './package.json': './package.json',
       },
       license: this.spdxLicense ?? '',
       files: ['dist', 'openapi.json'],

--- a/packages/test-utils/sdks/alby/package.json
+++ b/packages/test-utils/sdks/alby/package.json
@@ -12,7 +12,8 @@
     "./types": {
       "import": "./dist/types.d.mts",
       "require": "./dist/types.d.ts"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "files": [
     "dist",

--- a/packages/test-utils/sdks/metrotransit/package.json
+++ b/packages/test-utils/sdks/metrotransit/package.json
@@ -12,7 +12,8 @@
     "./types": {
       "import": "./dist/types.d.mts",
       "require": "./dist/types.d.ts"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "files": [
     "dist",

--- a/packages/test-utils/sdks/operationid-quirks/package.json
+++ b/packages/test-utils/sdks/operationid-quirks/package.json
@@ -8,7 +8,8 @@
     ".": {
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "files": [
     "dist",

--- a/packages/test-utils/sdks/optional-payload/package.json
+++ b/packages/test-utils/sdks/optional-payload/package.json
@@ -12,7 +12,8 @@
     "./types": {
       "import": "./dist/types.d.mts",
       "require": "./dist/types.d.ts"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "files": [
     "dist",

--- a/packages/test-utils/sdks/petstore/package.json
+++ b/packages/test-utils/sdks/petstore/package.json
@@ -12,7 +12,8 @@
     "./types": {
       "import": "./dist/types.d.mts",
       "require": "./dist/types.d.ts"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "license": "Apache-2.0",
   "files": [

--- a/packages/test-utils/sdks/readme/package.json
+++ b/packages/test-utils/sdks/readme/package.json
@@ -12,7 +12,8 @@
     "./types": {
       "import": "./dist/types.d.mts",
       "require": "./dist/types.d.ts"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "files": [
     "dist",

--- a/packages/test-utils/sdks/response-title-quirks/package.json
+++ b/packages/test-utils/sdks/response-title-quirks/package.json
@@ -12,7 +12,8 @@
     "./types": {
       "import": "./dist/types.d.mts",
       "require": "./dist/types.d.ts"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "files": [
     "dist",

--- a/packages/test-utils/sdks/simple/package.json
+++ b/packages/test-utils/sdks/simple/package.json
@@ -12,7 +12,8 @@
     "./types": {
       "import": "./dist/types.d.mts",
       "require": "./dist/types.d.ts"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "files": [
     "dist",

--- a/packages/test-utils/sdks/star-trek/package.json
+++ b/packages/test-utils/sdks/star-trek/package.json
@@ -12,7 +12,8 @@
     "./types": {
       "import": "./dist/types.d.mts",
       "require": "./dist/types.d.ts"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "files": [
     "dist",


### PR DESCRIPTION
## 🧰 Changes

This updates our codegen'd SDKs so their `package.json` files now surface the `package.json` in the `exports` object. Why? I still don't exactly know, but it feels like a safe convention to follow in lieu of an actual spec around this ¯\_(ツ)_/¯

I thought about also adding [`sideEffects: false`](https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free) the way we do in other places but I think the SDK might need to be set to `type: module` first?
