### PR TITLE
feat(snippets): splitting apart package and variable name configs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23075,7 +23075,6 @@
         "@types/content-type": "^1.1.6",
         "@types/stringify-object": "^4.0.3",
         "@vitest/coverage-v8": "^0.34.4",
-        "camelcase": "^8.0.0",
         "stringify-object": "^5.0.0",
         "typescript": "^5.2.2",
         "vitest": "^0.34.5"
@@ -23086,18 +23085,6 @@
       "peerDependencies": {
         "@readme/httpsnippet": ">=8.1.2",
         "oas": "^24.0.0"
-      }
-    },
-    "packages/httpsnippet-client-api/node_modules/camelcase": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-8.0.0.tgz",
-      "integrity": "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==",
-      "dev": true,
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "packages/httpsnippet-client-api/node_modules/is-obj": {

--- a/packages/httpsnippet-client-api/package.json
+++ b/packages/httpsnippet-client-api/package.json
@@ -49,7 +49,6 @@
     "@types/content-type": "^1.1.6",
     "@types/stringify-object": "^4.0.3",
     "@vitest/coverage-v8": "^0.34.4",
-    "camelcase": "^8.0.0",
     "stringify-object": "^5.0.0",
     "typescript": "^5.2.2",
     "vitest": "^0.34.5"

--- a/packages/httpsnippet-client-api/test/index.test.ts
+++ b/packages/httpsnippet-client-api/test/index.test.ts
@@ -141,15 +141,16 @@ describe('httpsnippet-client-api', () => {
         const code = await new HTTPSnippet(mock.har).convert('node', 'api', {
           api: {
             definition: mock.definition,
-            identifier: 'developers',
+            packageName: 'developers',
             registryURI: '@developers/v2.0#17273l2glm9fq4l5',
+            variableName: 'developersSDK',
           },
         });
 
-        expect(code).toStrictEqual(`import developers from '@api/developers';
+        expect(code).toStrictEqual(`import developersSDK from '@api/developers';
 
-developers.auth('123');
-developers.findPetsByStatus({status: 'available', accept: 'application/xml'})
+developersSDK.auth('123');
+developersSDK.findPetsByStatus({status: 'available', accept: 'application/xml'})
   .then(({ data }) => console.log(data))
   .catch(err => console.error(err));`);
       });
@@ -160,15 +161,16 @@ developers.findPetsByStatus({status: 'available', accept: 'application/xml'})
         const code = await new HTTPSnippet(mock.har).convert('node', 'api', {
           api: {
             definition: mock.definition,
-            identifier: 'metro-transit',
+            packageName: 'metro-transit',
             registryURI: '@metro-transit/v2.0#17273l2glm9fq4l5',
+            variableName: 'metro-transit-SDK',
           },
         });
 
-        expect(code).toStrictEqual(`import metroTransit from '@api/metro-transit';
+        expect(code).toStrictEqual(`import metroTransitSDK from '@api/metro-transit';
 
-metroTransit.auth('123');
-metroTransit.findPetsByStatus({status: 'available', accept: 'application/xml'})
+metroTransitSDK.auth('123');
+metroTransitSDK.findPetsByStatus({status: 'available', accept: 'application/xml'})
   .then(({ data }) => console.log(data))
   .catch(err => console.error(err));`);
       });

--- a/packages/httpsnippet-client-api/tsup.config.ts
+++ b/packages/httpsnippet-client-api/tsup.config.ts
@@ -17,7 +17,6 @@ export default defineConfig((options: Options) => ({
     // treat them as external dependencies as CJS libraries can't load ESM code that uses `export`.
     // `noExternal` will instead treeshake these dependencies down and include them in our compiled
     // dists.
-    'camelcase',
     'stringify-object',
   ],
 


### PR DESCRIPTION
## 🧰 Changes

This splits apart some confusing work I did in `httpsnippet-client-api` where I was always tying the `@api/<package name>` to the variable name if a custom variable name was supplied. For example if you supplied an `identifier` of `petstore` and `variableName` of `buster`, the variable name would be `buster` but `@api/<package name>` would also be `@api/buster`. Very confusing and not really now we intend this custom variable name support to be handled.

Instead I've renamed the `identifier` option to the clearer `packageName` and added a new dedicated `variableName` config for custom variable names. This small refactor will require a couple small changes to `@readme/oas-to-snippet`.