### PR TITLE
test: add mocks for `packageVersion`

### DIFF
--- a/packages/api/test/codegen/languages/typescript/index.test.ts
+++ b/packages/api/test/codegen/languages/typescript/index.test.ts
@@ -1,3 +1,5 @@
+import type { SpyInstance } from 'vitest';
+
 import fs from 'node:fs/promises';
 import path from 'node:path';
 
@@ -73,19 +75,16 @@ function assertSDKFixture(file: string, fixture: string) {
         // We have to wrap in our current package version into the `<<useragent>>` placeholder so
         // we don't need to worry about committing package versions into source control or trying
         // to mock out our `packageInfo` library, potentially causing sideeffects in other tests.
-        return fs
-          .readFile(expectedFilePath, 'utf8')
-          .then(expected => expected.replace('<<package version>>', packageInfo.PACKAGE_VERSION))
-          .then(async expected => {
-            if (actual !== expected && process.env.UPDATE_FIXTURES) {
-              // eslint-disable-next-line no-console
-              console.info('[sdk fixture updated]', expectedFilePath);
-              await fs.writeFile(expectedFilePath, actual.replace(packageInfo.PACKAGE_VERSION, '<<package version>>'));
-              return;
-            }
+        return fs.readFile(expectedFilePath, 'utf8').then(async expected => {
+          if (actual !== expected && process.env.UPDATE_FIXTURES) {
+            // eslint-disable-next-line no-console
+            console.info('[sdk fixture updated]', expectedFilePath);
+            await fs.writeFile(expectedFilePath, actual);
+            return;
+          }
 
-            expect(actual).toBe(expected);
-          });
+          expect(actual).toBe(expected);
+        });
       }),
     );
 
