### PR TITLE
fix: use correct import attributes syntax

### DIFF
--- a/packages/api/bin/buildVersionedFiles.ts
+++ b/packages/api/bin/buildVersionedFiles.ts
@@ -7,7 +7,7 @@ import fs from 'node:fs';
 // eslint-disable-next-line import/no-extraneous-dependencies, node/no-extraneous-import
 import prettier from 'prettier';
 
-import pkg from '../package.json' assert { type: 'json' };
+import pkg from '../package.json' with { type: 'json' };
 import { lockfileSchema } from '../src/lockfileSchema.js';
 
 async function run() {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -33,7 +33,7 @@
   "author": "Jon Ursenbach <jon@readme.io>",
   "license": "MIT",
   "engines": {
-    "node": ">=18"
+    "node": "^18.20.0 || >=20.10.0"
   },
   "files": [
     "dist",

--- a/packages/api/src/codegen/languages/typescript/index.ts
+++ b/packages/api/src/codegen/languages/typescript/index.ts
@@ -19,7 +19,7 @@ import type { JsonObject, PackageJson, TsConfigJson } from 'type-fest';
 
 import path from 'node:path';
 
-import corePkg from '@readme/api-core/package.json' assert { type: 'json' };
+import corePkg from '@readme/api-core/package.json' with { type: 'json' };
 import { execa } from 'execa';
 import { getLicense } from 'license';
 import { setWith } from 'lodash-es';

--- a/packages/api/test/storage.test.ts
+++ b/packages/api/test/storage.test.ts
@@ -11,7 +11,7 @@ import fetchMock from 'fetch-mock';
 import uniqueTempDir from 'unique-temp-dir';
 import { describe, beforeAll, beforeEach, afterEach, it, expect } from 'vitest';
 
-import lockfileSchema from '../schema.json' assert { type: 'json' };
+import lockfileSchema from '../schema.json' with { type: 'json' };
 import { SupportedLanguages } from '../src/codegen/factory.js';
 import { PACKAGE_VERSION } from '../src/packageInfo.js';
 import Storage from '../src/storage.js';


### PR DESCRIPTION
| 🚥 Resolves #950 |
| :------------------- |

## 🧰 Changes

<sub>(PR description stolen from https://github.com/readmeio/rdme/pull/993)</sub>

TC39 updated their import _assertions_ to be import _attributes_ and it's a bit of a mess now that we're running tests against Node v22.

Here's what importing JSON in ESM used to look like:

```js
import { x } from "./mod" assert { type: "json" }
```

now it looks like this:

```js
import { x } from "./mod" with { type: "json" };
```

Support for this new `with` keyword was added in [Node v18.20.0](https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V18.md#added-support-for-import-attributes) and [Node v20.10.0](https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V20.md#2023-11-22-version-20100-iron-lts-targos) (and is supported on all v21 and v22 channels), but importantly the older `assert` keyword is **_not_** supported in Node v22, so unfortunately our `package.json#engines.node` field is going to look a little ridiculous for the time being.

Details: https://github.com/tc39/proposal-import-attributes?tab=readme-ov-file#history

## 🧬 QA & Testing

Annoyingly, we don't have anything in our unit tests to catch this sort of thing at the moment because we have stuff like this:

https://github.com/readmeio/api/blob/353cd8b52cdab893f7297f0fbf3ced1da6de352c/packages/api/src/codegen/languages/typescript/index.ts#L127-L130

but I confirmed that Node v22 works again with this change. See the before:


![CleanShot 2024-11-18 at 08 32 53@2x](https://github.com/user-attachments/assets/3cca4159-54c1-4b10-a5cb-6713f45913a2)

And the after:

![CleanShot 2024-11-18 at 08 33 18@2x](https://github.com/user-attachments/assets/5dc0c3d1-fcba-4a9d-80b7-44e231f05247)