### PR TITLE
feat: enhance ConfigOptions to include init parameter for fetch requests

### DIFF
--- a/packages/api/src/core/index.ts
+++ b/packages/api/src/core/index.ts
@@ -22,6 +22,11 @@ export interface ConfigOptions {
    * in milliseconds.
    */
   timeout?: number;
+  /**
+   * Additional arguments to pass to the `init` object used in fetch requests.
+   * These will be shallow-merged with internal options. The `signal` property is always managed internally and cannot be overridden.
+   */
+  init?: Omit<RequestInit, 'signal'>;
 }
 
 export interface FetchResponse<status, data> {
@@ -109,7 +114,7 @@ export default class APICore {
       const har = oasToHar(this.spec, operation, data, prepareAuth(this.auth, operation));
 
       let timeoutSignal: any;
-      const init: RequestInit = {};
+      const init: RequestInit = { ...this.config.init };
       if (this.config.timeout) {
         const controller = new AbortController();
         timeoutSignal = setTimeout(() => controller.abort(), this.config.timeout);


### PR DESCRIPTION
| 🚥 Resolves #1046 |
| :------------------- |

## 🧰 Changes

This PR adds support for passing custom init options to the fetch request in the API core.
* The ConfigOptions interface now includes an optional init property, allowing users to specify additional RequestInit options.
* The APICore class now merges config.init into the fetch request's init object, ensuring user-supplied options are respected (except for signal, which is managed internally).

## 🧬 QA & Testing

1. Set up an instance of APICore and pass custom init options (e.g., custom headers or credentials) via setConfig({ init: { ... } }).
2. Make a request using fetch or fetchOperation.
3. Verify that the custom init options are present in the outgoing request (except for signal).
4. Ensure that the request still respects the internal timeout and abort logic.
5. Run the existing test suite to confirm no regressions.