### PR TITLE
feat: add support for calling out to restless cli for specific commands

### DIFF
--- a/.changeset/chilly-regions-reply.md
+++ b/.changeset/chilly-regions-reply.md
@@ -1,0 +1,5 @@
+---
+"api": patch
+---
+
+Adding support for calling out to Restless for specific commands.

--- a/packages/api/src/bin.ts
+++ b/packages/api/src/bin.ts
@@ -4,25 +4,32 @@ import updateNotifier from 'update-notifier';
 import commands from './commands/index.js';
 import logger from './logger.js';
 import { PACKAGE_NAME, PACKAGE_VERSION } from './packageInfo.js';
+import { classifyInvocation, dispatchToRestlessCli } from './router.js';
 
-updateNotifier({ pkg: { name: PACKAGE_NAME, version: PACKAGE_VERSION } }).notify();
+const cliArgs = process.argv.slice(2);
 
-void (async () => {
-  const program = new Command();
-  program.name(PACKAGE_NAME);
-  program.version(PACKAGE_VERSION);
+if (classifyInvocation(cliArgs) === 'restless') {
+  dispatchToRestlessCli(cliArgs);
+} else {
+  updateNotifier({ pkg: { name: PACKAGE_NAME, version: PACKAGE_VERSION } }).notify();
 
-  /**
-   * Instead of using Commander's `executableDir` API for loading in external command files we're
-   * programatically doing it like this because it's cleaner for us to let Commander manage option
-   * and argument parsing within this file than having each command  manage that itself.
-   */
-  Object.entries(commands).forEach(([, cmd]: [string, Command]) => {
-    program.addCommand(cmd);
-  });
+  void (async () => {
+    const program = new Command();
+    program.name(PACKAGE_NAME);
+    program.version(PACKAGE_VERSION);
 
-  await program.parseAsync(process.argv).catch(err => {
-    if (err.message) logger(err.message, true);
-    process.exit(1);
-  });
-})();
+    /**
+     * Instead of using Commander's `executableDir` API for loading in external command files we're
+     * programatically doing it like this because it's cleaner for us to let Commander manage option
+     * and argument parsing within this file than having each command  manage that itself.
+     */
+    Object.entries(commands).forEach(([, cmd]: [string, Command]) => {
+      program.addCommand(cmd);
+    });
+
+    await program.parseAsync(process.argv).catch(err => {
+      if (err.message) logger(err.message, true);
+      process.exit(1);
+    });
+  })();
+}

--- a/packages/api/src/router.ts
+++ b/packages/api/src/router.ts
@@ -1,0 +1,76 @@
+import { spawn } from 'node:child_process';
+
+/**
+ * Commands that are handled by this package's own Commander program. Anything else is dispatched
+ * to the Restless CLI.
+ */
+const CODEGEN_COMMANDS = new Set(['install', 'list', 'uninstall']);
+
+const HELP_AND_VERSION_FLAGS = new Set(['--help', '-h', '--version', '-V']);
+
+export type Route = 'codegen' | 'restless';
+
+/**
+ * Determine whether an invocation should be handled by our own Commander program (`codegen`) or
+ * dispatched to the separately published Restless CLI.
+ *
+ * @param args CLI arguments — `process.argv` minus the Node binary and the script path.
+ */
+export function classifyInvocation(args: string[]): Route {
+  for (const arg of args) {
+    // A help or version flag ahead of any command (`api --help`, `api -V`) is ours.
+    if (HELP_AND_VERSION_FLAGS.has(arg)) {
+      return 'codegen';
+    }
+
+    // The first non-flag argument is the command.
+    if (!arg.startsWith('-')) {
+      return CODEGEN_COMMANDS.has(arg) ? 'codegen' : 'restless';
+    }
+  }
+
+  // No command at all — Commander prints its usage.
+  return 'codegen';
+}
+
+/**
+ * Re-run the invocation against the Restless CLI (published on npm as `@restlessai/cli`) in a
+ * child process, forwarding its exit code and any termination signals. The Restless CLI is
+ * intentionally **not** a dependency of this package: `npx -y` fetches (and caches) it on
+ * demand, keeping the two fully decoupled.
+ *
+ * @param args CLI arguments — `process.argv` minus the Node binary and the script path.
+ */
+export function dispatchToRestlessCli(args: string[]): void {
+  const child = spawn('npx', ['-y', '@restlessai/cli@latest', ...args], {
+    // `npx` is a `.cmd` shim on Windows and can't be spawned directly there.
+    shell: process.platform === 'win32',
+    stdio: 'inherit',
+  });
+
+  const forwardSignal = (signal: NodeJS.Signals) => {
+    child.kill(signal);
+  };
+
+  // Handling these ourselves keeps the parent alive until the child has finished shutting down.
+  process.on('SIGINT', forwardSignal);
+  process.on('SIGTERM', forwardSignal);
+
+  child.on('error', err => {
+    process.stderr.write(`${err.message}\n`);
+    process.exit(1);
+  });
+
+  child.on('close', (code, signal) => {
+    process.off('SIGINT', forwardSignal);
+    process.off('SIGTERM', forwardSignal);
+
+    if (signal) {
+      // The child was killed by a signal — re-raise it so our own exit status reflects that.
+      process.kill(process.pid, signal);
+      return;
+    }
+
+    process.exit(code ?? 0);
+  });
+}