@@ -96,12 +95,17 @@ function assertSDKFixture(file: string, fixture: string) {
 }
 
 describe('typescript', () => {
+  let packageInfoSpy: SpyInstance;
+
   beforeEach(() => {
+    // @ts-expect-error deliberately setting this const to another value
+    packageInfoSpy = vi.spyOn(packageInfo, 'PACKAGE_VERSION', 'get').mockReturnValue('7.0.0-mock');
     vi.setSystemTime(new Date('2023-10-25'));
     Storage.setStorageDir(uniqueTempDir());
   });
 
   afterEach(() => {
+    packageInfoSpy.mockReset();
     vi.useRealTimers();
     Storage.reset();
   });

--- a/packages/api/test/commands/__snapshots__/list.test.ts.snap
+++ b/packages/api/test/commands/__snapshots__/list.test.ts.snap
@@ -9,7 +9,7 @@ language: [90mjs[39m
 
 source: [90m@petstore/v1.0#n6kvf10vakpemvplx[39m
 
-installer version: [90m7.0.0-beta.3[39m
+installer version: [90m7.0.0-mock[39m
 
 created at: [90m2023-10-25T00:00:00.000Z[39m"
 `;

--- a/packages/api/test/commands/list.test.ts
+++ b/packages/api/test/commands/list.test.ts
@@ -8,6 +8,7 @@ import { describe, beforeEach, it, expect, vi, afterEach } from 'vitest';
 
 import { SupportedLanguages } from '../../src/codegen/factory.js';
 import installCmd from '../../src/commands/list.js';
+import * as packageInfo from '../../src/packageInfo.js';
 import Storage from '../../src/storage.js';
 
 const baseCommand = ['api', 'list'];
@@ -18,6 +19,7 @@ describe('install command', () => {
   let stdout: string[];
   let stderr: string[];
   let consoleLogSpy: SpyInstance;
+  let packageInfoSpy: SpyInstance;
 
   const getCommandOutput = () => {
     return [consoleLogSpy.mock.calls.join('\n\n')].filter(Boolean).join('\n\n');
@@ -34,13 +36,16 @@ describe('install command', () => {
     });
 
     consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    // @ts-expect-error deliberately setting this const to another value
+    packageInfoSpy = vi.spyOn(packageInfo, 'PACKAGE_VERSION', 'get').mockReturnValue('7.0.0-mock');
     Storage.setStorageDir(uniqueTempDir());
     vi.setSystemTime(new Date('2023-10-25'));
   });
 
   afterEach(() => {
-    consoleLogSpy.mockRestore();
+    consoleLogSpy.mockReset();
     fetchMock.restore();
+    packageInfoSpy.mockReset();
     Storage.reset();
     vi.useRealTimers();
   });

--- a/packages/test-utils/sdks/alby/README.md
+++ b/packages/test-utils/sdks/alby/README.md
@@ -17,7 +17,7 @@ alby.getMe()
 
 Here's some additional info about the generated SDK:
 
-`api` version: <<package version>>
+`api` version: 7.0.0-mock
 Generated at 2023-10-25T00:00:00.000Z
 
 --->

--- a/packages/test-utils/sdks/alby/src/index.ts
+++ b/packages/test-utils/sdks/alby/src/index.ts
@@ -7,7 +7,7 @@ class SDK {
   core: APICore;
 
   constructor() {
-    this.core = new APICore(definition, 'alby/1.0.14 (api/<<package version>>)');
+    this.core = new APICore(definition, 'alby/1.0.14 (api/7.0.0-mock)');
   }
 
   /**

--- a/packages/test-utils/sdks/metrotransit/README.md
+++ b/packages/test-utils/sdks/metrotransit/README.md
@@ -16,7 +16,7 @@ metrotransit.getNextripAgencies()
 
 Here's some additional info about the generated SDK:
 
-`api` version: <<package version>>
+`api` version: 7.0.0-mock
 Generated at 2023-10-25T00:00:00.000Z
 
 --->

--- a/packages/test-utils/sdks/metrotransit/src/index.ts
+++ b/packages/test-utils/sdks/metrotransit/src/index.ts
@@ -7,7 +7,7 @@ class SDK {
   core: APICore;
 
   constructor() {
-    this.core = new APICore(definition, 'metrotransit/2 (api/<<package version>>)');
+    this.core = new APICore(definition, 'metrotransit/2 (api/7.0.0-mock)');
   }
 
   /**

--- a/packages/test-utils/sdks/operationid-quirks/README.md
+++ b/packages/test-utils/sdks/operationid-quirks/README.md
@@ -16,7 +16,7 @@ operationidQuirks.quirky_OperationId_string()
 
 Here's some additional info about the generated SDK:
 
-`api` version: <<package version>>
+`api` version: 7.0.0-mock
 Generated at 2023-10-25T00:00:00.000Z
 
 --->

--- a/packages/test-utils/sdks/operationid-quirks/src/index.ts
+++ b/packages/test-utils/sdks/operationid-quirks/src/index.ts
@@ -6,7 +6,7 @@ class SDK {
   core: APICore;
 
   constructor() {
-    this.core = new APICore(definition, 'operationid-quirks/1.0.0 (api/<<package version>>)');
+    this.core = new APICore(definition, 'operationid-quirks/1.0.0 (api/7.0.0-mock)');
   }
 
   /**

--- a/packages/test-utils/sdks/optional-payload/README.md
+++ b/packages/test-utils/sdks/optional-payload/README.md
@@ -8,7 +8,7 @@ Add SDK setup information and usage examples here so your users get started in a
 
 Here's some additional info about the generated SDK:
 
-`api` version: <<package version>>
+`api` version: 7.0.0-mock
 Generated at 2023-10-25T00:00:00.000Z
 
 --->

--- a/packages/test-utils/sdks/optional-payload/src/index.ts
+++ b/packages/test-utils/sdks/optional-payload/src/index.ts
@@ -7,7 +7,7 @@ class SDK {
   core: APICore;
 
   constructor() {
-    this.core = new APICore(definition, 'optional-payload/1.0.0 (api/<<package version>>)');
+    this.core = new APICore(definition, 'optional-payload/1.0.0 (api/7.0.0-mock)');
   }
 
   /**

--- a/packages/test-utils/sdks/petstore/README.md
+++ b/packages/test-utils/sdks/petstore/README.md
@@ -17,7 +17,7 @@ petstore.getInventory()
 
 Here's some additional info about the generated SDK:
 
-`api` version: <<package version>>
+`api` version: 7.0.0-mock
 Generated at 2023-10-25T00:00:00.000Z
 
 --->

--- a/packages/test-utils/sdks/petstore/src/index.ts
+++ b/packages/test-utils/sdks/petstore/src/index.ts
@@ -7,7 +7,7 @@ class SDK {
   core: APICore;
 
   constructor() {
-    this.core = new APICore(definition, 'petstore/1.0.0 (api/<<package version>>)');
+    this.core = new APICore(definition, 'petstore/1.0.0 (api/7.0.0-mock)');
   }
 
   /**

--- a/packages/test-utils/sdks/readme/README.md
+++ b/packages/test-utils/sdks/readme/README.md
@@ -17,7 +17,7 @@ readme.getAPISpecification()
 
 Here's some additional info about the generated SDK:
 
-`api` version: <<package version>>
+`api` version: 7.0.0-mock
 Generated at 2023-10-25T00:00:00.000Z
 
 --->

--- a/packages/test-utils/sdks/readme/src/index.ts
+++ b/packages/test-utils/sdks/readme/src/index.ts
@@ -7,7 +7,7 @@ class SDK {
   core: APICore;
 
   constructor() {
-    this.core = new APICore(definition, 'readme/4.355.0 (api/<<package version>>)');
+    this.core = new APICore(definition, 'readme/4.355.0 (api/7.0.0-mock)');
   }
 
   /**

--- a/packages/test-utils/sdks/response-title-quirks/README.md
+++ b/packages/test-utils/sdks/response-title-quirks/README.md
@@ -8,7 +8,7 @@ Add SDK setup information and usage examples here so your users get started in a
 
 Here's some additional info about the generated SDK:
 
-`api` version: <<package version>>
+`api` version: 7.0.0-mock
 Generated at 2023-10-25T00:00:00.000Z
 
 --->

--- a/packages/test-utils/sdks/response-title-quirks/src/index.ts
+++ b/packages/test-utils/sdks/response-title-quirks/src/index.ts
@@ -7,7 +7,7 @@ class SDK {
   core: APICore;
 
   constructor() {
-    this.core = new APICore(definition, 'response-title-quirks/1.0.0 (api/<<package version>>)');
+    this.core = new APICore(definition, 'response-title-quirks/1.0.0 (api/7.0.0-mock)');
   }
 
   /**

--- a/packages/test-utils/sdks/simple/README.md
+++ b/packages/test-utils/sdks/simple/README.md
@@ -8,7 +8,7 @@ Add SDK setup information and usage examples here so your users get started in a
 
 Here's some additional info about the generated SDK:
 
-`api` version: <<package version>>
+`api` version: 7.0.0-mock
 Generated at 2023-10-25T00:00:00.000Z
 
 --->

--- a/packages/test-utils/sdks/simple/src/index.ts
+++ b/packages/test-utils/sdks/simple/src/index.ts
@@ -7,7 +7,7 @@ class SDK {
   core: APICore;
 
   constructor() {
-    this.core = new APICore(definition, 'simple/1.0.0 (api/<<package version>>)');
+    this.core = new APICore(definition, 'simple/1.0.0 (api/7.0.0-mock)');
   }
 
   /**

--- a/packages/test-utils/sdks/star-trek/README.md
+++ b/packages/test-utils/sdks/star-trek/README.md
@@ -16,7 +16,7 @@ starTrek.getAnimalSearch()
 
 Here's some additional info about the generated SDK:
 
-`api` version: <<package version>>
+`api` version: 7.0.0-mock
 Generated at 2023-10-25T00:00:00.000Z
 
 --->

--- a/packages/test-utils/sdks/star-trek/src/index.ts
+++ b/packages/test-utils/sdks/star-trek/src/index.ts
@@ -7,7 +7,7 @@ class SDK {
   core: APICore;
 
   constructor() {
-    this.core = new APICore(definition, 'star-trek/1.0.0 (api/<<package version>>)');
+    this.core = new APICore(definition, 'star-trek/1.0.0 (api/7.0.0-mock)');
   }
 
   /**


### PR DESCRIPTION
## 🧰 Changes

Fixes a broken test that was introduced in https://github.com/readmeio/api/pull/799 — added a mock for the `PACKAGE_VERSION` const in a few places so these tests should be stable for future package bumps.

## 🧬 QA & Testing

Do tests pass now?
