### PR TITLE
feat(api): small CLI quality-of-life changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2885,7 +2885,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@pnpm/config.env-replace/-/config.env-replace-1.1.0.tgz",
       "integrity": "sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==",
-      "dev": true,
       "engines": {
         "node": ">=12.22.0"
       }
@@ -3000,7 +2999,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@pnpm/network.ca-file/-/network.ca-file-1.0.2.tgz",
       "integrity": "sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA==",
-      "dev": true,
       "dependencies": {
         "graceful-fs": "4.2.10"
       },
@@ -3011,14 +3009,12 @@
     "node_modules/@pnpm/network.ca-file/node_modules/graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
-      "dev": true
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
     },
     "node_modules/@pnpm/npm-conf": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/@pnpm/npm-conf/-/npm-conf-2.2.2.tgz",
       "integrity": "sha512-UA91GwWPhFExt3IizW6bOeY/pQ0BkuNwKjk9iQW9KqxluGCrg4VenZ0/L+2Y0+ZOtme72EVvg6v0zo3AMQRCeA==",
-      "dev": true,
       "dependencies": {
         "@pnpm/config.env-replace": "^1.1.0",
         "@pnpm/network.ca-file": "^1.0.1",
@@ -3407,7 +3403,6 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-5.6.0.tgz",
       "integrity": "sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==",
-      "dev": true,
       "engines": {
         "node": ">=14.16"
       },
@@ -3445,7 +3440,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
       "integrity": "sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==",
-      "dev": true,
       "dependencies": {
         "defer-to-connect": "^2.0.1"
       },
@@ -3630,6 +3624,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/configstore": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@types/configstore/-/configstore-6.0.2.tgz",
+      "integrity": "sha512-OS//b51j9uyR3zvwD04Kfs5kHpve2qalQ18JhY/ho3voGYUTPLEG90/ocfKPI48hyHH8T04f7KEEbK6Ue60oZQ==",
+      "dev": true
+    },
     "node_modules/@types/content-type": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/@types/content-type/-/content-type-1.1.7.tgz",
@@ -3676,8 +3676,7 @@
     "node_modules/@types/http-cache-semantics": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.2.tgz",