--- a/packages/api/test/bin.test.ts
+++ b/packages/api/test/bin.test.ts
@@ -1,0 +1,78 @@
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+interface BinResult {
+  code: number | null;
+  stderr: string;
+  stdout: string;
+}
+
+const packageDir = fileURLToPath(new URL('..', import.meta.url));
+
+let stubDir: string;
+
+/**
+ * Runs `src/bin.ts` through `tsx` with a stubbed `npx` at the front of the `PATH`, so dispatched
+ * invocations hit the stub (which echoes its arguments and exits 7) instead of the network.
+ */
+function runBin(args: string[]): Promise<BinResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn('node', ['--import', 'tsx', path.join(packageDir, 'src', 'bin.ts'), ...args], {
+      cwd: packageDir,
+      env: { ...process.env, PATH: `${stubDir}${path.delimiter}${process.env.PATH}` },
+    });
+
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', chunk => {
+      stdout += chunk;
+    });
+    child.stderr.on('data', chunk => {
+      stderr += chunk;
+    });
+
+    child.on('error', reject);
+    child.on('close', code => {
+      resolve({ code, stderr, stdout });
+    });
+  });
+}
+
+describe.skipIf(process.platform === 'win32')('bin routing', () => {
+  beforeAll(() => {
+    stubDir = fs.mkdtempSync(path.join(os.tmpdir(), 'api-router-stub-'));
+    const stub = path.join(stubDir, 'npx');
+    fs.writeFileSync(stub, '#!/bin/sh\necho "npx-stub:$@"\nexit 7\n');
+    fs.chmodSync(stub, 0o755);
+  });
+
+  afterAll(() => {
+    fs.rmSync(stubDir, { force: true, recursive: true });
+  });
+
+  it(
+    'should dispatch unknown commands to the Restless CLI and forward the exit code',
+    { timeout: 60_000 },
+    async () => {
+      const result = await runBin(['init', '--help']);
+
+      expect(result.stdout).toContain('npx-stub:-y @restlessai/cli@latest init --help');
+      expect(result.code).toBe(7);
+    },
+  );
+
+  it('should not dispatch `--help` and should not mention the Restless CLI in it', { timeout: 60_000 }, async () => {
+    const result = await runBin(['--help']);
+
+    expect(result.stdout).toContain('Usage:');
+    expect(result.stdout).toContain('install');
+    expect(result.stdout.toLowerCase()).not.toContain('restless');
+    expect(result.stdout).not.toContain('npx-stub');
+    expect(result.code).toBe(0);
+  });
+});

