### PR TITLE
chore: moving the `oas` dep in `httpsnippet-client-api` off a peerDep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3490,11 +3490,12 @@
       }
     },
     "node_modules/@readme/openapi-parser": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@readme/openapi-parser/-/openapi-parser-4.1.0.tgz",
-      "integrity": "sha512-zZaGaOJ+0bYPGkPK4ekspE1BoO1iifxe5d3rsAE6AqFCoyHCjt/xMDtmJpy4slFdd1YtEv/VHhBpB1FlNClCNw==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@readme/openapi-parser/-/openapi-parser-4.1.2.tgz",
+      "integrity": "sha512-lAFH88r/CHs5VZDUocEda0OSMSQsr6801sziIjOKyVA+0hSFN+BPuelPF5XvkMROHecnPd+XEJN1iNQqCgER/g==",
+      "license": "MIT",
       "dependencies": {
-        "@apidevtools/json-schema-ref-parser": "^13.0.1",
+        "@apidevtools/json-schema-ref-parser": "^13.0.5",
         "@readme/better-ajv-errors": "^2.3.2",
         "@readme/openapi-schemas": "^3.1.0",
         "@types/json-schema": "^7.0.15",
@@ -17675,11 +17676,12 @@
       }
     },
     "node_modules/oas": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-27.1.0.tgz",
-      "integrity": "sha512-K1qOiNguPMTRG52pboD1xyNPvdg1DImxjKXDjSTXe/4NVzXosYrLsDw9T3N82HFSlsGqOyXNAfPpZ80VYcDedw==",
+      "version": "27.2.1",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-27.2.1.tgz",
+      "integrity": "sha512-W+j0KxKjIBVSixUA6halqnSRMNW5aydO9TwZinR8bLPejAY0au8JDBK97ZM3XKGL4JRqObu9mOB7Fy/GxAgAMQ==",
+      "license": "MIT",
       "dependencies": {
-        "@readme/openapi-parser": "^4.1.0",
+        "@readme/openapi-parser": "^4.1.2",
         "@types/json-schema": "^7.0.11",
         "json-schema-merge-allof": "^0.8.1",
         "jsonpath-plus": "^10.0.0",
@@ -24754,6 +24756,7 @@
       "license": "MIT",
       "dependencies": {
         "content-type": "^1.0.5",
+        "oas": "^27.2.1",
         "reserved2": "^0.1.5"
       },
       "devDependencies": {
@@ -24771,8 +24774,7 @@
         "node": ">=20.10.0"
       },
       "peerDependencies": {
-        "@readme/httpsnippet": "^11.0.0",
-        "oas": "^27.0.0"
+        "@readme/httpsnippet": "^11.0.0"
       }
     },
     "packages/httpsnippet-client-api/node_modules/camelcase": {

--- a/packages/httpsnippet-client-api/package.json
+++ b/packages/httpsnippet-client-api/package.json
@@ -37,11 +37,11 @@
   },
   "dependencies": {
     "content-type": "^1.0.5",
+    "oas": "^27.2.1",
     "reserved2": "^0.1.5"
   },
   "peerDependencies": {
-    "@readme/httpsnippet": "^11.0.0",
-    "oas": "^27.0.0"
+    "@readme/httpsnippet": "^11.0.0"
   },
   "devDependencies": {
     "@readme/oas-examples": "^6.0.0",


### PR DESCRIPTION
## 🧰 Changes

I published a new major version of `oas` today and am having a real hard time getting it installed in our monorepo thanks to the peerdep for `oas@27` that exists in `httpsnippet-client-api`. Moving it to a normal dependency should resolve my woes.
