### PR TITLE
feat(core): export `FetchError` as a named export from `@readme/api-core`

### DIFF
--- a/.changeset/tame-rivers-jog.md
+++ b/.changeset/tame-rivers-jog.md
@@ -1,0 +1,5 @@
+---
+"@readme/api-core": minor
+---
+
+Export `FetchError` as a named export from the package root, so it can be imported directly from `@readme/api-core` instead of the `@readme/api-core/errors/fetchError` subpath.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,6 +11,8 @@ import Oas from 'oas';
 import FetchError from './errors/fetchError.js';
 import { parseResponse, prepareAuth, prepareParams, prepareServer } from './lib/index.js';
 
+export { FetchError };
+
 export default class APICore {
   spec!: Oas;
 

--- a/packages/core/test/index.test.ts
+++ b/packages/core/test/index.test.ts
@@ -14,7 +14,13 @@ import nock from 'nock';
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import FetchError from '../src/errors/fetchError.js';
-import APICore from '../src/index.js';
+import APICore, { FetchError as FetchErrorFromCore } from '../src/index.js';
+
+describe('exports', () => {
+  it('should re-export `FetchError` as a named export alongside the default `APICore` export', () => {
+    expect(FetchErrorFromCore).toBe(FetchError);
+  });
+});
 
 describe('APICore', () => {
   let fileUploads: APICore;


### PR DESCRIPTION
## Description

`FetchError` is thrown directly by `APICore#fetch` for error-level status codes, but it could only be imported via the `@readme/api-core/errors/fetchError` subpath. There was no way to import it alongside the main `APICore` import from the package root, making it harder for consumers to discover how to do `instanceof` checks against it.

This adds a named export for `FetchError` from the package root (`packages/core/src/index.ts`), so it can now be imported as:

```ts
import APICore, { FetchError } from '@readme/api-core';
```

in addition to the existing subpath import.

Fixes #967

## Testing

Added a test asserting that the named export from the package root is the exact same class as the one imported from the `errors/fetchError` subpath. Ran the full `@readme/api-core` test suite (83 passing) and `tsc --noEmit`, both clean.