--- a/packages/api/test/router.test.ts
+++ b/packages/api/test/router.test.ts
@@ -1,0 +1,153 @@
+import type * as childProcess from 'node:child_process';
+import type { MockInstance } from 'vitest';
+
+import { EventEmitter } from 'node:events';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { classifyInvocation, dispatchToRestlessCli } from '../src/router.js';
+
+const spawn = vi.hoisted(() =>
+  vi.fn<(command: string, args: string[], options: Record<string, unknown>) => FakeChildProcess>(),
+);
+
+vi.mock(import('node:child_process'), () => ({ spawn }) as unknown as typeof childProcess);
+
+class FakeChildProcess extends EventEmitter {
+  kill = vi.fn<(signal?: NodeJS.Signals) => boolean>();
+}
+
+describe('#classifyInvocation', () => {
+  it.each([
+    ['install', ['install', 'https://example.com/petstore.json']],
+    ['list', ['list']],
+    ['uninstall', ['uninstall', 'petstore']],
+    ['install --help', ['install', '--help']],
+  ])('should classify `%s` as a codegen command', (_, args) => {
+    expect(classifyInvocation(args)).toBe('codegen');
+  });
+
+  it.each([
+    ['(empty)', []],
+    ['--help', ['--help']],
+    ['-h', ['-h']],
+    ['--version', ['--version']],
+    ['-V', ['-V']],
+    ['--help init', ['--help', 'init']],
+  ])('should classify `%s` as a codegen invocation for Commander to handle', (_, args) => {
+    expect(classifyInvocation(args)).toBe('codegen');
+  });
+
+  it.each([
+    ['init', ['init']],
+    ['reset', ['reset']],
+    ['debug', ['debug', 'req_12345']],
+    ['skill', ['skill', 'https://example.com/petstore.json']],
+    ['some-unknown-cmd', ['some-unknown-cmd']],
+    ['init --help', ['init', '--help']],
+    ['--yes init', ['--yes', 'init']],
+  ])('should classify `%s` as a Restless CLI command', (_, args) => {
+    expect(classifyInvocation(args)).toBe('restless');
+  });
+});
+
+describe('#dispatchToRestlessCli', () => {
+  let child: FakeChildProcess;
+  let exitSpy: MockInstance;
+  let stderrSpy: MockInstance;
+
+  beforeEach(() => {
+    child = new FakeChildProcess();
+    spawn.mockReturnValue(child);
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+    stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    // Emitting `close` unregisters any signal listeners that `dispatchToRestlessCli` left on
+    // `process` so they don't leak into other tests.
+    child.emit('close', 0, null);
+    vi.restoreAllMocks();
+    spawn.mockReset();
+  });
+
+  it('should spawn `npx` without writing anything to stderr itself', () => {
+    dispatchToRestlessCli(['init']);
+
+    expect(stderrSpy).not.toHaveBeenCalled();
+    expect(spawn).toHaveBeenCalledWith(
+      'npx',
+      ['-y', '@restlessai/cli@latest', 'init'],
+      expect.objectContaining({ stdio: 'inherit' }),
+    );
+  });
+
+  it('should forward all original arguments, flags included', () => {
+    dispatchToRestlessCli(['debug', 'req_12345', '--verbose']);
+
+    expect(spawn).toHaveBeenCalledWith(
+      'npx',
+      ['-y', '@restlessai/cli@latest', 'debug', 'req_12345', '--verbose'],
+      expect.objectContaining({ stdio: 'inherit' }),
+    );
+  });
+
+  it("should exit with the child's exit code", () => {
+    dispatchToRestlessCli(['init']);
+
+    child.emit('close', 3, null);
+
+    expect(exitSpy).toHaveBeenCalledWith(3);
+  });
+
+  it('should forward SIGINT and SIGTERM to the child', () => {
+    const sigintListeners = process.listeners('SIGINT');
+    const sigtermListeners = process.listeners('SIGTERM');
+
+    dispatchToRestlessCli(['init']);
+
+    const forwardSigint = process.listeners('SIGINT').find(listener => !sigintListeners.includes(listener));
+    const forwardSigterm = process.listeners('SIGTERM').find(listener => !sigtermListeners.includes(listener));
+
+    forwardSigint?.('SIGINT');
+    expect(child.kill).toHaveBeenCalledWith('SIGINT');
+
+    forwardSigterm?.('SIGTERM');
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+  });
+
+  it('should unregister its signal listeners once the child exits', () => {
+    const sigintListeners = process.listenerCount('SIGINT');
+    const sigtermListeners = process.listenerCount('SIGTERM');
+
+    dispatchToRestlessCli(['init']);
+
+    expect(process.listenerCount('SIGINT')).toBe(sigintListeners + 1);
+    expect(process.listenerCount('SIGTERM')).toBe(sigtermListeners + 1);
+
+    child.emit('close', 0, null);
+
+    expect(process.listenerCount('SIGINT')).toBe(sigintListeners);
+    expect(process.listenerCount('SIGTERM')).toBe(sigtermListeners);
+  });
+
+  it('should re-raise the signal that killed the child instead of exiting normally', () => {
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true);
+
+    dispatchToRestlessCli(['init']);
+
+    child.emit('close', null, 'SIGTERM');
+
+    expect(killSpy).toHaveBeenCalledWith(process.pid, 'SIGTERM');
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it('should exit with code 1 if the child fails to spawn', () => {
+    dispatchToRestlessCli(['init']);
+
+    child.emit('error', new Error('spawn npx ENOENT'));
+
+    expect(stderrSpy).toHaveBeenCalledWith('spawn npx ENOENT\n');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});


### PR DESCRIPTION
In Restless, we are using the `api` namespace as a way to onboard users into the new product. That code lives in a [separate repo](https://github.com/restlesshq/npx-api), and this adds support for calling out to those commands when someone does `npx api init` (for example). 

I don't love how we are overloading this so much (and I'll take a stab at making this more clear in the readme.md file later) but wanted to get a first pass of this going. 