### PR TITLE
feat(core): adding support for supplying `RequestInit` options

### DIFF
--- a/.changeset/spicy-news-dance.md
+++ b/.changeset/spicy-news-dance.md
@@ -1,0 +1,5 @@
+---
+"@readme/api-core": minor
+---
+
+Adding support for supplying custom `RequestInit` options.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12276,17 +12276,17 @@
       }
     },
     "packages/api": {
-      "version": "7.0.0-beta.17",
+      "version": "7.0.0-next.18",
       "license": "MIT",
       "dependencies": {
-        "@readme/api-core": "7.0.0-beta.17",
+        "@readme/api-core": "7.0.0-next.18",
         "chalk": "^5.3.0",
         "ci-info": "^4.0.0",
         "commander": "^14.0.0",
         "emphasize": "^7.0.0",
         "execa": "^8.0.1",
         "figures": "^6.0.1",
-        "httpsnippet-client-api": "^7.0.0-beta.17",
+        "httpsnippet-client-api": "^7.0.0-next.18",
         "js-yaml": "^5.2.1",
         "json-schema-traverse": "^1.0.0",
         "license": "^1.0.3",
@@ -12639,7 +12639,7 @@
     },
     "packages/core": {
       "name": "@readme/api-core",
-      "version": "7.0.0-beta.17",
+      "version": "7.0.0-next.18",
       "license": "MIT",
       "dependencies": {
         "@readme/oas-to-har": "^37.0.0",
@@ -12699,7 +12699,7 @@
       }
     },
     "packages/httpsnippet-client-api": {
-      "version": "7.0.0-beta.17",
+      "version": "7.0.0-next.18",
       "license": "MIT",
       "dependencies": {
         "content-type": "^2.0.0",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -99,7 +99,7 @@ export default class APICore {
       const har = this.getHARForRequest(operation, data, prepareAuth(this.auth, operation));
 
       let timeoutSignal: NodeJS.Timeout;
-      const init: RequestInit = {};
+      const init: RequestInit = { ...this.config.init };
       if (this.config.timeout) {
         const controller = new AbortController();
         timeoutSignal = setTimeout(() => controller.abort(), this.config.timeout);

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -2,6 +2,14 @@ export { FromSchema } from 'json-schema-to-ts';
 
 export interface ConfigOptions {
   /**
+   * Additional arguments to pass to the `init` object used in fetch requests.
+   *
+   * These will be shallow-merged with internal options. The `signal` property is always managed
+   * internally and cannot be overridden.
+   */
+  init?: Omit<RequestInit, 'signal'>;
+
+  /**
    * Override the default `fetch` request timeout of 30 seconds. This number should be represented
    * in milliseconds.
    */


### PR DESCRIPTION
## 🧰 Changes

This incorporates the work that @Magi1053 did over in https://github.com/readmeio/api/pull/1061 to support supplying custom `RequestInit` options to SDKs.