### PR TITLE
fix: ensure prepareServer respects server variables when custom url is the same as the OAS url

### DIFF
--- a/packages/core/src/lib/prepareServer.ts
+++ b/packages/core/src/lib/prepareServer.ts
@@ -14,7 +14,7 @@ function stripTrailingSlash(url: string) {
  *
  */
 export default function prepareServer(spec: Oas, url: string, variables: Record<string, string | number> = {}) {
-  let serverIdx;
+  let serverIdx: number | undefined;
   const sanitizedUrl = stripTrailingSlash(url);
   (spec.api.servers || []).forEach((server, i) => {
     if (server.url === sanitizedUrl) {

--- a/packages/core/src/lib/prepareServer.ts
+++ b/packages/core/src/lib/prepareServer.ts
@@ -25,7 +25,7 @@ export default function prepareServer(spec: Oas, url: string, variables: Record<
   // If we were able to find the passed in server in the OAS servers, we should use that! If we
   // couldn't and server variables were passed in we should try our best to handle that, otherwise
   // we should ignore the passed in server and use whever the default from the OAS is.
-  if (serverIdx) {
+  if (serverIdx !== undefined) {
     return {
       selected: serverIdx,
       variables,


### PR DESCRIPTION
| 🚥 Resolves ISSUE_ID |
| :------------------- |

## 🧰 Changes

A truthy check was being performed on the `serverIdx`, which would effectively ignore the value when `serverIdx` was 0.

This fixes that to ensure that server variables are respected when the server URL passed in is the same as the server URL defined in the OAS.

## 🧬 QA & Testing

It now works for us, whereas it didn't before.
