### PR TITLE
feat: drop support for node 18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "tsup": "^8.4.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=20.10.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -48,11 +48,22 @@
       "resolved": "packages/test-utils",
       "link": true
     },
-    "node_modules/@apidevtools/swagger-methods": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
-      "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg==",
-      "license": "MIT"
+    "node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "11.9.3",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.9.3.tgz",
+      "integrity": "sha512-60vepv88RwcJtSHrD6MjIL6Ta3SOYbgfnkHb+ppAVK+o9mXprRtulx7VlRl3lN3bbvysAfCS7WMVfhUYemB0IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.15",
+        "js-yaml": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/philsturgeon"
+      }
     },
     "node_modules/@arethetypeswrong/cli": {
       "version": "0.17.4",
@@ -972,7 +983,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@exodus/schemasafe/-/schemasafe-1.3.0.tgz",
       "integrity": "sha512-5Aap/GaRupgNx/feGBwLLTVv8OQFfv3pq2lPRzPg9R+IOBnDgghTGW7l7EuVXOvg5cc/xSAlRW8rBrjIC3Nvqw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -3053,9 +3063,9 @@
       "link": true
     },
     "node_modules/@readme/better-ajv-errors": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@readme/better-ajv-errors/-/better-ajv-errors-2.1.2.tgz",
-      "integrity": "sha512-nfAs1+wzO9SWwji/7mbhXo2vJZ6PLMSpv7XNrFrwufhdwRPc07GNBwcEsiL6qq8VnI+A2lMEkcj7xCEK1nOrNQ==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@readme/better-ajv-errors/-/better-ajv-errors-2.3.2.tgz",
+      "integrity": "sha512-T4GGnRAlY3C339NhoUpgJJFsMYko9vIgFAlhgV+/vEGFw66qEY4a4TRJIAZBcX/qT1pq5DvXSme+SQODHOoBrw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/code-frame": "^7.22.5",
@@ -3125,7 +3135,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@readme/http-status-codes/-/http-status-codes-7.2.0.tgz",
       "integrity": "sha512-/dBh9qw3QhJYqlGwt2I+KUP/lQ6nytdCx3aq+GpMUhibLHF3O7fwoowNcTwlbnwtyJ+TJYTIIrp3oVUlRNx3fA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@readme/httpsnippet": {
@@ -3177,66 +3186,43 @@
         "node": ">=4"
       }
     },
