### PR TITLE
feat: avoid modifying the response object when calling response.text()

### DIFF
--- a/packages/core/src/lib/parseResponse.ts
+++ b/packages/core/src/lib/parseResponse.ts
@@ -4,7 +4,7 @@ export default async function parseResponse<HTTPStatus extends number = number>(
   const contentType = response.headers.get('Content-Type');
   const isJSON = contentType && (matchesMimeType.json(contentType) || matchesMimeType.wildcard(contentType));
 
-  const responseBody = await response.text();
+  const responseBody = await response.clone().text();
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let data: any = responseBody;

--- a/packages/core/test/lib/parseResponse.test.ts
+++ b/packages/core/test/lib/parseResponse.test.ts
@@ -110,7 +110,7 @@ describe('#parseResponse', () => {
     expect(res).toBeInstanceOf(Response);
   });
 
-  it('original response object should remain unchanged', async () => {
+  it('should not modify original response object', async () => {
     const responseMethodSpyText = vi.spyOn(response, 'text');
     const responseMethodSpyArrayBuffer = vi.spyOn(response, 'arrayBuffer');
     const responseMethodSpyJson = vi.spyOn(response, 'json');

--- a/packages/core/test/lib/parseResponse.test.ts
+++ b/packages/core/test/lib/parseResponse.test.ts
@@ -1,4 +1,4 @@
-import { describe, beforeEach, it, expect } from 'vitest';
+import { describe, beforeEach, it, expect, vi } from 'vitest';
 
 import parseResponse from '../../src/lib/parseResponse.js';
 
@@ -108,5 +108,17 @@ describe('#parseResponse', () => {
     expect(status).toBe(204);
     expect(headers).toHaveHeader('content-type', 'application/json');
     expect(res).toBeInstanceOf(Response);
+  });
+
+  it('original response object should remain unchanged', async () => {
+    const responseMethodSpyText = vi.spyOn(response, 'text');
+    const responseMethodSpyArrayBuffer = vi.spyOn(response, 'arrayBuffer');
+    const responseMethodSpyJson = vi.spyOn(response, 'json');
+
+    await parseResponse(response);
+
+    expect(responseMethodSpyText).not.toHaveBeenCalled();
+    expect(responseMethodSpyArrayBuffer).not.toHaveBeenCalled();
+    expect(responseMethodSpyJson).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
| 🚥 Resolves ISSUE_ID |
| :------------------- |

## 🧰 Changes

- Avoid mutating the response object when calling `response.text()`. This can be helpful if we want to consume the response in a different way, like `response.arrayBuffer()` when working with files

## 🧬 QA & Testing

- With this change, the original response object is returned. 
