### PR TITLE
fix: package name for ESM syntax

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -39,7 +39,7 @@ petstore.listPets().then(({ data }) => {
 The ESM syntax is supported as well:
 
 ```js
-import api from 'api';
+import api from '@api/petstore';
 const petstore = api('@petstore/v1.0#tl1e4kl1cl8eg8');
 
 petstore.listPets().then(({ data }) => {

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -39,8 +39,7 @@ petstore.listPets().then(({ data }) => {
 The ESM syntax is supported as well:
 
 ```js
-import api from '@api/petstore';
-const petstore = api('@petstore/v1.0#tl1e4kl1cl8eg8');
+import petstore from '@api/petstore';
 
 petstore.listPets().then(({ data }) => {
   console.log(`My pets name is ${data[0].name}!`);


### PR DESCRIPTION
| 🚥 Resolves ISSUE_ID |
| :------------------- |

## 🧰 Changes

After "npx api install" the dependecy "@api/gkmmk":"file:.api/apis/gkmmk" was created, but not "api": "file:.api/apis/gkmmk"

## 🧬 QA & Testing
for ESM
I haven't tested the package fully, but I thought I'd point it out, because the way from the readme doesn't work for me
