### PR TITLE
fix: zsh compatibility for `api` installation instructions

### DIFF
--- a/packages/httpsnippet-client-api/src/index.ts
+++ b/packages/httpsnippet-client-api/src/index.ts
@@ -126,7 +126,7 @@ const client: Client<APIOptions> = {
     link: 'https://npm.im/api',
     description: 'Automatic SDK generation from an OpenAPI definition.',
     extname: '.js',
-    installation: 'npx api install {packageName}',
+    installation: 'npx api install "{packageName}"',
   },
   convert: ({ cookiesObj, headersObj, postData, queryObj, url, ...source }, options) => {
     const opts = {

--- a/packages/httpsnippet-client-api/test/index.test.ts
+++ b/packages/httpsnippet-client-api/test/index.test.ts
@@ -45,7 +45,7 @@ describe('httpsnippet-client-api', () => {
       link: 'https://npm.im/api',
       description: 'Automatic SDK generation from an OpenAPI definition.',
       extname: '.js',
-      installation: 'npx api install {packageName}',
+      installation: 'npx api install "{packageName}"',
     });
   });
 


### PR DESCRIPTION
## 🧰 Changes

Running `npx api install @handbook/v1.0#fzmso1cluu0vbwv` on a Zsh environment breaks because the hash there sends Zsh into a tizzy. Wrapping our registry identifiers for `api` in quotes fixes this.