### PR TITLE
fix: failing tests (multipart-formdata)

### DIFF
--- a/packages/core/test/index.test.ts
+++ b/packages/core/test/index.test.ts
@@ -250,7 +250,7 @@ describe('APICore', () => {
           const { data } = await parametersStyle.fetch('/anything/form-data/form', 'post', body);
 
           expect(data.uri).toBe('/anything/form-data/form');
-          expect(data.requestBody.split(`${data.boundary}`).filter(Boolean)).toStrictEqual([
+          expect(data.requestBody.trim().split(`${data.boundary}`).filter(Boolean)).toStrictEqual([
             '\r\nContent-Disposition: form-data; name="primitive"\r\n\r\nstring\r\n',
             '\r\nContent-Disposition: form-data; name="array"\r\n\r\nstring\r\n',
             '\r\nContent-Disposition: form-data; name="object"\r\n\r\nfoo,foo-string,bar,bar-string\r\n',
@@ -270,7 +270,7 @@ describe('APICore', () => {
 
             const { data } = await fileUploads.fetch('/anything/multipart-formdata', 'post', body);
             expect(data.uri).toBe('/anything/multipart-formdata');
-            expect(data.requestBody.split(`${data.boundary}`).filter(Boolean)).toStrictEqual([
+            expect(data.requestBody.trim().split(`${data.boundary}`).filter(Boolean)).toStrictEqual([
               '\r\nContent-Disposition: form-data; name="orderId"\r\n\r\n1234\r\n',
               '\r\nContent-Disposition: form-data; name="userId"\r\n\r\n5678\r\n',
               '\r\nContent-Disposition: form-data; name="documentFile"; filename="hello.txt"\r\nContent-Type: text/plain\r\n\r\nHello world!\n\r\n',
@@ -287,7 +287,7 @@ describe('APICore', () => {
 
             const { data } = await fileUploads.fetch('/anything/multipart-formdata', 'post', body);
             expect(data.uri).toBe('/anything/multipart-formdata');
-            expect(data.requestBody.split(`${data.boundary}`).filter(Boolean)).toStrictEqual([
+            expect(data.requestBody.trim().split(`${data.boundary}`).filter(Boolean)).toStrictEqual([
               '\r\nContent-Disposition: form-data; name="documentFile"; filename="hello.jp.txt"\r\nContent-Type: text/plain\r\n\r\n速い茶色のキツネは怠惰な犬を飛び越えます\n\r\n',
               '--',
             ]);


### PR DESCRIPTION
## 🧰 Changes

Fixes three failing tests in packages/core/test/index.test.ts under APICore > #fetch > multipart/form-data in Node.js 24:
- should support multipart/form-data requests
- should support plaintext files
- should support plaintext files containing unicode characters

Node.js 24 appends a newline (\n) to the final multipart/form-data boundary, causing data.requestBody to end with "--\n" instead of "--" expected by tests.

## 🧬 QA & Testing

Run `npm run test` to run unit tests
