### PR TITLE
feat(api): import schemas in the types file as types

### DIFF
--- a/packages/api/src/codegen/languages/typescript/index.ts
+++ b/packages/api/src/codegen/languages/typescript/index.ts
@@ -778,7 +778,7 @@ Generated at ${createdAt}
 
     sourceFile.addImportDeclarations([
       { defaultImport: 'type { FromSchema }', moduleSpecifier: '@readme/api-core/types' },
-      { defaultImport: '* as schemas', moduleSpecifier: './schemas.js' },
+      { defaultImport: 'type * as schemas', moduleSpecifier: './schemas.js' },
     ]);
 
     Array.from(new Map(Array.from(this.types.entries()).sort())).forEach(([typeName, typeExpression]) => {

--- a/packages/test-utils/sdks/alby/src/types.ts
+++ b/packages/test-utils/sdks/alby/src/types.ts
@@ -1,5 +1,5 @@
 import type { FromSchema } from '@readme/api-core/types';
-import * as schemas from './schemas.js';
+import type * as schemas from './schemas.js';
 
 export type AmqpExternalRulePatch = FromSchema<typeof schemas.AmqpExternalRulePatch>;
 export type AmqpExternalRulePost = FromSchema<typeof schemas.AmqpExternalRulePost>;

--- a/packages/test-utils/sdks/metrotransit/src/types.ts
+++ b/packages/test-utils/sdks/metrotransit/src/types.ts
@@ -1,5 +1,5 @@
 import type { FromSchema } from '@readme/api-core/types';
-import * as schemas from './schemas.js';
+import type * as schemas from './schemas.js';
 
 export type Agency = FromSchema<typeof schemas.Agency>;
 export type AlertMessage = FromSchema<typeof schemas.AlertMessage>;

--- a/packages/test-utils/sdks/optional-payload/src/types.ts
+++ b/packages/test-utils/sdks/optional-payload/src/types.ts
@@ -1,5 +1,5 @@
 import type { FromSchema } from '@readme/api-core/types';
-import * as schemas from './schemas.js';
+import type * as schemas from './schemas.js';
 
 export type UpdatePetWithFormFormDataParam = FromSchema<typeof schemas.UpdatePetWithForm.formData>;
 export type UpdatePetWithFormMetadataParam = FromSchema<typeof schemas.UpdatePetWithForm.metadata>;

--- a/packages/test-utils/sdks/petstore/src/types.ts
+++ b/packages/test-utils/sdks/petstore/src/types.ts
@@ -1,5 +1,5 @@
 import type { FromSchema } from '@readme/api-core/types';
-import * as schemas from './schemas.js';
+import type * as schemas from './schemas.js';
 
 export type ApiResponse = FromSchema<typeof schemas.ApiResponse>;
 export type Category = FromSchema<typeof schemas.Category>;

--- a/packages/test-utils/sdks/readme/src/types.ts
+++ b/packages/test-utils/sdks/readme/src/types.ts
@@ -1,5 +1,5 @@
 import type { FromSchema } from '@readme/api-core/types';
-import * as schemas from './schemas.js';
+import type * as schemas from './schemas.js';
 
 export type Apply = FromSchema<typeof schemas.Apply>;
 export type Category = FromSchema<typeof schemas.Category>;

--- a/packages/test-utils/sdks/response-title-quirks/src/types.ts
+++ b/packages/test-utils/sdks/response-title-quirks/src/types.ts
@@ -1,5 +1,5 @@
 import type { FromSchema } from '@readme/api-core/types';
-import * as schemas from './schemas.js';
+import type * as schemas from './schemas.js';
 
 export type GetAnythingMetadataParam = FromSchema<typeof schemas.GetAnything.metadata>;
 export type GetAnythingResponse2XX = FromSchema<typeof schemas.GetAnything.response['2XX']>;

--- a/packages/test-utils/sdks/simple/src/types.ts
+++ b/packages/test-utils/sdks/simple/src/types.ts
@@ -1,5 +1,5 @@
 import type { FromSchema } from '@readme/api-core/types';
-import * as schemas from './schemas.js';
+import type * as schemas from './schemas.js';
 
 export type Category = FromSchema<typeof schemas.Category>;
 export type FindPetsByStatusMetadataParam = FromSchema<typeof schemas.FindPetsByStatus.metadata>;

--- a/packages/test-utils/sdks/star-trek/src/types.ts
+++ b/packages/test-utils/sdks/star-trek/src/types.ts
@@ -1,5 +1,5 @@
 import type { FromSchema } from '@readme/api-core/types';
-import * as schemas from './schemas.js';
+import type * as schemas from './schemas.js';
 
 export type AnimalBase = FromSchema<typeof schemas.AnimalBase>;
 export type AnimalBaseResponse = FromSchema<typeof schemas.AnimalBaseResponse>;


### PR DESCRIPTION
## 🧰 Changes

Because all of the schemas that we're importing in codegen'd `types.ts` files are for types only we can import them explicitly as types.