-      "integrity": "sha512-FD+nQWA2zJjh4L9+pFXqWOi0Hs1ryBCfI+985NjluQ1p8EYtoLvjLOKidXBtZ4/IcxDX4o8/E8qDS3540tNliw==",
-      "dev": true
+      "integrity": "sha512-FD+nQWA2zJjh4L9+pFXqWOi0Hs1ryBCfI+985NjluQ1p8EYtoLvjLOKidXBtZ4/IcxDX4o8/E8qDS3540tNliw=="
     },
     "node_modules/@types/is-empty": {
       "version": "1.2.1",
@@ -3847,6 +3846,16 @@
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.8.tgz",
       "integrity": "sha512-d0XxK3YTObnWVp6rZuev3c49+j4Lo8g4L1ZRm9z5L0xpoZycUPshHgczK5gsUMaZOstjVYYi09p5gYvUtfChYw=="
+    },
+    "node_modules/@types/update-notifier": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@types/update-notifier/-/update-notifier-6.0.7.tgz",
+      "integrity": "sha512-nJuO9aZYKVzOEsjkmcLl86YqnJghl3MOukTObamkdKUvWz608gvNpG6U3E7rqnkxeVq4/KjbX+URe+FA5SFU7A==",
+      "dev": true,
+      "dependencies": {
+        "@types/configstore": "*",
+        "boxen": "^7.0.0"
+      }
     },
     "node_modules/@types/uslug": {
       "version": "1.0.3",
@@ -4544,7 +4553,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
       "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
-      "dev": true,
       "dependencies": {
         "string-width": "^4.1.0"
       }
@@ -4552,14 +4560,12 @@
     "node_modules/ansi-align/node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "node_modules/ansi-align/node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -5041,7 +5047,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-7.1.1.tgz",
       "integrity": "sha512-2hCgjEmP8YLWQ130n2FerGv7rYpfBmnmp9Uy2Le1vge6X3gZIfSmEzP5QTDElFxcvVcXlEn8Aq6MU/PZygIOog==",
-      "dev": true,
       "dependencies": {
         "ansi-align": "^3.0.1",
         "camelcase": "^7.0.1",
@@ -5063,7 +5068,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
       "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
-      "dev": true,
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -5075,7 +5079,6 @@
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
       "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "dev": true,
       "engines": {
         "node": ">=12.20"
       },
@@ -5294,7 +5297,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
       "integrity": "sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==",
-      "dev": true,
       "engines": {
         "node": ">=14.16"
       }
@@ -5303,7 +5305,6 @@
       "version": "10.2.13",
       "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-10.2.13.tgz",
       "integrity": "sha512-3SD4rrMu1msNGEtNSt8Od6enwdo//U9s4ykmXfA2TD58kcLkCobtCDiby7kNyj7a/Q7lz/mAesAFI54rTdnvBA==",
-      "dev": true,
       "dependencies": {
         "@types/http-cache-semantics": "^4.0.1",
         "get-stream": "^6.0.1",
@@ -5347,7 +5348,6 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-7.0.1.tgz",
       "integrity": "sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==",
-      "dev": true,
       "engines": {
         "node": ">=14.16"
       },
@@ -5618,7 +5618,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
       "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -5897,7 +5896,6 @@
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
       "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
-      "dev": true,
       "dependencies": {
         "ini": "^1.3.4",
         "proto-list": "~1.2.1"
@@ -5907,7 +5905,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-6.0.0.tgz",
       "integrity": "sha512-cD31W1v3GqUlQvbBCGcXmd2Nj9SvLDOP1oQ0YFuLETufzSPaKp11rYBsSOm7rCsW3OnIRAFM3OxRhceaXNYHkA==",
-      "dev": true,
       "dependencies": {
         "dot-prop": "^6.0.1",
         "graceful-fs": "^4.2.6",
@@ -5926,7 +5923,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-6.0.1.tgz",
       "integrity": "sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==",
-      "dev": true,
       "dependencies": {
         "is-obj": "^2.0.0"
       },
@@ -5941,7 +5937,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
       "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
-      "dev": true,
       "dependencies": {
         "imurmurhash": "^0.1.4",
         "is-typedarray": "^1.0.0",
@@ -7029,7 +7024,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-4.0.0.tgz",
       "integrity": "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==",
-      "dev": true,
       "dependencies": {
         "type-fest": "^1.0.1"
       },
@@ -7044,7 +7038,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
       "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -7195,7 +7188,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "dev": true,
       "dependencies": {
         "mimic-response": "^3.1.0"
       },
@@ -7210,7 +7202,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -7239,7 +7230,6 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "dev": true,
       "engines": {
         "node": ">=4.0.0"
       }
@@ -7416,7 +7406,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
       "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       }
@@ -7622,8 +7611,7 @@
     "node_modules/emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
     },
     "node_modules/emphasize": {
       "version": "6.0.0",
@@ -7965,7 +7953,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-goat/-/escape-goat-4.0.0.tgz",
       "integrity": "sha512-2Sd4ShcWxbx6OY1IHyla/CVNwvg7XwZVoXZHcSu9w9SReNP1EzzD5T8NWKIR38fIqEns9kDWKUQTXXAmlDrdPg==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -9628,7 +9615,6 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-2.1.4.tgz",
       "integrity": "sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==",
-      "dev": true,
       "engines": {
         "node": ">= 14.17"
       }
@@ -9996,7 +9982,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
       "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -10324,7 +10309,6 @@
       "version": "12.6.1",
       "resolved": "https://registry.npmjs.org/got/-/got-12.6.1.tgz",
       "integrity": "sha512-mThBblvlAF1d4O5oqyvN+ZxLAYwIJK7bpMxgYqPD9okW0C3qm5FFn7k811QrcuEBwaogR3ngOFoCfs6mRv7teQ==",
-      "dev": true,
       "dependencies": {
         "@sindresorhus/is": "^5.2.0",
         "@szmarczak/http-timer": "^5.0.1",
@@ -10695,8 +10679,7 @@
     "node_modules/http-cache-semantics": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
-      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
-      "dev": true
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
     },
     "node_modules/http-proxy-agent": {
       "version": "5.0.0",
@@ -10721,7 +10704,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.0.tgz",
       "integrity": "sha512-kZB0wxMo0sh1PehyjJUWRFEd99KC5TLjZ2cULC4f9iqJBAmKQQXEICjxl5iPJRwP40dpeHFqqhm7tYCvODpqpQ==",
-      "dev": true,
       "dependencies": {
         "quick-lru": "^5.1.1",
         "resolve-alpn": "^1.2.0"
@@ -10734,7 +10716,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -10899,7 +10880,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
       "integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -11423,6 +11403,20 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/is-in-ci": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-in-ci/-/is-in-ci-0.1.0.tgz",
+      "integrity": "sha512-d9PXLEY0v1iJ64xLiQMJ51J128EYHAaOR4yZqQi8aHGfw6KgifM3/Viw1oZZ1GCVmb3gBuyhLyHj0HgR2DhSXQ==",
+      "bin": {
+        "is-in-ci": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-inside-container": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
@@ -11460,7 +11454,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.4.0.tgz",
       "integrity": "sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ==",
-      "dev": true,
       "dependencies": {
         "global-dirs": "^3.0.0",
         "is-path-inside": "^3.0.2"
@@ -11476,7 +11469,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-3.0.1.tgz",
       "integrity": "sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA==",
-      "dev": true,
       "dependencies": {
         "ini": "2.0.0"
       },
@@ -11491,7 +11483,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
       "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       }
@@ -11545,7 +11536,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-6.0.0.tgz",
       "integrity": "sha512-JEjxbSmtPSt1c8XTkVrlujcXdKV1/tvuQ7GwKcAlyiVLeYFQ2VHat8xfrDJsIkhCdF/tZ7CiIR3sy141c6+gPQ==",
-      "dev": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -11589,7 +11579,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
       "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -12020,8 +12009,7 @@
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-      "dev": true
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
     },
     "node_modules/json-parse-better-errors": {
       "version": "1.0.2",
@@ -12199,7 +12187,6 @@
       "version": "4.5.3",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.3.tgz",
       "integrity": "sha512-QCiSav9WaX1PgETJ+SpNnx2PRRapJ/oRSXM4VO5OGYGSjrxbKPVFVhB3l2OCbLCk329N8qyAtsJjSjvVBWzEug==",
-      "dev": true,
       "dependencies": {
         "json-buffer": "3.0.1"
       }
@@ -12329,7 +12316,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-7.0.0.tgz",
       "integrity": "sha512-KvNT4XqAMzdcL6ka6Tl3i2lYeFDgXNCuIX+xNx6ZMVR1dFq+idXd9FLKNMOIx0t9mJ9/HudyX4oZWXZQ0UJHeg==",
-      "dev": true,
       "dependencies": {
         "package-json": "^8.1.0"
       },
@@ -13851,7 +13837,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
       "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
-      "dev": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -15443,7 +15428,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-4.0.0.tgz",
       "integrity": "sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==",
-      "dev": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -15476,7 +15460,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -16309,7 +16292,6 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.0.0.tgz",
       "integrity": "sha512-uVFpKhj5MheNBJRTiMZ9pE/7hD1QTeEvugSJW/OmLzAp78PB5O6adfMNTvmfKhXBkvCzC+rqifWcVYpGFwTjnw==",
-      "dev": true,
       "engines": {
         "node": ">=14.16"
       },
@@ -17187,7 +17169,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-3.0.0.tgz",
       "integrity": "sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==",
-      "dev": true,
       "engines": {
         "node": ">=12.20"
       }
@@ -17382,7 +17363,6 @@
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/package-json/-/package-json-8.1.1.tgz",
       "integrity": "sha512-cbH9IAIJHNj9uXi196JVsRlt7cHKak6u/e6AkL/bkRelZ7rlL3X1YKxsZwa36xipOEKAsdtmaG6aAJoM1fx2zA==",
-      "dev": true,
       "dependencies": {
         "got": "^12.1.0",
         "registry-auth-token": "^5.0.1",
@@ -18212,8 +18192,7 @@
     "node_modules/proto-list": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
-      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
-      "dev": true
+      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA=="
     },
     "node_modules/protocols": {
       "version": "2.0.1",
@@ -18260,7 +18239,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/pupa/-/pupa-3.1.0.tgz",
       "integrity": "sha512-FLpr4flz5xZTSJxSeaheeMKN/EDzMdK7b8PTOC6a5PYFKTucWbdqjgqaEyH0shFiSJrVB1+Qqi4Tk19ccU6Aug==",
-      "dev": true,
       "dependencies": {
         "escape-goat": "^4.0.0"
       },
@@ -18359,7 +18337,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "dev": true,
       "dependencies": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -18374,7 +18351,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -18814,7 +18790,6 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-5.0.2.tgz",
       "integrity": "sha512-o/3ikDxtXaA59BmZuZrJZDJv8NMDGSj+6j6XaeBmHw8eY1i1qd9+6H+LjVvQXx3HN6aRCGa1cUdJ9RaJZUugnQ==",
-      "dev": true,
       "dependencies": {
         "@pnpm/npm-conf": "^2.1.0"
       },
@@ -18826,7 +18801,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-6.0.1.tgz",
       "integrity": "sha512-+crtS5QjFRqFCoQmvGduwYWEBng99ZvmFvF+cUJkGYF1L1BfU8C6Zp9T7f5vPAwyLkUExpvK+ANVZmGU49qi4Q==",
-      "dev": true,
       "dependencies": {
         "rc": "1.2.8"
       },
@@ -19074,8 +19048,7 @@
     "node_modules/resolve-alpn": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
-      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
-      "dev": true
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g=="
     },
     "node_modules/resolve-cwd": {
       "version": "3.0.0",
@@ -19111,7 +19084,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/responselike/-/responselike-3.0.0.tgz",
       "integrity": "sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==",
-      "dev": true,
       "dependencies": {
         "lowercase-keys": "^3.0.0"
       },
@@ -19409,7 +19381,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-4.0.0.tgz",
       "integrity": "sha512-0Ju4+6A8iOnpL/Thra7dZsSlOHYAHIeMxfhWQRI1/VLcT3WDBZKKtQt/QkBOsiIN9ZpuvHE6cGZ0x4glCMmfiA==",
-      "dev": true,
       "dependencies": {
         "semver": "^7.3.5"
       },
@@ -19964,7 +19935,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "dev": true,
       "dependencies": {
         "eastasianwidth": "^0.2.0",
         "emoji-regex": "^9.2.2",
@@ -20002,7 +19972,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
       "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -20014,7 +19983,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
       "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-      "dev": true,
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -21361,7 +21329,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-3.0.0.tgz",
       "integrity": "sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==",
-      "dev": true,
       "dependencies": {
         "crypto-random-string": "^4.0.0"
       },
@@ -22274,7 +22241,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-4.0.1.tgz",
       "integrity": "sha512-o0cyEG0e8GPzT4iGHphIOh0cJOV8fivsXxddQasHPHfoZf1ZexrfeA21w2NaEN1RHE+fXlfISmOE8R9N3u3Qig==",
-      "dev": true,
       "dependencies": {
         "string-width": "^5.0.1"
       },
@@ -22295,7 +22261,6 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^6.1.0",
         "string-width": "^5.0.1",
@@ -22350,7 +22315,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
       "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -22362,7 +22326,6 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
       "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -22374,7 +22337,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
       "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-      "dev": true,
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -22507,7 +22469,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-5.1.0.tgz",
       "integrity": "sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -22688,6 +22649,7 @@
         "@readme/api-core": "file:../core",
         "@readme/openapi-parser": "^2.4.0",
         "chalk": "^5.3.0",
+        "ci-info": "^4.0.0",
         "commander": "^11.1.0",
         "emphasize": "^6.0.0",
         "execa": "^8.0.1",
@@ -22705,6 +22667,7 @@
         "semver": "^7.3.8",
         "ssri": "^10.0.1",
         "ts-morph": "^20.0.0",
+        "update-notifier": "^7.0.0",
         "uslug": "^1.0.4",
         "validate-npm-package-name": "^5.0.0"
       },
@@ -22722,6 +22685,7 @@
         "@types/prompts": "^2.4.6",
         "@types/semver": "^7.5.1",
         "@types/ssri": "^7.1.1",
+        "@types/update-notifier": "^6.0.7",
         "@types/uslug": "^1.0.2",
         "@types/validate-npm-package-name": "^4.0.0",
         "@vitest/coverage-v8": "^0.34.4",
@@ -22760,6 +22724,20 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "packages/api/node_modules/ci-info": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.0.0.tgz",
+      "integrity": "sha512-TdHqgGf9odd8SXNuxtUBVx8Nv+qZOejE6qyqiy5NtbYYQOeFa6zmHkxlPzmaLxWWHsU6nJmB7AETdVPi+2NBUg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "engines": {
+        "node": ">=8"
       }
     },
     "packages/api/node_modules/cli-cursor": {
@@ -23018,6 +22996,31 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/api/node_modules/update-notifier": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-7.0.0.tgz",
+      "integrity": "sha512-Hv25Bh+eAbOLlsjJreVPOs4vd51rrtCrmhyOJtbpAojro34jS4KQaEp4/EvlHJX7jSO42VvEFpkastVyXyIsdQ==",
+      "dependencies": {
+        "boxen": "^7.1.1",
+        "chalk": "^5.3.0",
+        "configstore": "^6.0.0",
+        "import-lazy": "^4.0.0",
+        "is-in-ci": "^0.1.0",
+        "is-installed-globally": "^0.4.0",
+        "is-npm": "^6.0.0",
+        "latest-version": "^7.0.0",
+        "pupa": "^3.1.0",
+        "semver": "^7.5.4",
+        "semver-diff": "^4.0.0",
+        "xdg-basedir": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/yeoman/update-notifier?sponsor=1"
       }
     },
     "packages/core": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -50,6 +50,7 @@
     "@readme/api-core": "file:../core",
     "@readme/openapi-parser": "^2.4.0",
     "chalk": "^5.3.0",
+    "ci-info": "^4.0.0",
     "commander": "^11.1.0",
     "emphasize": "^6.0.0",
     "execa": "^8.0.1",
@@ -67,6 +68,7 @@
     "semver": "^7.3.8",
     "ssri": "^10.0.1",
     "ts-morph": "^20.0.0",
+    "update-notifier": "^7.0.0",
     "uslug": "^1.0.4",
     "validate-npm-package-name": "^5.0.0"
   },
@@ -81,6 +83,7 @@
     "@types/prompts": "^2.4.6",
     "@types/semver": "^7.5.1",
     "@types/ssri": "^7.1.1",
+    "@types/update-notifier": "^6.0.7",
     "@types/uslug": "^1.0.2",
     "@types/validate-npm-package-name": "^4.0.0",
     "@vitest/coverage-v8": "^0.34.4",

--- a/packages/api/src/bin.ts
+++ b/packages/api/src/bin.ts
@@ -1,8 +1,11 @@
 import { Command } from 'commander';
+import updateNotifier from 'update-notifier';
 
 import commands from './commands/index.js';
 import logger from './logger.js';
 import * as pkg from './packageInfo.js';
+
+updateNotifier({ pkg: { name: pkg.PACKAGE_NAME, version: pkg.PACKAGE_VERSION } }).notify();
 
 (async () => {
   const program = new Command();

--- a/packages/api/src/lib/isCI.ts
+++ b/packages/api/src/lib/isCI.ts
@@ -1,0 +1,19 @@
+import ci from 'ci-info';
+
+/**
+ * Small env check to determine if we're running our testbed
+ */
+function isTest() {
+  return process.env.NODE_ENV === 'rdme-test';
+}
+
+/**
+ * Small check to ensure we're in a safe CI environment.
+ *
+ * The reason we have this weird conditional logic is because we run our tests in
+ * a CI environment and we don't want false positives when running tests.
+ */
+export default function isCI() {
+  /* istanbul ignore next */
+  return ci.isCI && !isTest();
+}

--- a/packages/api/src/lib/prompt.ts
+++ b/packages/api/src/lib/prompt.ts
@@ -1,5 +1,7 @@
 import prompts from 'prompts';
 
+import isCI from './isCI.js';
+
 /**
  * The `prompts` library doesn't always interpret CTRL+C and release the terminal back to the user
  * so we need handle this ourselves. This function is just a simple overload of the main `prompts`
@@ -8,22 +10,49 @@ import prompts from 'prompts';
  * @see {@link https://github.com/terkelg/prompts/issues/252}
  */
 export default async function promptTerminal<T extends string = string>(
-  question: prompts.PromptObject<T>,
+  questions: prompts.PromptObject<T> | prompts.PromptObject<T>[],
   options?: prompts.Options,
 ) {
   const enableTerminalCursor = () => {
     process.stdout.write('\x1B[?25h');
   };
 
-  const onState = (state: { aborted: boolean }) => {
-    if (state.aborted) {
-      // If we don't re-enable the terminal cursor before exiting the program, the cursor will
-      // remain hidden.
-      enableTerminalCursor();
-      process.stdout.write('\n');
-      process.exit(1);
-    }
+  /**
+   * The CTRL+C handler discussed above.
+   * @see {@link https://github.com/terkelg/prompts#optionsoncancel}
+   */
+  const onCancel = () => {
+    // If we don't re-enable the terminal cursor before exiting the program, the cursor will
+    // remain hidden.
+    enableTerminalCursor();
+    process.stdout.write('\n');
+    process.exit(1);
   };
 
-  return prompts({ ...question, onState }, options);
+  /**
+   * Runs a check before every prompt renders to make sure that
+   * prompt is not being run in a CI environment.
+   */
+  function onRender() {
+    if (isCI()) {
+      process.stdout.write('\n');
+      process.stdout.write(
+        'Yikes! Looks like we were about to prompt you for something in a CI environment. Are you missing an argument?',
+      );
+      process.stdout.write('\n\n');
+      process.stdout.write('Try running `api <command> --help` to get more information.');
+      process.stdout.write('\n\n');
+      process.exit(1);
+    }
+  }
+
+  if (Array.isArray(questions)) {
+    // eslint-disable-next-line no-param-reassign
+    questions = questions.map(question => ({ onRender, ...question }));
+  } else {
+    // eslint-disable-next-line no-param-reassign
+    questions.onRender = onRender;
+  }
+
+  return prompts(questions, { onCancel, ...options });
 }


### PR DESCRIPTION
| 🚥 Resolves RM-8193 |
| :------------------- |

## 🧰 Changes

This PR rips a couple pages from the `rdme` playbook:

- [x] Brings in `update-notifier` to ensure people are using the latest and greatest updates. People are unlikely to have this CLI globally installed, but it will still be valuable since `npx` caches versions.
- [x] Similar to `rdme`, we now detect whether the `api` CLI is being run from a CI environment and throw an error if the user attempts to prompt for something.

## 🧬 QA & Testing

The `update-notifier` changes are minimal enough and the package is weird enough where it's not particularly easy nor worth it to QA, but I confirmed that the CLI still works!

As for the prompt handler changes, you can check out this branch and try running the following command:

```sh
CI=true npm run debug:bin install https://raw.githubusercontent.com/readmeio/oas-examples/main/3.0/json/petstore-simple.json
```

It should error out with an output like this:

```
> api@7.0.0-beta.4 debug:bin
> NODE_OPTIONS=--no-warnings node --loader ts-node/esm src/bin.ts install https://raw.githubusercontent.com/readmeio/oas-examples/main/3.0/json/petstore-simple.json

- Fetching your API definition
✔ Fetching your API definition

Yikes! Looks like we were about to prompt you for something in a CI environment. Are you missing an argument?

Try running `api <command> --help` to get more information.

npm ERR! Lifecycle script `debug:bin` failed with error: 
npm ERR! Error: command failed 
npm ERR!   in workspace: api@7.0.0-beta.4 
npm ERR!   at location: /Users/kanadg/Code/readmeio/api/packages/api 
```
