### PR TITLE
feat: use project name rather than `sdk` in sdk snippet

### DIFF
--- a/packages/httpsnippet-client-api/src/index.ts
+++ b/packages/httpsnippet-client-api/src/index.ts
@@ -164,7 +164,7 @@ const client: Client<APIOptions> = {
       }
     } else {
       sdkPackageName = getProjectPrefixFromRegistryUUID(opts.api.registryURI);
-      sdkVariable = camelCase(sdkPackageName as string);
+      sdkVariable = camelCase(sdkPackageName || 'sdk');
     }
 
     const operationSlugs = foundOperation.url.slugs;

--- a/packages/httpsnippet-client-api/src/index.ts
+++ b/packages/httpsnippet-client-api/src/index.ts
@@ -164,7 +164,7 @@ const client: Client<APIOptions> = {
       }
     } else {
       sdkPackageName = getProjectPrefixFromRegistryUUID(opts.api.registryURI);
-      sdkVariable = getProjectPrefixFromRegistryUUID(opts.api.registryURI) as string;
+      sdkVariable = camelCase(getProjectPrefixFromRegistryUUID(opts.api.registryURI) as string) as string;
     }
 
     const operationSlugs = foundOperation.url.slugs;

--- a/packages/httpsnippet-client-api/src/index.ts
+++ b/packages/httpsnippet-client-api/src/index.ts
@@ -164,7 +164,7 @@ const client: Client<APIOptions> = {
       }
     } else {
       sdkPackageName = getProjectPrefixFromRegistryUUID(opts.api.registryURI);
-      sdkVariable = camelCase(getProjectPrefixFromRegistryUUID(opts.api.registryURI) as string) as string;
+      sdkVariable = camelCase(sdkPackageName as string);
     }
 
     const operationSlugs = foundOperation.url.slugs;

--- a/packages/httpsnippet-client-api/src/index.ts
+++ b/packages/httpsnippet-client-api/src/index.ts
@@ -164,7 +164,7 @@ const client: Client<APIOptions> = {
       }
     } else {
       sdkPackageName = getProjectPrefixFromRegistryUUID(opts.api.registryURI);
-      sdkVariable = 'sdk';
+      sdkVariable = getProjectPrefixFromRegistryUUID(opts.api.registryURI) as string;
     }
 
     const operationSlugs = foundOperation.url.slugs;

--- a/packages/httpsnippet-client-api/src/index.ts
+++ b/packages/httpsnippet-client-api/src/index.ts
@@ -191,7 +191,7 @@ const client: Client<APIOptions> = {
         const serverVars = oas.splitVariables(baseUrl);
         const serverUrl = serverVars ? oas.url(serverVars.selected, serverVars.variables) : baseUrl;
 
-        configData.push(`sdk.server('${serverUrl}');`);
+        configData.push(`${sdkVariable}.server('${serverUrl}');`);
       }
     }
 

--- a/packages/httpsnippet-client-api/test/__datasets__/alternate-server/output.js
+++ b/packages/httpsnippet-client-api/test/__datasets__/alternate-server/output.js
@@ -1,6 +1,6 @@
-import sdk from '@api/alternate-server';
+import alternateServer from '@api/alternate-server';
 
-sdk.server('http://dev.local/v2');
-sdk.postGlobal()
+alternateServer.server('http://dev.local/v2');
+alternateServer.postGlobal()
   .then(({ data }) => console.log(data))
   .catch(err => console.error(err));

--- a/packages/httpsnippet-client-api/test/__datasets__/application-form-encoded/output.js
+++ b/packages/httpsnippet-client-api/test/__datasets__/application-form-encoded/output.js
@@ -1,5 +1,5 @@
-import sdk from '@api/application-form-encoded';
+import applicationFormEncoded from '@api/application-form-encoded';
 
-sdk.postAnything({foo: 'bar', hello: 'world'})
+applicationFormEncoded.postAnything({foo: 'bar', hello: 'world'})
   .then(({ data }) => console.log(data))
   .catch(err => console.error(err));

--- a/packages/httpsnippet-client-api/test/__datasets__/application-json/output.js
+++ b/packages/httpsnippet-client-api/test/__datasets__/application-json/output.js
@@ -1,6 +1,6 @@
-import sdk from '@api/application-json';
+import applicationJson from '@api/application-json';
 
