### PR TITLE
fix(httpsnippet-client-api): making external deps no longer external

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23063,6 +23063,10 @@
     },
     "packages/httpsnippet-client-api": {
       "version": "7.0.0-beta.3",
+      "bundleDependencies": [
+        "camelcase",
+        "stringify-object"
+      ],
       "license": "MIT",
       "dependencies": {
         "camelcase": "^8.0.0",
@@ -23091,6 +23095,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-8.0.0.tgz",
       "integrity": "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==",
+      "inBundle": true,
       "engines": {
         "node": ">=16"
       },
@@ -23102,6 +23107,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-3.0.0.tgz",
       "integrity": "sha512-IlsXEHOjtKhpN8r/tRFj2nDyTmHvcfNeu/nrRIcXE17ROeatXchkojffa1SpdqW4cr/Fj6QkEf/Gn4zf6KKvEQ==",
+      "inBundle": true,
       "engines": {
         "node": ">=12"
       },
@@ -23113,6 +23119,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-3.1.0.tgz",
       "integrity": "sha512-rbku49cWloU5bSMI+zaRaXdQHXnthP6DZ/vLnfdSKyL4zUzuWnomtOEiZZOd+ioQ+avFo/qau3KPTc7Fjy1uPA==",
+      "inBundle": true,
       "engines": {
         "node": ">=12"
       },
@@ -23124,6 +23131,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-5.0.0.tgz",
       "integrity": "sha512-zaJYxz2FtcMb4f+g60KsRNFOpVMUyuJgA51Zi5Z1DOTC3S59+OQiVOzE9GZt0x72uBGWKsQIuBKeF9iusmKFsg==",
+      "inBundle": true,
       "dependencies": {
         "get-own-enumerable-keys": "^1.0.0",
         "is-obj": "^3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9825,6 +9825,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/get-own-enumerable-keys/-/get-own-enumerable-keys-1.0.0.tgz",
       "integrity": "sha512-PKsK2FSrQCyxcGHsGrLDcK0lx+0Ke+6e8KFFozA9/fIQLhQzPaRvJFdcz7+Axg3jUH/Mq+NI4xa5u/UT2tQskA==",
+      "dev": true,
       "engines": {
         "node": ">=14.16"
       },
@@ -23069,10 +23070,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "camelcase": "^8.0.0",
         "content-type": "^1.0.5",
-        "reserved2": "^0.1.5",
-        "stringify-object": "^5.0.0"
+        "reserved2": "^0.1.5"
       },
       "devDependencies": {
         "@readme/oas-examples": "^5.12.0",
@@ -23080,6 +23079,8 @@
         "@types/content-type": "^1.1.6",
         "@types/stringify-object": "^4.0.3",
         "@vitest/coverage-v8": "^0.34.4",
+        "camelcase": "^8.0.0",
+        "stringify-object": "^5.0.0",
         "typescript": "^5.2.2",
         "vitest": "^0.34.5"
       },
@@ -23095,6 +23096,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-8.0.0.tgz",
       "integrity": "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==",
+      "dev": true,
       "inBundle": true,
       "engines": {
         "node": ">=16"
@@ -23107,6 +23109,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-3.0.0.tgz",
       "integrity": "sha512-IlsXEHOjtKhpN8r/tRFj2nDyTmHvcfNeu/nrRIcXE17ROeatXchkojffa1SpdqW4cr/Fj6QkEf/Gn4zf6KKvEQ==",
+      "dev": true,
       "inBundle": true,
       "engines": {
         "node": ">=12"
@@ -23119,6 +23122,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-3.1.0.tgz",
       "integrity": "sha512-rbku49cWloU5bSMI+zaRaXdQHXnthP6DZ/vLnfdSKyL4zUzuWnomtOEiZZOd+ioQ+avFo/qau3KPTc7Fjy1uPA==",
+      "dev": true,
       "inBundle": true,
       "engines": {
         "node": ">=12"
@@ -23131,6 +23135,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-5.0.0.tgz",
       "integrity": "sha512-zaJYxz2FtcMb4f+g60KsRNFOpVMUyuJgA51Zi5Z1DOTC3S59+OQiVOzE9GZt0x72uBGWKsQIuBKeF9iusmKFsg==",
+      "dev": true,
       "inBundle": true,
       "dependencies": {
         "get-own-enumerable-keys": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23064,10 +23064,6 @@
     },
     "packages/httpsnippet-client-api": {
       "version": "7.0.0-beta.3",
-      "bundleDependencies": [
-        "camelcase",
-        "stringify-object"
-      ],
       "license": "MIT",
       "dependencies": {
         "content-type": "^1.0.5",
@@ -23097,7 +23093,6 @@
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-8.0.0.tgz",
       "integrity": "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==",
       "dev": true,
-      "inBundle": true,
       "engines": {
         "node": ">=16"
       },
@@ -23110,7 +23105,6 @@
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-3.0.0.tgz",
       "integrity": "sha512-IlsXEHOjtKhpN8r/tRFj2nDyTmHvcfNeu/nrRIcXE17ROeatXchkojffa1SpdqW4cr/Fj6QkEf/Gn4zf6KKvEQ==",
       "dev": true,
-      "inBundle": true,
       "engines": {
         "node": ">=12"
       },
@@ -23123,7 +23117,6 @@
       "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-3.1.0.tgz",
       "integrity": "sha512-rbku49cWloU5bSMI+zaRaXdQHXnthP6DZ/vLnfdSKyL4zUzuWnomtOEiZZOd+ioQ+avFo/qau3KPTc7Fjy1uPA==",
       "dev": true,
-      "inBundle": true,
       "engines": {
         "node": ">=12"
       },
@@ -23136,7 +23129,6 @@
       "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-5.0.0.tgz",
       "integrity": "sha512-zaJYxz2FtcMb4f+g60KsRNFOpVMUyuJgA51Zi5Z1DOTC3S59+OQiVOzE9GZt0x72uBGWKsQIuBKeF9iusmKFsg==",
       "dev": true,
-      "inBundle": true,
       "dependencies": {
         "get-own-enumerable-keys": "^1.0.0",
         "is-obj": "^3.0.0",

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -11,11 +11,14 @@ export default defineConfig((options: Options) => ({
   ...config,
 
   entry: ['src/errors/fetchError.ts', 'src/lib/index.ts', 'src/index.ts', 'src/types.ts'],
+
   noExternal: [
-    // `get-stream` is ESM-only and we need to build for CommonJS,
-    // so including it here means that its (tree-shaken!) source code
-    // will be included directly in our dist outputs.
+    // These dependencies are ESM-only but because we're building for ESM **and** CJS we can't
+    // treat them as external dependencies as CJS libraries can't load ESM code that uses `export`.
+    // `noExternal` will instead treeshake these dependencies down and include them in our compiled
+    // dists.
     'get-stream',
   ],
+
   silent: !options.watch,
 }));

--- a/packages/httpsnippet-client-api/package.json
+++ b/packages/httpsnippet-client-api/package.json
@@ -36,10 +36,8 @@
     "node": ">=18"
   },
   "dependencies": {
-    "camelcase": "^8.0.0",
     "content-type": "^1.0.5",
-    "reserved2": "^0.1.5",
-    "stringify-object": "^5.0.0"
+    "reserved2": "^0.1.5"
   },
   "peerDependencies": {
     "@readme/httpsnippet": ">=8.1.2",
@@ -55,6 +53,8 @@
     "@types/content-type": "^1.1.6",
     "@types/stringify-object": "^4.0.3",
     "@vitest/coverage-v8": "^0.34.4",
+    "camelcase": "^8.0.0",
+    "stringify-object": "^5.0.0",
     "typescript": "^5.2.2",
     "vitest": "^0.34.5"
   },

--- a/packages/httpsnippet-client-api/package.json
+++ b/packages/httpsnippet-client-api/package.json
@@ -45,6 +45,10 @@
     "@readme/httpsnippet": ">=8.1.2",
     "oas": "^24.0.0"
   },
+  "bundledDependencies": [
+    "camelcase",
+    "stringify-object"
+  ],
   "devDependencies": {
     "@readme/oas-examples": "^5.12.0",
     "@readme/openapi-parser": "^2.5.0",

--- a/packages/httpsnippet-client-api/package.json
+++ b/packages/httpsnippet-client-api/package.json
@@ -43,10 +43,6 @@
     "@readme/httpsnippet": ">=8.1.2",
     "oas": "^24.0.0"
   },
-  "bundledDependencies": [
-    "camelcase",
-    "stringify-object"
-  ],
   "devDependencies": {
     "@readme/oas-examples": "^5.12.0",
     "@readme/openapi-parser": "^2.5.0",

--- a/packages/httpsnippet-client-api/src/index.ts
+++ b/packages/httpsnippet-client-api/src/index.ts
@@ -4,12 +4,12 @@ import type { Operation } from 'oas/operation';
 import type { HttpMethods, OASDocument } from 'oas/types';
 
 import { CodeBuilder } from '@readme/httpsnippet/helpers/code-builder';
-import camelCase from 'camelcase';
+import camelCase from 'camelcase'; // eslint-disable-line import/no-extraneous-dependencies
 import contentType from 'content-type';
 import Oas from 'oas';
 import { matchesMimeType } from 'oas/utils';
 import { isReservedOrBuiltinsLC } from 'reserved2';
-import stringifyObject from 'stringify-object';
+import stringifyObject from 'stringify-object'; // eslint-disable-line import/no-extraneous-dependencies
 
 /**
  * @note This regex also exists in `api/fetcher`.

--- a/packages/httpsnippet-client-api/tsup.config.ts
+++ b/packages/httpsnippet-client-api/tsup.config.ts
@@ -11,5 +11,15 @@ export default defineConfig((options: Options) => ({
   ...config,
 
   entry: ['src/index.ts'],
+
+  noExternal: [
+    // These dependencies are ESM-only but because we're building for ESM **and** CJS we can't
+    // treat them as external dependencies as CJS libraries can't load ESM code that uses `export`.
+    // `noExternal` will instead treeshake these dependencies down and include them in our compiled
+    // dists.
+    'camelcase',
+    'stringify-object',
+  ],
+
   silent: !options.watch,
 }));


### PR DESCRIPTION
## 🧰 Changes

`camelcase` and `stringify-object` being ESM only is causing issues with loading `httpsnippet-client-api` in CJS environments. This work moves them to now being compiled into our dist.