-    "node_modules/@readme/json-schema-ref-parser": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@readme/json-schema-ref-parser/-/json-schema-ref-parser-1.2.0.tgz",
-      "integrity": "sha512-Bt3QVovFSua4QmHa65EHUmh2xS0XJ3rgTEUPH998f4OW4VVJke3BuS16f+kM0ZLOGdvIrzrPRqwihuv5BAjtrA==",
-      "license": "MIT",
-      "dependencies": {
-        "@jsdevtools/ono": "^7.1.3",
-        "@types/json-schema": "^7.0.6",
-        "call-me-maybe": "^1.0.1",
-        "js-yaml": "^4.1.0"
-      }
-    },
     "node_modules/@readme/oas-examples": {
-      "version": "5.18.2",
-      "resolved": "https://registry.npmjs.org/@readme/oas-examples/-/oas-examples-5.18.2.tgz",
-      "integrity": "sha512-ENAqUaKGLVM7u0KIwuWAqER2D2Fcc8w0EpGOD9BbjVeOnVNQg4gSFvr6zNQtblu5i/D1m3upKqBMeSPIhocXJg==",
+      "version": "5.19.1",
+      "resolved": "https://registry.npmjs.org/@readme/oas-examples/-/oas-examples-5.19.1.tgz",
+      "integrity": "sha512-uFEA5mw2Rj828+duAI6YKDKhwyaS6QbbVqnjKcgUQvR4Qma0Q/NRgYJU+ayPN1CtP60HVwKuxSt2ZjUxdP4QHw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@readme/oas-to-har": {
-      "version": "24.0.7",
-      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-24.0.7.tgz",
-      "integrity": "sha512-4PGnAFn0zmri47L0wluyThmaho1W5Fa32sRavqa7tz5E+Om1y/zDhot5y1Y4x9bmphZHmtxviBhV4P3IpLa4+A==",
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-25.0.1.tgz",
+      "integrity": "sha512-gn4Bch0CmoJSOPrx1MbfR8FL/3kMwi+9QNtamGvjcYOJc12mnH5iIFq/eh5po6U6toFyeHsqz58leZQF2M6m2A==",
       "license": "ISC",
       "dependencies": {
         "@readme/data-urls": "^3.0.0",
-        "oas": "^25.3.0",
+        "oas": "^26.0.1",
         "qs": "^6.12.0",
-        "remove-undefined-objects": "^5.0.0"
+        "remove-undefined-objects": "^6.0.0"
       },
       "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@readme/oas-to-har/node_modules/remove-undefined-objects": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/remove-undefined-objects/-/remove-undefined-objects-5.0.0.tgz",
-      "integrity": "sha512-DE8C17uIWeHaY4SqIkpQpHXm0MIdYHtIqjieWuh0I2PG8YcZRxFE6pqeEhnRetsrQ7Lu9uvSNQkDbg95NLpvnQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/@readme/openapi-parser": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@readme/openapi-parser/-/openapi-parser-2.7.0.tgz",
-      "integrity": "sha512-P8WSr8WTOxilnT89tcCRKWYsG/II4sAwt1a/DIWub8xTtkrG9cCBBy/IUcvc5X8oGWN82MwcTA3uEkDrXZd/7A==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@readme/openapi-parser/-/openapi-parser-3.0.1.tgz",
+      "integrity": "sha512-U0Hn3bJRs8ZWn6cylNxLsieJjr5liibzn9JDuWNVvBILK5geEtJDS7S2vMbNViufGGLu08q1dvsbbYIZCSkBzw==",
       "license": "MIT",
       "dependencies": {
-        "@apidevtools/swagger-methods": "^3.0.2",
-        "@jsdevtools/ono": "^7.1.3",
-        "@readme/better-ajv-errors": "^2.0.0",
-        "@readme/json-schema-ref-parser": "^1.2.0",
+        "@apidevtools/json-schema-ref-parser": "^11.9.2",
+        "@readme/better-ajv-errors": "^2.3.2",
         "@readme/openapi-schemas": "^3.1.0",
+        "@types/json-schema": "^7.0.15",
         "ajv": "^8.12.0",
-        "ajv-draft-04": "^1.0.0",
-        "call-me-maybe": "^1.0.1"
+        "ajv-draft-04": "^1.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "peerDependencies": {
         "openapi-types": ">=7"
@@ -3255,7 +3241,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@readme/postman-to-openapi/-/postman-to-openapi-4.1.0.tgz",
       "integrity": "sha512-VvV2Hzjskz01m8doSn7Ypt6cSZzgjnypVqXy1ipThbyYD6SGiM74VSePXykOODj/43Y2m6zeYedPk/ZLts/HvQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@readme/http-status-codes": "^7.2.0",
@@ -5808,7 +5793,6 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
@@ -5823,7 +5807,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -5839,7 +5822,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -5852,21 +5834,18 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cliui/node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cliui/node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -5881,7 +5860,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -7332,7 +7310,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -7343,7 +7320,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -7663,7 +7639,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
       "integrity": "sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/es6-symbol": {
@@ -7735,7 +7710,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -8956,7 +8930,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-uri": {
@@ -10470,7 +10443,6 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/http2-client/-/http2-client-1.3.5.tgz",
       "integrity": "sha512-EC2utToWl4RKfs5zd36Mxq7nzHHBuomZboI0yYL6Y0RmBgT7Sgkq4rQ0ezFTYoIsSs7Tm9SJe+o2FcAg6GBhGA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/http2-wrapper": {
@@ -11956,6 +11928,31 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/jest-expect-openapi": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jest-expect-openapi/-/jest-expect-openapi-2.0.1.tgz",
+      "integrity": "sha512-hvZFOkI9Kehn68hQjZEw8rnvjZ6LOwaDIQ5ZEZVYI9R5YX7OGeK1Bebl0EHasiWrloz6Khzi7CNcFNTYF3nhzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@readme/openapi-parser": "^3.0.1",
+        "@vitest/expect": "^3.0.7"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "jest": "^29.0.2"
+      },
+      "peerDependenciesMeta": {
+        "jest": {
+          "optional": true
+        },
+        "vitest": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/jest-get-type": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
@@ -12136,7 +12133,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
       "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/jsonfile": {
@@ -13905,7 +13901,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.ismatch": {
@@ -14125,7 +14120,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
       "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
@@ -16007,7 +16001,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
       "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "mustache": "bin/mustache"
@@ -16198,7 +16191,6 @@
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
       "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
@@ -16219,7 +16211,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/node-fetch-h2/-/node-fetch-h2-2.3.0.tgz",
       "integrity": "sha512-ofRW94Ab0T4AOh5Fk8t0h8OBWrmjb0SSB20xh1H8YnPV9EJ+f5AMoYSUQ2zgJ4Iq2HAK0I2l5/Nequ8YzFS3Hg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "http2-client": "^1.2.5"
@@ -16286,7 +16277,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/node-readfiles/-/node-readfiles-0.2.0.tgz",
       "integrity": "sha512-SU00ZarexNlE4Rjdm83vglt5Y9yiQ+XI1XpflWlb7q7UTN1JUItm69xMeiQCTxtTfnzt+83T8Cx+vI2ED++VDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es6-promise": "^3.2.1"
@@ -16751,12 +16741,12 @@
       }
     },
     "node_modules/oas": {
-      "version": "25.3.0",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-25.3.0.tgz",
-      "integrity": "sha512-98HLqUASE1u4kS8o3O7ZqjT1LG5oNwNjG1oXTsMscYVl2RSW4gMzlrn80dpxjsxpMlVuqPPa/sUS5WFtkk+Xxg==",
+      "version": "26.0.1",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-26.0.1.tgz",
+      "integrity": "sha512-eDaiCqAohUbYvqixseo2IygrfsnkFRNVz3FrKHMze3A8INeCbVNoR2fvSIBEhzwQIEy/nszddA91KBJ6gU3aJw==",
       "license": "MIT",
       "dependencies": {
-        "@readme/json-schema-ref-parser": "^1.2.0",
+        "@readme/openapi-parser": "^3.0.1",
         "@types/json-schema": "^7.0.11",
         "json-schema-merge-allof": "^0.8.1",
         "jsonpath-plus": "^10.0.0",
@@ -16764,17 +16754,16 @@
         "memoizee": "^0.4.16",
         "openapi-types": "^12.1.1",
         "path-to-regexp": "^8.1.0",
-        "remove-undefined-objects": "^5.0.0"
+        "remove-undefined-objects": "^6.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/oas-kit-common": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/oas-kit-common/-/oas-kit-common-1.0.8.tgz",
       "integrity": "sha512-pJTS2+T0oGIwgjGpw7sIRU8RQMcUoKCDWFLdBqKB2BNmGpbBMH2sdqAaOXUg8OzonZHU0L7vfJu1mJFEiYDWOQ==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "fast-safe-stringify": "^2.0.7"
@@ -16784,7 +16773,6 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/oas-linter/-/oas-linter-3.2.2.tgz",
       "integrity": "sha512-KEGjPDVoU5K6swgo9hJVA/qYGlwfbFx+Kg2QB/kd7rzV5N8N5Mg6PlsoCMohVnQmo+pzJap/F610qTodKzecGQ==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@exodus/schemasafe": "^1.0.0-rc.2",
@@ -16796,27 +16784,25 @@
       }
     },
     "node_modules/oas-normalize": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-12.1.0.tgz",
-      "integrity": "sha512-YDIkzgiyxV+WunOWtc9zKvGPK37KMhNiCRArSZ2D7olQmcZ3iSmYwZ9NbNj9xgJUAnNVFJJNOFLrXtsR2z/6Yg==",
-      "dev": true,
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-13.1.0.tgz",
+      "integrity": "sha512-ybVVes6mu5bcjoTAtlQ1ra5rqdbq4AYYd1tgeAplaL5pMZWW3TTJs5a5MMhadbd+fFaH8UQ9YMZu2EJsnSDsog==",
       "license": "MIT",
       "dependencies": {
-        "@readme/openapi-parser": "^2.7.0",
+        "@readme/openapi-parser": "^3.0.1",
         "@readme/postman-to-openapi": "^4.1.0",
         "js-yaml": "^4.1.0",
         "openapi-types": "^12.1.3",
         "swagger2openapi": "^7.0.8"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/oas-resolver": {
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/oas-resolver/-/oas-resolver-2.5.6.tgz",
       "integrity": "sha512-Yx5PWQNZomfEhPPOphFbZKi9W93CocQj18NlD2Pa4GWZzdZpSJvYwoiuurRI7m3SpcChrnO08hkuQDL3FGsVFQ==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "node-fetch-h2": "^2.3.0",
@@ -16836,7 +16822,6 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/oas-schema-walker/-/oas-schema-walker-1.1.5.tgz",
       "integrity": "sha512-2yucenq1a9YPmeNExoUa9Qwrt9RFkjqaMAA1X+U7sbb0AqBeTIdMHky9SQQ6iN94bO5NW0W4TRYXerG+BdAvAQ==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "funding": {
         "url": "https://github.com/Mermade/oas-kit?sponsor=1"
@@ -16846,7 +16831,6 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/oas-validator/-/oas-validator-5.0.8.tgz",
       "integrity": "sha512-cu20/HE5N5HKqVygs3dt94eYJfBi0TsZvPVXDhbXQHiEityDN+RROTleefoKRKKJ9dFAF2JBkDHgvWj0sjKGmw==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "call-me-maybe": "^1.0.1",
@@ -16860,15 +16844,6 @@
       },
       "funding": {
         "url": "https://github.com/Mermade/oas-kit?sponsor=1"
-      }
-    },
-    "node_modules/oas/node_modules/remove-undefined-objects": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/remove-undefined-objects/-/remove-undefined-objects-5.0.0.tgz",
-      "integrity": "sha512-DE8C17uIWeHaY4SqIkpQpHXm0MIdYHtIqjieWuh0I2PG8YcZRxFE6pqeEhnRetsrQ7Lu9uvSNQkDbg95NLpvnQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/object-assign": {
@@ -18647,7 +18622,6 @@
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/reftools/-/reftools-1.1.9.tgz",
       "integrity": "sha512-OVede/NQE13xBQ+ob5CKd5KyeJYU2YInb1bmV4nRoOfquZPkAkxuOXicSe1PvqIuZZ4kD13sPKBbR7UFDmli6w==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "funding": {
         "url": "https://github.com/Mermade/oas-kit?sponsor=1"
@@ -19378,7 +19352,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/semver": {
@@ -19485,7 +19459,6 @@
       "version": "13.2.3",
       "resolved": "https://registry.npmjs.org/should/-/should-13.2.3.tgz",
       "integrity": "sha512-ggLesLtu2xp+ZxI+ysJTmNjh2U0TsC+rQ/pfED9bUZZ4DKefP27D+7YJVVTvKsmjLpIi9jAa7itwDGkDDmt1GQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "should-equal": "^2.0.0",
@@ -19499,7 +19472,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/should-equal/-/should-equal-2.0.0.tgz",
       "integrity": "sha512-ZP36TMrK9euEuWQYBig9W55WPC7uo37qzAEmbjHz4gfyuXrEUgF8cUvQVO+w+d3OMfPvSRQJ22lSm8MQJ43LTA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "should-type": "^1.4.0"
@@ -19509,7 +19481,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/should-format/-/should-format-3.0.3.tgz",
       "integrity": "sha512-hZ58adtulAk0gKtua7QxevgUaXTTXxIi8t41L3zo9AHvjXO1/7sdLECuHeIN2SRtYXpNkmhoUP2pdeWgricQ+Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "should-type": "^1.3.0",
@@ -19520,14 +19491,12 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/should-type/-/should-type-1.4.0.tgz",
       "integrity": "sha512-MdAsTu3n25yDbIe1NeN69G4n6mUnJGtSJHygX3+oN0ZbO3DTiATnf7XnYJdGT42JCXurTb1JI0qOBR65shvhPQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/should-type-adaptors": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/should-type-adaptors/-/should-type-adaptors-1.1.0.tgz",
       "integrity": "sha512-JA4hdoLnN+kebEp2Vs8eBe9g7uy0zbRo+RMcU0EsNy+R+k049Ki+N5tT5Jagst2g7EAja+euFuoXFCa8vIklfA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "should-type": "^1.3.0",
@@ -19538,7 +19507,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/should-util/-/should-util-1.0.1.tgz",
       "integrity": "sha512-oXF8tfxx5cDk8r2kYqlkUJzZpDBqVY/II2WhvU0n9Y3XYvAYRmeaf1PvvIvTgPnv4KJ+ES5M0PyDq5Jp+Ygy2g==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/side-channel": {
@@ -20425,7 +20393,6 @@
       "version": "7.0.8",
       "resolved": "https://registry.npmjs.org/swagger2openapi/-/swagger2openapi-7.0.8.tgz",
       "integrity": "sha512-upi/0ZGkYgEcLeGieoz8gT74oWHA0E7JivX7aN9mAf+Tc7BQoRBvnIGHoPDw+f9TXTW4s6kGYCZJtauP6OYp7g==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "call-me-maybe": "^1.0.1",
@@ -20775,7 +20742,6 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tree-kill": {
@@ -23813,14 +23779,12 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tr46": "~0.0.3",
@@ -24309,7 +24273,6 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -24326,7 +24289,6 @@
       "version": "1.10.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
       "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">= 6"
@@ -24336,7 +24298,6 @@
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
@@ -24355,7 +24316,6 @@
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -24365,14 +24325,12 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/yargs/node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -24435,7 +24393,6 @@
       "license": "MIT",
       "dependencies": {
         "@readme/api-core": "file:../core",
-        "@readme/openapi-parser": "^2.4.0",
         "chalk": "^5.3.0",
         "ci-info": "^4.0.0",
         "commander": "^13.0.0",
@@ -24446,7 +24403,8 @@
         "js-yaml": "^4.1.0",
         "license": "^1.0.3",
         "lodash-es": "^4.17.21",
-        "oas": "^25.0.1",
+        "oas": "^26.0.1",
+        "oas-normalize": "^13.1.0",
         "ora": "^8.0.1",
         "preferred-pm": "^4.0.0",
         "prompts": "^2.4.2",
@@ -24462,7 +24420,7 @@
       },
       "devDependencies": {
         "@api/test-utils": "file:../test-utils",
-        "@readme/oas-examples": "^5.12.1",
+        "@readme/oas-examples": "^5.19.1",
         "@types/js-yaml": "^4.0.9",
         "@types/lodash-es": "^4.17.12",
         "@types/prompts": "^2.4.9",
@@ -24475,7 +24433,6 @@
         "ajv": "^8.12.0",
         "ajv-formats": "^3.0.1",
         "nock": "^14.0.1",
-        "oas-normalize": "^12.0.0",
         "openapi-types": "^12.1.3",
         "tsup": "^8.4.0",
         "tsx": "^4.19.1",
@@ -24485,7 +24442,7 @@
         "vitest": "^3.0.4"
       },
       "engines": {
-        "node": "^18.20.0 || >=20.10.0"
+        "node": ">=20.10.0"
       }
     },
     "packages/api/node_modules/ansi-regex": {
@@ -24786,19 +24743,19 @@
       "version": "7.0.0-beta.12",
       "license": "MIT",
       "dependencies": {
-        "@readme/oas-to-har": "^24.0.0",
+        "@readme/oas-to-har": "^25.0.1",
         "caseless": "^0.12.0",
         "datauri": "^4.1.0",
         "fetch-har": "^11.0.1",
         "json-schema-to-ts": "^3.0.0",
         "json-schema-traverse": "^1.0.0",
         "lodash.merge": "^4.6.2",
-        "oas": "^25.0.1",
+        "oas": "^26.0.1",
         "remove-undefined-objects": "^6.0.0"
       },
       "devDependencies": {
         "@api/test-utils": "file:../test-utils",
-        "@readme/oas-examples": "^5.12.0",
+        "@readme/oas-examples": "^5.19.1",
         "@types/caseless": "^0.12.5",
         "@types/lodash.merge": "^4.6.9",
         "@vitest/coverage-v8": "^3.0.5",
@@ -24808,7 +24765,7 @@
         "vitest": "^3.0.4"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20.10.0"
       }
     },
     "packages/core/node_modules/get-stream": {
@@ -24863,22 +24820,22 @@
         "reserved2": "^0.1.5"
       },
       "devDependencies": {
-        "@readme/oas-examples": "^5.12.0",
-        "@readme/openapi-parser": "^2.5.0",
+        "@readme/oas-examples": "^5.19.1",
         "@types/content-type": "^1.1.8",
         "@types/stringify-object": "^4.0.5",
         "@vitest/coverage-v8": "^3.0.5",
         "camelcase": "^8.0.0",
+        "jest-expect-openapi": "^2.0.1",
         "stringify-object": "^5.0.0",
         "typescript": "^5.8.2",
         "vitest": "^3.0.4"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20.10.0"
       },
       "peerDependencies": {
         "@readme/httpsnippet": "^11.0.0",
-        "oas": "^25.0.1"
+        "oas": "^26.0.1"
       }
     },
     "packages/httpsnippet-client-api/node_modules/camelcase": {
@@ -24919,7 +24876,7 @@
       },
       "devDependencies": {
         "@types/caseless": "^0.12.3",
-        "oas": "^25.0.2",
+        "oas": "^26.0.1",
         "typescript": "^5.8.2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "url": "https://github.com/readmeio/api.git"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=20.10.0"
   },
   "workspaces": [
     "./packages/*"

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -33,7 +33,7 @@
   "author": "Jon Ursenbach <jon@readme.io>",
   "license": "MIT",
   "engines": {
-    "node": "^18.20.0 || >=20.10.0"
+    "node": ">=20.10.0"
   },
   "files": [
     "dist",
@@ -48,7 +48,6 @@
   ],
   "dependencies": {
     "@readme/api-core": "file:../core",
-    "@readme/openapi-parser": "^2.4.0",
     "chalk": "^5.3.0",
     "ci-info": "^4.0.0",
     "commander": "^13.0.0",
@@ -59,7 +58,8 @@
     "js-yaml": "^4.1.0",
     "license": "^1.0.3",
     "lodash-es": "^4.17.21",
-    "oas": "^25.0.1",
+    "oas": "^26.0.1",
+    "oas-normalize": "^13.1.0",
     "ora": "^8.0.1",
     "preferred-pm": "^4.0.0",
     "prompts": "^2.4.2",
@@ -72,7 +72,7 @@
   },
   "devDependencies": {
     "@api/test-utils": "file:../test-utils",
-    "@readme/oas-examples": "^5.12.1",
+    "@readme/oas-examples": "^5.19.1",
     "@types/js-yaml": "^4.0.9",
     "@types/lodash-es": "^4.17.12",
     "@types/prompts": "^2.4.9",
@@ -85,7 +85,6 @@
     "ajv": "^8.12.0",
     "ajv-formats": "^3.0.1",
     "nock": "^14.0.1",
-    "oas-normalize": "^12.0.0",
     "openapi-types": "^12.1.3",
     "tsup": "^8.4.0",
     "tsx": "^4.19.1",

--- a/packages/api/src/codegen/languages/typescript/index.ts
+++ b/packages/api/src/codegen/languages/typescript/index.ts
@@ -1151,7 +1151,10 @@ Generated at ${createdAt}
 
             return s;
           },
-        });
+          /**
+           * @todo can remove this casting after https://github.com/readmeio/oas/pull/956 is published
+           */
+        }) as SchemaObject[];
 
         if (!schema) {
           return false;

--- a/packages/api/src/fetcher.ts
+++ b/packages/api/src/fetcher.ts
@@ -129,16 +129,18 @@ export default class Fetcher {
       throw new Error('Sorry, this module only supports OpenAPI definitions.');
     }
 
-    const normalize = new OASNormalize(json, { parser: {
-      dereference: {
-        /**
-         * If circular `$refs` are ignored they'll remain in the API definition as `$ref: String`.
-         * This allows us to not only do easy circular reference detection but also stringify and
-         * save dereferenced API definitions back into the cache directory.
-         */
-        circular: 'ignore',
+    const normalize = new OASNormalize(json, {
+      parser: {
+        dereference: {
+          /**
+           * If circular `$refs` are ignored they'll remain in the API definition as `$ref: String`.
+           * This allows us to not only do easy circular reference detection but also stringify and
+           * save dereferenced API definitions back into the cache directory.
+           */
+          circular: 'ignore',
+        },
       },
-  }});
+    });
 
     await normalize.validate().catch(err => {
       // Zhuzh up this error message a bit so our errors here are consistenly prefixed with "Sorry".

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -46,22 +46,22 @@
   "author": "Jon Ursenbach <jon@readme.io>",
   "license": "MIT",
   "engines": {
-    "node": ">=18"
+    "node": ">=20.10.0"
   },
   "dependencies": {
-    "@readme/oas-to-har": "^24.0.0",
+    "@readme/oas-to-har": "^25.0.1",
     "caseless": "^0.12.0",
     "datauri": "^4.1.0",
     "fetch-har": "^11.0.1",
     "json-schema-to-ts": "^3.0.0",
     "json-schema-traverse": "^1.0.0",
     "lodash.merge": "^4.6.2",
-    "oas": "^25.0.1",
+    "oas": "^26.0.1",
     "remove-undefined-objects": "^6.0.0"
   },
   "devDependencies": {
     "@api/test-utils": "file:../test-utils",
-    "@readme/oas-examples": "^5.12.0",
+    "@readme/oas-examples": "^5.19.1",
     "@types/caseless": "^0.12.5",
     "@types/lodash.merge": "^4.6.9",
     "@vitest/coverage-v8": "^3.0.5",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -104,11 +104,10 @@ export default class APICore {
         init.signal = controller.signal;
       }
 
-      return fetchHar(har as Har, {
-        files: data.files || {},
-        init,
-        userAgent: this.userAgent,
-      })
+      // `getHarForRequest` returns a partial HAR object, by way of `@readme/oas-to-har` but
+      // `fetch-har` is typed to expect the full thing. Though we're supplying an incomplete HAR
+      // object, at least the spec, our partial is fine.
+      return fetchHar(har as unknown as Har, { files: data.files || {}, init, userAgent: this.userAgent })
         .then(async (res: Response) => {
           const parsed = await parseResponse<HTTPStatus>(res);
 

--- a/packages/httpsnippet-client-api/package.json
+++ b/packages/httpsnippet-client-api/package.json
@@ -33,7 +33,7 @@
   "author": "Jon Ursenbach <jon@readme.io>",
   "license": "MIT",
   "engines": {
-    "node": ">=18"
+    "node": ">=20.10.0"
   },
   "dependencies": {
     "content-type": "^1.0.5",
@@ -41,15 +41,15 @@
   },
   "peerDependencies": {
     "@readme/httpsnippet": "^11.0.0",
-    "oas": "^25.0.1"
+    "oas": "^26.0.1"
   },
   "devDependencies": {
-    "@readme/oas-examples": "^5.12.0",
-    "@readme/openapi-parser": "^2.5.0",
+    "@readme/oas-examples": "^5.19.1",
     "@types/content-type": "^1.1.8",
     "@types/stringify-object": "^4.0.5",
     "@vitest/coverage-v8": "^3.0.5",
     "camelcase": "^8.0.0",
+    "jest-expect-openapi": "^2.0.1",
     "stringify-object": "^5.0.0",
     "typescript": "^5.8.2",
     "vitest": "^3.0.4"

--- a/packages/test-utils/load-spec.ts
+++ b/packages/test-utils/load-spec.ts
@@ -2,7 +2,8 @@
  * Because parts of our OpenAPI dereferencer in `oas` can update variable references passed to it
  * we may need to sometimes fully clone a spec to test something. This is just a small DIY wrapper
  * for doing so.
+ *
  */
-export function loadSpec(spec: string) {
+export async function loadSpec(spec: string) {
   return import(spec).then(({ default: data }) => JSON.stringify(data)).then(JSON.parse);
 }

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@types/caseless": "^0.12.3",
-    "oas": "^25.0.2",
+    "oas": "^26.0.1",
     "typescript": "^5.8.2"
   },
   "prettier": "@readme/eslint-config/prettier"


### PR DESCRIPTION
## 🧰 Changes

Over the past couple weeks I've been rewriting our OpenAPI parser, `@readme/openapi-parser`, to support a new error leveling system -- you can read up on details on this in https://github.com/readmeio/oas/pull/943. This PR pulls in the fruits of my labor there and across `oas` and `oas-normalize`.

* [x] Drops support for Node 18. Because our v7 release is still being considered as a beta and Node 18 is being EOL'd at the end of April we're making the conscious decision now to drop support for Node 18 across our OpenAPI tooling and this application.
* [x] Updates `oas`, `oas-normalize`, `@readme/oas-examples`, and `@readme/openapi-parser` to their latest, breaking releases.