-sdk.postAnything({
+applicationJson.postAnything({
   number: 1,
   string: 'f"oo',
   arr: [1, 2, 3],

--- a/packages/httpsnippet-client-api/test/__datasets__/auth-apikey-cookie/output.js
+++ b/packages/httpsnippet-client-api/test/__datasets__/auth-apikey-cookie/output.js
@@ -1,6 +1,6 @@
-import sdk from '@api/auth-apikey-cookie';
+import authApikeyCookie from '@api/auth-apikey-cookie';
 
-sdk.auth('buster');
-sdk.postAnythingApikey()
+authApikeyCookie.auth('buster');
+authApikeyCookie.postAnythingApikey()
   .then(({ data }) => console.log(data))
   .catch(err => console.error(err));

--- a/packages/httpsnippet-client-api/test/__datasets__/auth-apikey-header/output.js
+++ b/packages/httpsnippet-client-api/test/__datasets__/auth-apikey-header/output.js
@@ -1,6 +1,6 @@
-import sdk from '@api/auth-apikey-header';
+import authApikeyHeader from '@api/auth-apikey-header';
 
-sdk.auth('a5a220e');
-sdk.putAnythingApikey()
+authApikeyHeader.auth('a5a220e');
+authApikeyHeader.putAnythingApikey()
   .then(({ data }) => console.log(data))
   .catch(err => console.error(err));

--- a/packages/httpsnippet-client-api/test/__datasets__/auth-basic-full/output.js
+++ b/packages/httpsnippet-client-api/test/__datasets__/auth-basic-full/output.js
@@ -1,6 +1,6 @@
-import sdk from '@api/auth-basic-full';
+import authBasicFull from '@api/auth-basic-full';
 
-sdk.auth('buster', 'pug');
-sdk.getAPISpecification({perPage: '10', page: '1'})
+authBasicFull.auth('buster', 'pug');
+authBasicFull.getAPISpecification({perPage: '10', page: '1'})
   .then(({ data }) => console.log(data))
   .catch(err => console.error(err));

--- a/packages/httpsnippet-client-api/test/__datasets__/auth-basic-password-only/output.js
+++ b/packages/httpsnippet-client-api/test/__datasets__/auth-basic-password-only/output.js
@@ -1,6 +1,6 @@
-import sdk from '@api/auth-basic-password-only';
+import authBasicPasswordOnly from '@api/auth-basic-password-only';
 
-sdk.auth('', 'pug');
-sdk.getAPISpecification({perPage: '10', page: '1'})
+authBasicPasswordOnly.auth('', 'pug');
+authBasicPasswordOnly.getAPISpecification({perPage: '10', page: '1'})
   .then(({ data }) => console.log(data))
   .catch(err => console.error(err));

--- a/packages/httpsnippet-client-api/test/__datasets__/auth-basic-username-only/output.js
+++ b/packages/httpsnippet-client-api/test/__datasets__/auth-basic-username-only/output.js
@@ -1,6 +1,6 @@
-import sdk from '@api/auth-basic-username-only';
+import authBasicUsernameOnly from '@api/auth-basic-username-only';
 
-sdk.auth('buster');
-sdk.getAPISpecification({perPage: '10', page: '1'})
+authBasicUsernameOnly.auth('buster');
+authBasicUsernameOnly.getAPISpecification({perPage: '10', page: '1'})
   .then(({ data }) => console.log(data))
   .catch(err => console.error(err));

--- a/packages/httpsnippet-client-api/test/__datasets__/auth-bearer/output.js
+++ b/packages/httpsnippet-client-api/test/__datasets__/auth-bearer/output.js
@@ -1,6 +1,6 @@
-import sdk from '@api/auth-bearer';
+import authBearer from '@api/auth-bearer';
 
-sdk.auth('myBearerToken');
-sdk.postAnythingBearer()
+authBearer.auth('myBearerToken');
+authBearer.postAnythingBearer()
   .then(({ data }) => console.log(data))
   .catch(err => console.error(err));

--- a/packages/httpsnippet-client-api/test/__datasets__/auth-query/output.js
+++ b/packages/httpsnippet-client-api/test/__datasets__/auth-query/output.js
@@ -1,6 +1,6 @@
-import sdk from '@api/auth-query';
+import authQuery from '@api/auth-query';
 
-sdk.auth('a5a220e');
-sdk.getAnythingApikey()
+authQuery.auth('a5a220e');
+authQuery.getAnythingApikey()
   .then(({ data }) => console.log(data))
   .catch(err => console.error(err));

--- a/packages/httpsnippet-client-api/test/__datasets__/cookies/output.js
+++ b/packages/httpsnippet-client-api/test/__datasets__/cookies/output.js
@@ -1,5 +1,5 @@
-import sdk from '@api/cookies';
+import cookies from '@api/cookies';
 
-sdk.postAnything({bar: 'baz', foo: 'bar'})
+cookies.postAnything({bar: 'baz', foo: 'bar'})
   .then(({ data }) => console.log(data))
   .catch(err => console.error(err));

--- a/packages/httpsnippet-client-api/test/__datasets__/full-many-query-params/output.js
+++ b/packages/httpsnippet-client-api/test/__datasets__/full-many-query-params/output.js
@@ -1,6 +1,6 @@
-import sdk from '@api/full-many-query-params';
+import fullManyQueryParams from '@api/full-many-query-params';
 
-sdk.postAnything({
+fullManyQueryParams.postAnything({
   foo: 'bar',
   foo2: 'bar2',
   foo3: 'bar3',

--- a/packages/httpsnippet-client-api/test/__datasets__/full/output.js
+++ b/packages/httpsnippet-client-api/test/__datasets__/full/output.js
@@ -1,6 +1,6 @@
-import sdk from '@api/full';
+import full from '@api/full';
 
-sdk.postAnything({foo: 'bar'}, {
+full.postAnything({foo: 'bar'}, {
   foo: ['bar', 'baz'],
   baz: 'abc',
   key: 'value',

--- a/packages/httpsnippet-client-api/test/__datasets__/headers/output.js
+++ b/packages/httpsnippet-client-api/test/__datasets__/headers/output.js
@@ -1,5 +1,5 @@
-import sdk from '@api/headers';
+import headers from '@api/headers';
 
-sdk.getAnything({'x-foo': 'Bar', 'x-bar': 'foo', reqKey: 'baz'})
+headers.getAnything({'x-foo': 'Bar', 'x-bar': 'foo', reqKey: 'baz'})
   .then(({ data }) => console.log(data))
   .catch(err => console.error(err));

--- a/packages/httpsnippet-client-api/test/__datasets__/http-insecure/output.js
+++ b/packages/httpsnippet-client-api/test/__datasets__/http-insecure/output.js
@@ -1,5 +1,5 @@
-import sdk from '@api/http-insecure';
+import httpInsecure from '@api/http-insecure';
 
-sdk.getAnything()
+httpInsecure.getAnything()
   .then(({ data }) => console.log(data))
   .catch(err => console.error(err));

--- a/packages/httpsnippet-client-api/test/__datasets__/issue-128/output.js
+++ b/packages/httpsnippet-client-api/test/__datasets__/issue-128/output.js
@@ -1,6 +1,6 @@
-import sdk from '@api/issue-128';
+import issue128 from '@api/issue-128';
 
-sdk.auth('authKey\'With\'Apostrophes');
-sdk.getItem()
+issue128.auth('authKey\'With\'Apostrophes');
+issue128.getItem()
   .then(({ data }) => console.log(data))
   .catch(err => console.error(err));

--- a/packages/httpsnippet-client-api/test/__datasets__/issue-76/output.js
+++ b/packages/httpsnippet-client-api/test/__datasets__/issue-76/output.js
@@ -1,6 +1,6 @@
-import sdk from '@api/issue-76';
+import issue76 from '@api/issue-76';
 
-sdk.auth('a5a220e');
-sdk.getPetFindbystatus({status: 'available'})
+issue76.auth('a5a220e');
+issue76.getPetFindbystatus({status: 'available'})
   .then(({ data }) => console.log(data))
   .catch(err => console.error(err));

--- a/packages/httpsnippet-client-api/test/__datasets__/issue-78-operationid/output.js
+++ b/packages/httpsnippet-client-api/test/__datasets__/issue-78-operationid/output.js
@@ -1,5 +1,5 @@
-import sdk from '@api/issue-78-operationid';
+import issue78Operationid from '@api/issue-78-operationid';
 
-sdk.getOrder({orderId: '1234'})
+issue78Operationid.getOrder({orderId: '1234'})
   .then(({ data }) => console.log(data))
   .catch(err => console.error(err));

--- a/packages/httpsnippet-client-api/test/__datasets__/issue-78/output.js
+++ b/packages/httpsnippet-client-api/test/__datasets__/issue-78/output.js
@@ -1,5 +1,5 @@
-import sdk from '@api/issue-78';
+import issue78 from '@api/issue-78';
 
-sdk.getStoreOrderOrderidTrackingTrackingid({orderId: '1234', trackingId: '5678'})
+issue78.getStoreOrderOrderidTrackingTrackingid({orderId: '1234', trackingId: '5678'})
   .then(({ data }) => console.log(data))
   .catch(err => console.error(err));

--- a/packages/httpsnippet-client-api/test/__datasets__/jsonObj-multiline/output.js
+++ b/packages/httpsnippet-client-api/test/__datasets__/jsonObj-multiline/output.js
@@ -1,5 +1,5 @@
-import sdk from '@api/jsonObj-multiline';
+import jsonObjMultiline from '@api/jsonObj-multiline';
 
-sdk.postAnything({foo: 'bar'})
+jsonObjMultiline.postAnything({foo: 'bar'})
   .then(({ data }) => console.log(data))
   .catch(err => console.error(err));

--- a/packages/httpsnippet-client-api/test/__datasets__/jsonObj-null-value/output.js
+++ b/packages/httpsnippet-client-api/test/__datasets__/jsonObj-null-value/output.js
@@ -1,5 +1,5 @@
-import sdk from '@api/jsonObj-null-value';
+import jsonObjNullValue from '@api/jsonObj-null-value';
 
-sdk.postAnything({foo: null})
+jsonObjNullValue.postAnything({foo: null})
   .then(({ data }) => console.log(data))
   .catch(err => console.error(err));

--- a/packages/httpsnippet-client-api/test/__datasets__/multipart-data/output.js
+++ b/packages/httpsnippet-client-api/test/__datasets__/multipart-data/output.js
@@ -1,5 +1,5 @@
-import sdk from '@api/multipart-data';
+import multipartData from '@api/multipart-data';
 
-sdk.postAnything({foo: 'test/__fixtures__/files/hello.txt'})
+multipartData.postAnything({foo: 'test/__fixtures__/files/hello.txt'})
   .then(({ data }) => console.log(data))
   .catch(err => console.error(err));

--- a/packages/httpsnippet-client-api/test/__datasets__/multipart-file/output.js
+++ b/packages/httpsnippet-client-api/test/__datasets__/multipart-file/output.js
@@ -1,5 +1,5 @@
-import sdk from '@api/multipart-file';
+import multipartFile from '@api/multipart-file';
 
-sdk.postAnything({foo: 'test/__fixtures__/files/hello.txt'})
+multipartFile.postAnything({foo: 'test/__fixtures__/files/hello.txt'})
   .then(({ data }) => console.log(data))
   .catch(err => console.error(err));

--- a/packages/httpsnippet-client-api/test/__datasets__/multipart-form-data-no-params/output.js
+++ b/packages/httpsnippet-client-api/test/__datasets__/multipart-form-data-no-params/output.js
@@ -1,5 +1,5 @@
-import sdk from '@api/multipart-form-data-no-params';
+import multipartFormDataNoParams from '@api/multipart-form-data-no-params';
 
-sdk.postAnything()
+multipartFormDataNoParams.postAnything()
   .then(({ data }) => console.log(data))
   .catch(err => console.error(err));

--- a/packages/httpsnippet-client-api/test/__datasets__/multipart-form-data/output.js
+++ b/packages/httpsnippet-client-api/test/__datasets__/multipart-form-data/output.js
@@ -1,5 +1,5 @@
-import sdk from '@api/multipart-form-data';
+import multipartFormData from '@api/multipart-form-data';
 
-sdk.postAnything({foo: 'bar'})
+multipartFormData.postAnything({foo: 'bar'})
   .then(({ data }) => console.log(data))
   .catch(err => console.error(err));

--- a/packages/httpsnippet-client-api/test/__datasets__/operationid-non-alphanumerical/output.js
+++ b/packages/httpsnippet-client-api/test/__datasets__/operationid-non-alphanumerical/output.js
@@ -1,6 +1,6 @@
-import sdk from '@api/operationid-non-alphanumerical';
+import operationidNonAlphanumerical from '@api/operationid-non-alphanumerical';
 
-sdk.auth('123');
-sdk.findPetsByStatus({status: 'available'})
+operationidNonAlphanumerical.auth('123');
+operationidNonAlphanumerical.findPetsByStatus({status: 'available'})
   .then(({ data }) => console.log(data))
   .catch(err => console.error(err));

--- a/packages/httpsnippet-client-api/test/__datasets__/operationid-with-underscores/output.js
+++ b/packages/httpsnippet-client-api/test/__datasets__/operationid-with-underscores/output.js
@@ -1,5 +1,5 @@
-import sdk from '@api/operationid-with-underscores';
+import operationidWithUnderscores from '@api/operationid-with-underscores';
 
-sdk.anything_Operation()
+operationidWithUnderscores.anything_Operation()
   .then(({ data }) => console.log(data))
   .catch(err => console.error(err));

--- a/packages/httpsnippet-client-api/test/__datasets__/parameter-special-characters/output.js
+++ b/packages/httpsnippet-client-api/test/__datasets__/parameter-special-characters/output.js
@@ -1,5 +1,5 @@
-import sdk from '@api/parameter-special-characters';
+import parameterSpecialCharacters from '@api/parameter-special-characters';
 
-sdk.getAppIdNumInstalls_reportV5({'app-id': '1234', num: '5678'})
+parameterSpecialCharacters.getAppIdNumInstalls_reportV5({'app-id': '1234', num: '5678'})
   .then(({ data }) => console.log(data))
   .catch(err => console.error(err));

--- a/packages/httpsnippet-client-api/test/__datasets__/petstore/output.js
+++ b/packages/httpsnippet-client-api/test/__datasets__/petstore/output.js
@@ -1,6 +1,6 @@
-import sdk from '@api/petstore';
+import petstore from '@api/petstore';
 
-sdk.auth('123');
-sdk.findPetsByStatus({status: 'available', accept: 'application/xml'})
+petstore.auth('123');
+petstore.findPetsByStatus({status: 'available', accept: 'application/xml'})
   .then(({ data }) => console.log(data))
   .catch(err => console.error(err));

--- a/packages/httpsnippet-client-api/test/__datasets__/query/output.js
+++ b/packages/httpsnippet-client-api/test/__datasets__/query/output.js
@@ -1,5 +1,5 @@
-import sdk from '@api/query';
+import query from '@api/query';
 
-sdk.getAnything({foo: ['bar', 'baz'], baz: 'abc', key: 'value'})
+query.getAnything({foo: ['bar', 'baz'], baz: 'abc', key: 'value'})
   .then(({ data }) => console.log(data))
   .catch(err => console.error(err));

--- a/packages/httpsnippet-client-api/test/__datasets__/short/output.js
+++ b/packages/httpsnippet-client-api/test/__datasets__/short/output.js
@@ -1,5 +1,5 @@
-import sdk from '@api/short';
+import short from '@api/short';
 
-sdk.getAnything()
+short.getAnything()
   .then(({ data }) => console.log(data))
   .catch(err => console.error(err));

--- a/packages/httpsnippet-client-api/test/__datasets__/text-plain/output.js
+++ b/packages/httpsnippet-client-api/test/__datasets__/text-plain/output.js
@@ -1,5 +1,5 @@
-import sdk from '@api/text-plain';
+import textPlain from '@api/text-plain';
 
-sdk.postAnything('Hello World')
+textPlain.postAnything('Hello World')
   .then(({ data }) => console.log(data))
   .catch(err => console.error(err));


### PR DESCRIPTION
| 🚥 Resolves RM-6573 |
| :------------------- |

## 🧰 Changes
We wanted to update the `sdk` in our SDK snippet generation to use the site name so it feels more personalized. 

## 🧬 QA & Testing

Provide as much information as you can on how to test what you've done.
