### PR TITLE
test: run `tsc` on SDK fixtures

### DIFF
--- a/packages/test-utils/tsconfig.json
+++ b/packages/test-utils/tsconfig.json
@@ -2,8 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "lib": ["DOM", "ES2023"],
-    "noEmit": true
+    "noEmit": true,
+    "resolveJsonModule": true
   },
-  "include": ["./**/*"],
-  "exclude": ["./sdks/**/*"]
+  "include": ["./**/*"]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -6,7 +6,6 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
-    "strict": true,
     "useUnknownInCatchVariables": false
   }
 }


### PR DESCRIPTION
## 🧰 Changes

I've done cursory checks in the past to make sure our generated SDKs meet the requirements of TS strict mode, but it just occurred to me that we're not doing any type-checking in our tests, so this PR enables that. Glad to report that the SDKs passed with flying colors ✨

## 🧬 QA & Testing

Do tests still pass?
